### PR TITLE
refactor: consolidate createManifestResourceHref into streamer export

### DIFF
--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -17,6 +17,7 @@
 
 * [Contract](learn/contract.md)
 * [Streamer](learn/streamer/README.md)
+  * [API Reference](learn/streamer/api-reference.md)
   * [Archives](learn/streamer/archives.md)
   * [Node](learn/streamer/node.md)
   * [React Native](learn/streamer/react-native.md)

--- a/gitbook/learn/streamer/api-reference.md
+++ b/gitbook/learn/streamer/api-reference.md
@@ -1,0 +1,173 @@
+# API Reference
+
+The public surface of `@prose-reader/streamer`. Everything below is exported from the package root (`@prose-reader/streamer`) unless a **subpath** is called out explicitly.
+
+```typescript
+import {
+  generateManifestFromArchive,
+  generateResourceFromArchive,
+} from "@prose-reader/streamer"
+```
+
+The package splits into a few areas. Archives and hooks have dedicated guides — this page is the canonical index of what is exported and documents the pieces that don't have a page of their own (manifest/resource generation, the streaming classes, and the utilities).
+
+| Area | Exports | Where |
+| --- | --- | --- |
+| Archives | `createArchive`, the `createArchiveFrom*` creators, `arrayBufferFileAccessors`, `blobFileAccessors`, `readRecordAsText`, `getArchiveFileRecordByUri`, `isFileRecord`, `isDirectoryRecord`, `getArchiveHasComicInfo`, types `Archive` / `ArchiveRecord` | [Archives](archives.md) |
+| Manifest & resources | `generateManifestFromArchive`, `generateResourceFromArchive`, `createManifestResourceHref`, `getArchiveOpfInfo` | below |
+| Streaming | `Streamer`, `ServiceWorkerStreamer` | below · [Node](node.md) · [Service Worker](service-worker.md) · [Web (dom)](web-dom.md) |
+| Hooks | `StreamerHooks`, `StreamerManifestHook*`, `StreamerResourceHook*`, `HookResource` types | [Hooks](hooks.md) |
+| Utilities | `createXmlSafeId`, `createUniqueXmlSafeId`, `createXmlSafeIdFactory`, `sortByTitleComparator`, `removeTrailingSlash`, `getUriBasename`, `getUriBasePath` | below |
+| Setup | `configure` | below |
+
+## Archives
+
+Building an [`Archive`](archives.md#the-archive-contract) is always the first step, whatever the source. The creators, the record contract, the file-accessor factories and the lookup helpers are covered in full on the [Archives](archives.md) page. Type-only exports `Archive` and `ArchiveRecord` describe the container and its (file/directory) records.
+
+## Manifest & resource generation
+
+### `generateManifestFromArchive(archive, options?)`
+
+```typescript
+generateManifestFromArchive(
+  archive: Archive,
+  options?: { baseUrl?: string; hooks?: StreamerManifestHooks },
+): Promise<Manifest>
+```
+
+Produces a reader [`Manifest`](../contract.md) by reading the archive's OPF and reducing it through the built-in content/spine/presentation/navigation hook pipeline plus any user [hooks](hooks.md).
+
+```typescript
+import { generateManifestFromArchive } from "@prose-reader/streamer"
+
+const archive = await createArchiveFromJszip(zip)
+const manifest = await generateManifestFromArchive(archive)
+```
+
+### `generateResourceFromArchive(archive, resourcePath, options?)`
+
+```typescript
+generateResourceFromArchive(
+  archive: Archive,
+  resourcePath: string,
+  options?: { hooks?: StreamerResourceHookFactory[] },
+): Promise<HookResource> // resolved resource with a guaranteed `body` (string | Blob)
+```
+
+Resolves a single archive resource by URI, running it through the resource hook pipeline (default / self-closing-tags / css / calibre fixes, plus any user hooks) and falling back to the raw file blob when no hook sets a body.
+
+### `createManifestResourceHref({ baseUrl?, resourcePath })`
+
+```typescript
+createManifestResourceHref(params: {
+  baseUrl?: string // default ""
+  resourcePath: string
+}): string
+```
+
+Builds the `href` used for a manifest resource. An absolute `http(s)://` `resourcePath` is returned untouched (when no `baseUrl` is given); otherwise the path is prefixed with `baseUrl` (a trailing `/` is added when missing) or with `file://` when no `baseUrl` is provided. The result is always passed through `encodeURI`.
+
+```typescript
+import { createManifestResourceHref } from "@prose-reader/streamer"
+
+createManifestResourceHref({ resourcePath: "OEBPS/chapter-1.xhtml" })
+// "file://OEBPS/chapter-1.xhtml"
+
+createManifestResourceHref({ baseUrl: "https://cdn.example.com/book", resourcePath: "OEBPS/chapter-1.xhtml" })
+// "https://cdn.example.com/book/OEBPS/chapter-1.xhtml"
+```
+
+### `getArchiveOpfInfo(archive)`
+
+```typescript
+getArchiveOpfInfo(archive: Archive): {
+  data: ArchiveRecord | undefined // first record whose uri ends with ".opf"
+  basePath: string // directory portion of that .opf uri, or ""
+}
+```
+
+Locates the EPUB package document (`.opf`) within an archive and returns it together with its containing base path.
+
+## Streaming
+
+The streaming classes turn manifest and resource requests into HTTP `Response`s. See [Node](node.md), [Web (dom)](web-dom.md) and [Service Worker](service-worker.md) for end-to-end setups.
+
+### `Streamer`
+
+```typescript
+new Streamer(options: {
+  // archive loader options (how archives are created/cached by key)
+  hooks?: StreamerHooks
+  onError?: (error: unknown) => Response
+  onManifestSuccess?: (params: { manifest: Manifest; archive: Archive })
+    => Observable<Manifest> | Promise<Manifest>
+})
+
+streamer.fetchManifest(params: { key: string; baseUrl?: string }): Promise<Response>
+streamer.fetchResource(params: { key: string; resourcePath: string; request?: Request }): Promise<Response>
+streamer.accessArchive(key: string): Observable<{ archive: Archive; release: () => void }>
+streamer.accessArchiveWithoutLock(key: string): Observable<Archive>
+streamer.prune(): void
+```
+
+Core archive-serving engine: it loads and caches archives by `key` and generates the matching `Response`s. `fetchManifest` / `fetchResource` produce the manifest and resource responses (resource responses support HTTP range requests); `accessArchive` acquires a locked archive handle you release with `release()`; `accessArchiveWithoutLock` yields just the archive and releases immediately; `prune` purges the archive cache.
+
+### `ServiceWorkerStreamer`
+
+```typescript
+new ServiceWorkerStreamer(options: /* Streamer options */ & {
+  getUriInfo: (event: FetchEvent) => { baseUrl: string } | undefined
+})
+
+serviceWorkerStreamer.fetchEventListener(event: FetchEvent): void
+```
+
+A `Streamer` subclass for service-worker `fetch` events. `getUriInfo` maps a request to its `baseUrl` (or `undefined` to ignore the request); the bound `fetchEventListener` parses the request URL into `{ key, resourcePath }` and calls `event.respondWith` using `fetchManifest` (for `/manifest` URLs) or `fetchResource` otherwise.
+
+## Utilities
+
+### XML-safe identifiers
+
+```typescript
+createXmlSafeId(value: string): string
+createUniqueXmlSafeId(value: string, usedIds: Set<string>): string
+createXmlSafeIdFactory(): (value: string) => string
+```
+
+`createXmlSafeId` normalizes an arbitrary string into an XML-safe id (invalid characters and `/` become `_`, reserved `xml*` starts are prefixed). `createUniqueXmlSafeId` does the same but guarantees uniqueness against a `usedIds` set, suffixing `-2`, `-3`, … on collision (and mutates the set). `createXmlSafeIdFactory` returns a stateful generator that tracks used ids internally — convenient when assigning ids across a whole manifest.
+
+```typescript
+import { createXmlSafeIdFactory } from "@prose-reader/streamer"
+
+const nextId = createXmlSafeIdFactory()
+nextId("chapter 1") // "chapter_1"
+nextId("chapter 1") // "chapter_1-2"
+```
+
+### `sortByTitleComparator(a, b)`
+
+```typescript
+sortByTitleComparator(a: string, b: string): number
+```
+
+A natural-order string comparator for titles: it splits each string on digit runs and compares numeric segments numerically (so `"page 2"` sorts before `"page 10"`) and the rest with `localeCompare`. Pass it directly to `Array.prototype.sort`.
+
+### URI helpers
+
+```typescript
+removeTrailingSlash(uri: string): string
+getUriBasename(uri: string): string
+getUriBasePath(uri: string): string
+```
+
+Small string helpers for archive URIs: `removeTrailingSlash` drops a single trailing `/`; `getUriBasename` returns the last path segment (trailing slash ignored); `getUriBasePath` returns the directory portion (everything before the last `/`, or `""` when there is none).
+
+## Setup
+
+### `configure(options?)`
+
+```typescript
+configure(options?: { enableReport?: boolean }): void
+```
+
+Global setup toggle that enables or disables the streamer's internal `Report` logging.

--- a/packages/cbz/src/panoramaSplitManifest.ts
+++ b/packages/cbz/src/panoramaSplitManifest.ts
@@ -3,7 +3,11 @@ import {
   type Manifest,
   parseContentType,
 } from "@prose-reader/shared"
-import { type Archive, createXmlSafeId } from "@prose-reader/streamer"
+import {
+  type Archive,
+  createManifestResourceHref,
+  createXmlSafeId,
+} from "@prose-reader/streamer"
 import { alignSpineItemsForSpreadParity } from "./alignSpineItemsForSpreadParity"
 import { detectPanoramaFromBasename } from "./detectPanoramaFromBasename"
 
@@ -41,24 +45,6 @@ type ArchiveRecord = Archive["records"][number]
 type ArchiveFileRecord = Extract<ArchiveRecord, { dir: false }>
 
 const encodeOriginalUriSegment = (uri: string) => encodeURIComponent(uri)
-
-const createManifestResourceHref = ({
-  baseUrl = ``,
-  resourcePath,
-}: {
-  baseUrl?: string
-  resourcePath: string
-}) => {
-  if (!baseUrl && /^https?:\/\//.test(resourcePath)) {
-    return encodeURI(resourcePath)
-  }
-
-  const hrefBaseUrl = baseUrl
-    ? `${baseUrl}${baseUrl.endsWith(`/`) ? `` : `/`}`
-    : `file://`
-
-  return encodeURI(`${hrefBaseUrl}${resourcePath}`)
-}
 
 const hasOpfExtension = (path: string) => path.toLowerCase().endsWith(`.opf`)
 

--- a/packages/streamer/src/index.ts
+++ b/packages/streamer/src/index.ts
@@ -23,6 +23,7 @@ export {
 export { configure } from "./configure"
 export { getArchiveOpfInfo } from "./epubs/getArchiveOpfInfo"
 export { generateManifestFromArchive } from "./generators/manifest"
+export { createManifestResourceHref } from "./generators/manifest/createManifestResourceHref"
 export { generateResourceFromArchive } from "./generators/resources"
 export type {
   HookResource,


### PR DESCRIPTION
## Summary

Consolidates one genuinely duplicated helper: the `createManifestResourceHref` manifest-URL builder existed twice — once as the real implementation in `@prose-reader/streamer` and once as a byte-identical **private copy** in the `@prose-reader/cbz` package.

> Rebased onto `master` after #220 landed, which renamed the cbz file `pageSpreadSplitManifest.ts` → `panoramaSplitManifest.ts`. The consolidation now applies to `panoramaSplitManifest.ts`; the description below uses the current name.

### What was duplicated
- `packages/streamer/src/generators/manifest/createManifestResourceHref.ts` — the canonical, exported (internally) implementation, already used by streamer's manifest hooks and covered by `createManifestResourceHref.test.ts`.
- `packages/cbz/src/panoramaSplitManifest.ts` — a verbatim, character-for-character copy of the same function, declared privately.

Both build a resource `href`: pass through `http(s)://` URLs untouched, otherwise prefix with the given `baseUrl` (ensuring a trailing `/`) or `file://`, then `encodeURI`. Identical inputs, identical output — confirmed with `diff` (the only difference was the `export` keyword).

### What it became
- `createManifestResourceHref` is now re-exported from the streamer barrel (`packages/streamer/src/index.ts`), alongside the existing low-level utility exports (`createXmlSafeId`, `sortByTitleComparator`, uri utils).
- `cbz/src/panoramaSplitManifest.ts` imports it from `@prose-reader/streamer` — the same barrel it already imports `Archive` and `createXmlSafeId` from — and the local copy is deleted.

### Why these are truly the same concept
It is a literal copy-paste, not two implementations that happen to look alike, and cbz is downstream of streamer in the manifest-generation pipeline, so both are meant to produce the exact same streamer-compatible resource href. There is a single behavior with a single source of truth; no flags, modes, or conditionals were needed to unify them.

### Net LOC (consolidation)
**net −13 lines** across the two source files (one duplicated 17-line function removed; one export line added; the cbz import expanded to multi-line by the formatter).

## Behavior
Behavior-preserving: a byte-identical function was relocated to a shared export and re-imported. No signatures, return shapes, error handling, or call sites changed.

## Docs
Since this promotes a helper to the `@prose-reader/streamer` public entry point — and the package had **no API-reference doc at all** — this PR also adds one: `gitbook/learn/streamer/api-reference.md` (registered in `SUMMARY.md`). It indexes the full public surface, links to the existing Archives / Hooks / streaming guides, and fully documents the previously-undocumented exports: the manifest/resource generators (including `createManifestResourceHref`), the `Streamer` / `ServiceWorkerStreamer` classes, the XML-safe-id / title-sort / uri utilities, and `configure`. All signatures were transcribed from source.

## Validation
- `biome format` + `biome lint` clean on the changed files.
- Streamer's existing `createManifestResourceHref.test.ts` passes (3/3), re-checked after the rebase.
- `cbz/src/panoramaSplitManifest.ts` typechecks with **0 errors** against streamer source with the new export; the import resolves cleanly (re-checked against the post-#220 cbz code).
- Note: the repo's full `build`/`tsc` gate could not run to completion in the CI-mismatched sandbox (Node 22 vs the repo-pinned Node 25) — `@prose-reader/archive-parser`'s `vite build` fails in `rollup-plugin-node-externals` **on a clean checkout of `master` as well**, i.e. a pre-existing failure unrelated to this change.

## Review notes
- **Peer range (P1):** cbz's `@prose-reader/streamer` peer stays at `^1.296.0`. This matches the existing convention — cbz has imported `createXmlSafeId` from the streamer barrel since v1.302.0 under that same floor, set in the same commit that added the export. Floors are uniform across `core`/`cfi`/`shared`/`streamer` and this is a lockstep-published monorepo; raising only streamer's floor would be asymmetric, and tightening all of them is a separate versioning-policy call.

## Other candidates considered (left out on purpose)
- Left/right navigation resolver pairs (`getNavigationForLeft*` vs `getNavigationForRightOrBottom*`, `manualNavigator` turn methods) — symmetric but **diverging** concepts (opposite sign/direction); unifying would require direction flags, so per the consolidation criteria they are not duplicates.
- `removeCSS` in `frames.ts` already delegates to `dom.ts` — a thin adapter, not a duplicate.
- Trivial 2-line `waitFor` test helpers in different packages — not worth cross-package coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtLSJ2sbomgELJYaZH311Z