### PR TITLE
perf: O(1) spine item lookups in SpineItemsManager

### DIFF
--- a/packages/core/src/spine/SpineItemsManager.ts
+++ b/packages/core/src/spine/SpineItemsManager.ts
@@ -15,15 +15,48 @@ export class SpineItemsManager extends DestroyableClass {
   protected orderedSpineItemsSubject = new BehaviorSubject<SpineItem[]>([])
   public items$ = this.orderedSpineItemsSubject.asObservable()
 
+  /**
+   * Lookup caches for O(1) resolution of an item by id and of an item's index.
+   *
+   * `get(id)` and `getSpineItemIndex` are called on hot paths (every layout,
+   * navigation resolve and pagination update, often once per item inside a loop
+   * over the whole spine), which made the previous `find`/`indexOf` scans O(n²)
+   * over the spine. The maps are rebuilt lazily only when the items array
+   * reference changes (i.e. on `addMany`), so all subsequent lookups are O(1).
+   */
+  private lookupCacheSource: SpineItem[] | undefined
+  private itemById = new Map<string, SpineItem>()
+  private indexByItem = new Map<SpineItem, number>()
+
+  private ensureLookups() {
+    const items = this.orderedSpineItemsSubject.value
+
+    if (this.lookupCacheSource === items) return
+
+    this.lookupCacheSource = items
+    this.itemById = new Map()
+    this.indexByItem = new Map()
+
+    items.forEach((spineItem, index) => {
+      // Preserve first-occurrence semantics of the previous `find`/`indexOf`.
+      if (!this.indexByItem.has(spineItem)) {
+        this.indexByItem.set(spineItem, index)
+      }
+      if (!this.itemById.has(spineItem.item.id)) {
+        this.itemById.set(spineItem.item.id, spineItem)
+      }
+    })
+  }
+
   get(indexOrId: SpineItemReference | undefined) {
     if (typeof indexOrId === "number") {
       return this.orderedSpineItemsSubject.value[indexOrId]
     }
 
     if (typeof indexOrId === "string") {
-      return this.orderedSpineItemsSubject.value.find(
-        ({ item }) => item.id === indexOrId,
-      )
+      this.ensureLookups()
+
+      return this.itemById.get(indexOrId)
     }
 
     return indexOrId
@@ -48,9 +81,9 @@ export class SpineItemsManager extends DestroyableClass {
 
     if (!spineItem) return undefined
 
-    const index = this.orderedSpineItemsSubject.value.indexOf(spineItem)
+    this.ensureLookups()
 
-    return index < 0 ? undefined : index
+    return this.indexByItem.get(spineItem)
   }
 
   addMany(spineItems: SpineItem[]) {


### PR DESCRIPTION
## Target

**Subsystem:** `packages/core` spine item resolution (`SpineItemsManager`) and the layout / navigation / pagination paths that depend on it.

**User-visible symptom:** jank on layout, page-turns and pagination updates that grows with book size — worst for books with many spine items (large EPUBs with hundreds of chapters, and comics/CBZ where **each page is its own spine item**, so `n` reaches the thousands).

## Root cause / mechanism

`SpineItemsManager` resolved items with linear scans:

- `get(id)` → `Array.prototype.find` — **O(n)**
- `getSpineItemIndex(item)` → `Array.prototype.indexOf` — **O(n)**

These are not cold helpers. They are called **once per item inside loops that iterate the whole spine**, on paths that fire on every layout, navigation resolve and pagination update:

| Hot call site | Pattern | Cost before |
|---|---|---|
| `spine/locator/getSpineItemFromPosition.ts` | `items.find(...)` → `getSpineItemSpineLayoutInfo(item)` → `getSpineItemIndex` (`indexOf`) per probe | O(n²) per navigation resolve |
| `spine/locator/getVisibleSpineItemsFromPosition.ts` | `items.reduce(...)` → `getSpineItemSpineLayoutInfo(item)` per item | O(n²) per pagination update |
| `spine/Pages.ts` (layout reduce) | per-page `getSpinePositionFromSpineItemPosition` → index re-scan | O(pages × items) per layout |
| `spine/SpineItemsManager.ts` `comparePositionOf` | two `indexOf` per compare | O(n) per compare |

Every one routes through the same `indexOf`/`find` scan, so the enclosing per-item loops degrade to O(n²).

## The change (one mechanism)

Resolve id → item and item → index through two `Map`s instead of scanning the array. The maps are rebuilt **lazily, only when the items-array reference changes** — and the array is append-only (`addMany` is the sole mutator), so in practice the maps are built once at book load and reused across every subsequent event. Each lookup becomes **O(1)**, collapsing all the call sites above from O(n²)/O(pages×items) to O(n).

- Scale multiplier: number of spine items `n` (hundreds for large EPUBs, thousands for comics) × frequency (every layout / page-turn / pagination update).
- Impact: **O(n) work per interaction becomes O(1) per lookup**, so each affected hot pass drops from O(n²) to O(n).

**Behavior is unchanged** — the only observable difference is speed:
- first-occurrence semantics of `find`/`indexOf` are preserved (maps skip duplicate keys),
- not-found still yields `undefined`,
- `get(number)` still indexes the array directly.

## Measured impact

Micro-benchmark of the hot pattern (resolve an index for each spine item, per event; map built once at load and reused, mirroring the real code) — `node`, realistic scales:

```
n= 200 events=2000  old=24.4ms  new=6.7ms   speedup=4x
n= 500 events=2000  old=101.5ms new=15.7ms  speedup=6x
n=1000 events=2000  old=401.3ms new=27.5ms  speedup=15x
```

Speedup grows with spine size, as expected for an O(n²)→O(n) change.

## Verification

- `packages/core` tests: **27 files / 177 tests pass** (includes `SpineLayout.test.ts`, `getVisibleSpineItemsFromPosition.test.ts` and the navigation/pagination suites that exercise these lookups).
- Biome format + lint: clean on the changed file.
- `tsc` on `packages/core`: **no new type errors** — error count is identical (73) on baseline and with this change; all 73 are pre-existing unresolved-module errors from `@prose-reader/shared`/`@prose-reader/cfi` not being built in this environment (the `@prose-reader/cfi` bundle build fails on a clean checkout too, unrelated to this change — a `node-externals`/vite plugin incompatibility under the local Node version).

## Backlog (other perf opportunities found, not taken here)

- `viewport/Viewport.ts` `scaleFactor` getter calls `getBoundingClientRect()` (a layout read) on every access; it feeds coordinate-translation paths and could be cached per layout epoch.
- `utils/dom.ts` `getFirstVisibleElementForViewport` calls `getBoundingClientRect()` / `range.getClientRects()` per DOM node during first-visible-node resolution (already chunked to 10 pages/frame in `Pages.ts`); an `IntersectionObserver`-based approach would avoid forcing layout — the in-code comment already flags this.
- `spine/locator/getVisibleSpineItemsFromPosition.ts` also accumulates with `[...acc, spineItem]` (O(n²) allocation); a `push` would make it linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139gG4dWFq6coAeV192SND7

---
_Generated by [Claude Code](https://claude.ai/code/session_0139gG4dWFq6coAeV192SND7)_