### PR TITLE
refactor: consolidate reader dialog shells into shared AppDialog

### DIFF
--- a/packages/react-reader/src/annotations/AnnotationsDialog.tsx
+++ b/packages/react-reader/src/annotations/AnnotationsDialog.tsx
@@ -1,15 +1,5 @@
-import { Button } from "@chakra-ui/react"
 import { memo } from "react"
-import {
-  DialogActionTrigger,
-  DialogBody,
-  DialogCloseTrigger,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogRoot,
-  DialogTitle,
-} from "../components/ui/dialog"
+import { AppDialog } from "../components/AppDialog"
 import { AnnotationsDialogContent } from "./AnnotationsDialogContent"
 
 export const AnnotationsDialog = memo(
@@ -23,32 +13,18 @@ export const AnnotationsDialog = memo(
     onNavigate: () => void
   }) => {
     return (
-      <DialogRoot
-        lazyMount
-        placement="center"
+      <AppDialog
         open={!!openWith}
-        onOpenChange={(e) => setOpen(e.open)}
-        size={{ mdDown: "full", md: "lg" }}
-        scrollBehavior="inside"
+        onOpenChange={setOpen}
+        title="Annotations"
+        contentProps={{ height: "100%" }}
+        bodyProps={{ flex: 1 }}
       >
-        <DialogContent height="100%">
-          <DialogHeader>
-            <DialogTitle>Annotations</DialogTitle>
-          </DialogHeader>
-          <DialogBody flex={1}>
-            <AnnotationsDialogContent
-              onNavigate={onNavigate}
-              defaultTab={openWith}
-            />
-          </DialogBody>
-          <DialogFooter>
-            <DialogActionTrigger asChild>
-              <Button variant="outline">Cancel</Button>
-            </DialogActionTrigger>
-          </DialogFooter>
-          <DialogCloseTrigger />
-        </DialogContent>
-      </DialogRoot>
+        <AnnotationsDialogContent
+          onNavigate={onNavigate}
+          defaultTab={openWith}
+        />
+      </AppDialog>
     )
   },
 )

--- a/packages/react-reader/src/components/AppDialog.tsx
+++ b/packages/react-reader/src/components/AppDialog.tsx
@@ -1,0 +1,59 @@
+import { Button } from "@chakra-ui/react"
+import type { ComponentProps, ReactNode } from "react"
+import {
+  DialogActionTrigger,
+  DialogBody,
+  DialogCloseTrigger,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogRoot,
+  DialogTitle,
+} from "./ui/dialog"
+
+/**
+ * Shared shell for the reader's centered dialogs (search, table of contents,
+ * annotations, help, gallery). They all use the same root configuration, header
+ * layout, cancel footer and close trigger; only the title, body content and a
+ * few presentational props differ, which are forwarded through `contentProps`
+ * and `bodyProps`.
+ */
+export const AppDialog = ({
+  open,
+  onOpenChange,
+  title,
+  children,
+  contentProps,
+  bodyProps,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: ReactNode
+  children: ReactNode
+  contentProps?: Omit<ComponentProps<typeof DialogContent>, "children">
+  bodyProps?: Omit<ComponentProps<typeof DialogBody>, "children">
+}) => {
+  return (
+    <DialogRoot
+      lazyMount
+      placement="center"
+      open={open}
+      onOpenChange={(e) => onOpenChange(e.open)}
+      size={{ mdDown: "full", md: "lg" }}
+      scrollBehavior="inside"
+    >
+      <DialogContent {...contentProps}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <DialogBody {...bodyProps}>{children}</DialogBody>
+        <DialogFooter>
+          <DialogActionTrigger asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogActionTrigger>
+        </DialogFooter>
+        <DialogCloseTrigger />
+      </DialogContent>
+    </DialogRoot>
+  )
+}

--- a/packages/react-reader/src/gallery/GalleryDialog.tsx
+++ b/packages/react-reader/src/gallery/GalleryDialog.tsx
@@ -1,18 +1,9 @@
-import { Box, Button, Text } from "@chakra-ui/react"
+import { Box, Text } from "@chakra-ui/react"
 import type { SpineItem } from "@prose-reader/core"
 import { memo } from "react"
 import { useObserve } from "reactjrx"
 import { useMeasure } from "../common/useMeasure"
-import {
-  DialogActionTrigger,
-  DialogBody,
-  DialogCloseTrigger,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogRoot,
-  DialogTitle,
-} from "../components/ui/dialog"
+import { AppDialog } from "../components/AppDialog"
 import { useReader } from "../context/useReader"
 import { useAttachSnapshot } from "./useAttachSnapshot"
 
@@ -81,48 +72,33 @@ export const GalleryDialog = memo(
     )
 
     return (
-      <DialogRoot
-        lazyMount
-        placement="center"
+      <AppDialog
         open={open}
-        onOpenChange={(e) => setOpen(e.open)}
-        size={{ mdDown: "full", md: "lg" }}
-        scrollBehavior="inside"
+        onOpenChange={setOpen}
+        title="Gallery"
+        contentProps={{ height: "100%" }}
       >
-        <DialogContent height="100%">
-          <DialogHeader>
-            <DialogTitle>Gallery</DialogTitle>
-          </DialogHeader>
-          <DialogBody>
-            <Box
-              gridTemplateColumns={[
-                "repeat(2, minmax(0, 1fr))",
-                "repeat(3, minmax(0, 1fr))",
-              ]}
-              display="grid"
-              gap={[2, 4]}
-              pt={2}
-              data-grid
-            >
-              {items?.map((item) => (
-                <GalleryItem
-                  key={item.item.id}
-                  item={item}
-                  onNavigated={() => {
-                    setOpen(false)
-                  }}
-                />
-              ))}
-            </Box>
-          </DialogBody>
-          <DialogFooter>
-            <DialogActionTrigger asChild>
-              <Button variant="outline">Cancel</Button>
-            </DialogActionTrigger>
-          </DialogFooter>
-          <DialogCloseTrigger />
-        </DialogContent>
-      </DialogRoot>
+        <Box
+          gridTemplateColumns={[
+            "repeat(2, minmax(0, 1fr))",
+            "repeat(3, minmax(0, 1fr))",
+          ]}
+          display="grid"
+          gap={[2, 4]}
+          pt={2}
+          data-grid
+        >
+          {items?.map((item) => (
+            <GalleryItem
+              key={item.item.id}
+              item={item}
+              onNavigated={() => {
+                setOpen(false)
+              }}
+            />
+          ))}
+        </Box>
+      </AppDialog>
     )
   },
 )

--- a/packages/react-reader/src/help/HelpDialog.tsx
+++ b/packages/react-reader/src/help/HelpDialog.tsx
@@ -1,82 +1,58 @@
-import { Button, Heading, HStack, Kbd, Stack, Text } from "@chakra-ui/react"
+import { Heading, HStack, Kbd, Stack, Text } from "@chakra-ui/react"
 import { memo } from "react"
 import { LuArrowBigLeft, LuArrowBigRight } from "react-icons/lu"
 import { name, version } from "../../package.json"
-import {
-  DialogActionTrigger,
-  DialogBody,
-  DialogCloseTrigger,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogRoot,
-  DialogTitle,
-} from "../components/ui/dialog"
+import { AppDialog } from "../components/AppDialog"
 
 export const HelpDialog = memo(
   ({ open, setOpen }: { open: boolean; setOpen: (open: boolean) => void }) => {
     return (
-      <DialogRoot
-        lazyMount
-        placement="center"
+      <AppDialog
         open={open}
-        onOpenChange={(e) => setOpen(e.open)}
-        size={{ mdDown: "full", md: "lg" }}
-        scrollBehavior="inside"
+        onOpenChange={setOpen}
+        title="Help"
+        bodyProps={{
+          overflowY: "auto",
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          gap: 4,
+        }}
       >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Help</DialogTitle>
-          </DialogHeader>
-          <DialogBody
-            overflowY="auto"
-            flex={1}
-            display="flex"
-            flexDirection="column"
-            gap={4}
-          >
-            <Stack>
-              <Heading mb={2} as="h3" size="lg">
-                Shortcuts
-              </Heading>
-              <HStack mb={1}>
-                <Kbd>
-                  <LuArrowBigRight />
-                </Kbd>{" "}
-                <Text>Navigate to right page</Text>
-              </HStack>
-              <HStack mb={1}>
-                <Kbd>
-                  <LuArrowBigLeft />
-                </Kbd>{" "}
-                <Text>Navigate to left page</Text>
-              </HStack>
-            </Stack>
-            <Stack>
-              <Heading mb={2} as="h3" size="lg">
-                Bookmarks
-              </Heading>
-              <HStack mb={1}>
-                <Text>Tap on the top right corner of a page bookmark it</Text>
-              </HStack>
-            </Stack>
-            <Stack>
-              <Heading mb={2} as="h3" size="lg">
-                About
-              </Heading>
-              <Text>
-                {name} version: {version}
-              </Text>
-            </Stack>
-          </DialogBody>
-          <DialogFooter>
-            <DialogActionTrigger asChild>
-              <Button variant="outline">Cancel</Button>
-            </DialogActionTrigger>
-          </DialogFooter>
-          <DialogCloseTrigger />
-        </DialogContent>
-      </DialogRoot>
+        <Stack>
+          <Heading mb={2} as="h3" size="lg">
+            Shortcuts
+          </Heading>
+          <HStack mb={1}>
+            <Kbd>
+              <LuArrowBigRight />
+            </Kbd>{" "}
+            <Text>Navigate to right page</Text>
+          </HStack>
+          <HStack mb={1}>
+            <Kbd>
+              <LuArrowBigLeft />
+            </Kbd>{" "}
+            <Text>Navigate to left page</Text>
+          </HStack>
+        </Stack>
+        <Stack>
+          <Heading mb={2} as="h3" size="lg">
+            Bookmarks
+          </Heading>
+          <HStack mb={1}>
+            <Text>Tap on the top right corner of a page bookmark it</Text>
+          </HStack>
+        </Stack>
+        <Stack>
+          <Heading mb={2} as="h3" size="lg">
+            About
+          </Heading>
+          <Text>
+            {name} version: {version}
+          </Text>
+        </Stack>
+      </AppDialog>
     )
   },
 )

--- a/packages/react-reader/src/search/SearchDialog.tsx
+++ b/packages/react-reader/src/search/SearchDialog.tsx
@@ -1,15 +1,5 @@
-import { Button } from "@chakra-ui/react"
 import { memo } from "react"
-import {
-  DialogActionTrigger,
-  DialogBody,
-  DialogCloseTrigger,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogRoot,
-  DialogTitle,
-} from "../components/ui/dialog"
+import { AppDialog } from "../components/AppDialog"
 import { SearchDialogContent } from "./SearchDialogContent"
 
 export const SearchDialog = memo(
@@ -23,29 +13,15 @@ export const SearchDialog = memo(
     onNavigate: () => void
   }) => {
     return (
-      <DialogRoot
-        lazyMount
-        placement="center"
+      <AppDialog
         open={open}
-        onOpenChange={(e) => setOpen(e.open)}
-        size={{ mdDown: "full", md: "lg" }}
-        scrollBehavior="inside"
+        onOpenChange={setOpen}
+        title="Search"
+        contentProps={{ height: "100%" }}
+        bodyProps={{ flex: 1, p: 0 }}
       >
-        <DialogContent height="100%">
-          <DialogHeader>
-            <DialogTitle>Search</DialogTitle>
-          </DialogHeader>
-          <DialogBody flex={1} p={0}>
-            <SearchDialogContent onNavigate={onNavigate} />
-          </DialogBody>
-          <DialogFooter>
-            <DialogActionTrigger asChild>
-              <Button variant="outline">Cancel</Button>
-            </DialogActionTrigger>
-          </DialogFooter>
-          <DialogCloseTrigger />
-        </DialogContent>
-      </DialogRoot>
+        <SearchDialogContent onNavigate={onNavigate} />
+      </AppDialog>
     )
   },
 )

--- a/packages/react-reader/src/toc/TableOfContentsDialog.tsx
+++ b/packages/react-reader/src/toc/TableOfContentsDialog.tsx
@@ -1,15 +1,5 @@
-import { Button } from "@chakra-ui/react"
 import { memo } from "react"
-import {
-  DialogActionTrigger,
-  DialogBody,
-  DialogCloseTrigger,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogRoot,
-  DialogTitle,
-} from "../components/ui/dialog"
+import { AppDialog } from "../components/AppDialog"
 import { TableOfContentsDialogContent } from "./TableOfContentsDialogContent"
 
 export const TableOfContentsDialog = memo(
@@ -23,29 +13,14 @@ export const TableOfContentsDialog = memo(
     onNavigate: () => void
   }) => {
     return (
-      <DialogRoot
-        lazyMount
-        placement="center"
+      <AppDialog
         open={open}
-        onOpenChange={(e) => setOpen(e.open)}
-        size={{ mdDown: "full", md: "lg" }}
-        scrollBehavior="inside"
+        onOpenChange={setOpen}
+        title="Table of Contents"
+        bodyProps={{ overflowY: "auto", flex: 1 }}
       >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Table of Contents</DialogTitle>
-          </DialogHeader>
-          <DialogBody overflowY="auto" flex={1}>
-            <TableOfContentsDialogContent onNavigate={onNavigate} />
-          </DialogBody>
-          <DialogFooter>
-            <DialogActionTrigger asChild>
-              <Button variant="outline">Cancel</Button>
-            </DialogActionTrigger>
-          </DialogFooter>
-          <DialogCloseTrigger />
-        </DialogContent>
-      </DialogRoot>
+        <TableOfContentsDialogContent onNavigate={onNavigate} />
+      </AppDialog>
     )
   },
 )


### PR DESCRIPTION
## Summary

Five dialogs in `@prose-reader/react-reader` each hand-rolled the **same centered-dialog shell** — identical `DialogRoot` configuration (`lazyMount`, `placement="center"`, `size={{ mdDown: "full", md: "lg" }}`, `scrollBehavior="inside"`, the `onOpenChange` boolean bridge), the same header layout, the same `Cancel` footer, and the same close trigger. They differed only in the title, the body content, and a couple of presentational Chakra props.

This PR extracts that shell into a single `AppDialog` component and rewires each dialog to forward its title, content and the few differing props through it. The differing bits are passed as ordinary Chakra style props (`contentProps`, `bodyProps`) — no boolean flags, modes, or conditionals were introduced.

## Consolidation

**What was duplicated** — the centered-dialog shell in:
- `packages/react-reader/src/search/SearchDialog.tsx`
- `packages/react-reader/src/toc/TableOfContentsDialog.tsx`
- `packages/react-reader/src/annotations/AnnotationsDialog.tsx`
- `packages/react-reader/src/help/HelpDialog.tsx`
- `packages/react-reader/src/gallery/GalleryDialog.tsx`

**What it became** — one shared component:
- `packages/react-reader/src/components/AppDialog.tsx`

**Net LOC delta:** −62 (158 insertions, 220 deletions across 6 files; the new component is 59 lines).

**Why they are the same concept:** all five render the identical dialog scaffold with the same open/close semantics, the same responsive sizing, the same footer action, and the same close affordance. The only variation is presentational (title, body content, a `height="100%"` here, a `flex`/`overflow` there), which is naturally expressed as forwarded props rather than divergent behavior. There is now one place to evolve the reader's dialog chrome instead of five.

## Not included (deliberately left alone)

Two other jscpd hits were evaluated and rejected as **not** true duplicates:
- `RefitDialog` / `FontSizeControlsDialog` use a *different* shell (no `size`/`scrollBehavior`, a `Close` — not `Cancel` — footer), so they are excluded from `AppDialog`.
- The navigation resolvers (`getNavigationForLeftOrTopPage` / `getNavigationForRightOrBottomPage`) and the two `copyIframeContents` variants are directional/behavioral mirrors — unifying them would require sign/mode parameters and conditionals to cover diverging behavior, which the consolidation criteria explicitly exclude.

## Behavior preservation

Each call site passes exactly the props it used before; no public API, return shape, ordering, or styling changes. `AppDialog` is an internal component and is not part of the package's public exports, so no documentation changes were required.

## Verification

Ran the project's gates (node 25, matching CI's `.nvmrc`):
- `lerna run build --scope @prose-reader/*` (includes `tsc -b` typecheck) ✅
- `npm run tsc` ✅
- `biome lint` + `biome format` on the full repo ✅
- `@prose-reader/react-reader` test suite (`vitest run --coverage`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QADsCyyzf6JCDC4oRThDxT)_