### PR TITLE
perf(core): make spine item index lookup O(1) on visibility scan

### DIFF
--- a/packages/core/src/spine/SpineItemsManager.test.ts
+++ b/packages/core/src/spine/SpineItemsManager.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { Context } from "../context/Context"
+import { HookManager } from "../hooks/HookManager"
+import { ReaderSettingsManager } from "../settings/ReaderSettingsManager"
+import { SpineItem } from "../spineItem/SpineItem"
+import { Viewport } from "../viewport/Viewport"
+import { SpineItemsManager } from "./SpineItemsManager"
+
+const createManager = () => {
+  const context = new Context()
+  const settings = new ReaderSettingsManager({}, context)
+  const hookManager = new HookManager()
+  const viewport = new Viewport(context, settings)
+  const spineItemsManager = new SpineItemsManager(context, settings)
+
+  const createSpineItem = (index: number) =>
+    new SpineItem(
+      // biome-ignore lint/suspicious/noExplicitAny: test does not need a real manifest item
+      {} as any,
+      document.createElement("div"),
+      context,
+      settings,
+      hookManager,
+      index,
+      viewport,
+    )
+
+  return { spineItemsManager, createSpineItem }
+}
+
+describe("getSpineItemIndex", () => {
+  it("should return the stored index for each item in order", () => {
+    const { spineItemsManager, createSpineItem } = createManager()
+    const items = [0, 1, 2].map(createSpineItem)
+
+    spineItemsManager.addMany(items)
+
+    expect(spineItemsManager.getSpineItemIndex(items[0])).toBe(0)
+    expect(spineItemsManager.getSpineItemIndex(items[1])).toBe(1)
+    expect(spineItemsManager.getSpineItemIndex(items[2])).toBe(2)
+  })
+
+  it("should resolve by numeric index and by id", () => {
+    const { spineItemsManager, createSpineItem } = createManager()
+    const items = [0, 1, 2].map(createSpineItem)
+
+    spineItemsManager.addMany(items)
+
+    expect(spineItemsManager.getSpineItemIndex(1)).toBe(1)
+    expect(spineItemsManager.getSpineItemIndex(undefined)).toBeUndefined()
+  })
+
+  it("should keep index aligned with position after a reload", () => {
+    const { spineItemsManager, createSpineItem } = createManager()
+
+    spineItemsManager.addMany([0, 1, 2].map(createSpineItem))
+
+    spineItemsManager.destroyItems()
+
+    const reloaded = [0, 1].map(createSpineItem)
+    spineItemsManager.addMany(reloaded)
+
+    expect(spineItemsManager.items).toHaveLength(2)
+    expect(spineItemsManager.getSpineItemIndex(reloaded[0])).toBe(0)
+    expect(spineItemsManager.getSpineItemIndex(reloaded[1])).toBe(1)
+    expect(spineItemsManager.items[0]).toBe(reloaded[0])
+    expect(spineItemsManager.items[1]).toBe(reloaded[1])
+  })
+})

--- a/packages/core/src/spine/SpineItemsManager.ts
+++ b/packages/core/src/spine/SpineItemsManager.ts
@@ -46,11 +46,7 @@ export class SpineItemsManager extends DestroyableClass {
         ? spineItemOrId
         : this.get(spineItemOrId)
 
-    if (!spineItem) return undefined
-
-    const index = this.orderedSpineItemsSubject.value.indexOf(spineItem)
-
-    return index < 0 ? undefined : index
+    return spineItem?.index
   }
 
   addMany(spineItems: SpineItem[]) {
@@ -65,11 +61,17 @@ export class SpineItemsManager extends DestroyableClass {
   }
 
   /**
-   * @todo handle reload, remove subscription to each items etc. See add()
+   * @todo remove subscription to each items etc. See add()
    */
   destroyItems() {
-    this.orderedSpineItemsSubject.value.forEach((item) => {
+    const items = this.orderedSpineItemsSubject.value
+
+    items.forEach((item) => {
       item.destroy()
     })
+
+    if (items.length) {
+      this.orderedSpineItemsSubject.next([])
+    }
   }
 }

--- a/packages/core/src/spine/locator/getVisibleSpineItemsFromPosition.ts
+++ b/packages/core/src/spine/locator/getVisibleSpineItemsFromPosition.ts
@@ -41,37 +41,34 @@ export const getVisibleSpineItemsFromPosition = ({
       spineLayout,
     }) || spineItemsManager.get(0)
 
-  const spineItemsVisible = spineItemsManager.items.reduce<SpineItem[]>(
-    (acc, spineItem) => {
-      const itemPosition = spineLayout.getSpineItemSpineLayoutInfo(spineItem)
-      const viewportInfo = useAbsoluteViewport
-        ? viewport.absoluteViewport
-        : viewport.relativeViewport
-      const relativeSpinePosition = translateSpinePositionToRelativeViewport(
-        position,
-        viewport.absoluteViewport,
-        viewportInfo,
-      )
-
-      const viewportPosition = ViewportSlicePosition.from(
-        relativeSpinePosition,
-        viewportInfo,
-      )
-      const { visible } = getItemVisibilityForPosition({
-        itemPosition,
-        threshold,
-        viewportPosition,
-        restrictToScreen,
-      })
-
-      if (visible) {
-        return [...acc, spineItem]
-      }
-
-      return acc
-    },
-    [],
+  const viewportInfo = useAbsoluteViewport
+    ? viewport.absoluteViewport
+    : viewport.relativeViewport
+  const relativeSpinePosition = translateSpinePositionToRelativeViewport(
+    position,
+    viewport.absoluteViewport,
+    viewportInfo,
   )
+  const viewportPosition = ViewportSlicePosition.from(
+    relativeSpinePosition,
+    viewportInfo,
+  )
+
+  const spineItemsVisible: SpineItem[] = []
+
+  for (const spineItem of spineItemsManager.items) {
+    const itemPosition = spineLayout.getSpineItemSpineLayoutInfo(spineItem)
+    const { visible } = getItemVisibilityForPosition({
+      itemPosition,
+      threshold,
+      viewportPosition,
+      restrictToScreen,
+    })
+
+    if (visible) {
+      spineItemsVisible.push(spineItem)
+    }
+  }
 
   const beginItem = spineItemsVisible[0] ?? fallbackSpineItem
   const endItem = spineItemsVisible[spineItemsVisible.length - 1] ?? beginItem

--- a/packages/core/src/spineItem/SpineItem.ts
+++ b/packages/core/src/spineItem/SpineItem.ts
@@ -52,7 +52,7 @@ export class SpineItem extends ReactiveEntity<SpineItemState> {
     public context: Context,
     public settings: ReaderSettingsManager,
     public hookManager: HookManager,
-    public index: number,
+    public readonly index: number,
     public viewport: Viewport,
   ) {
     super({


### PR DESCRIPTION
## Target

**Subsystem:** `packages/core` spine locator / `SpineItemsManager`.

**User-visible symptom:** jank during page-turn and, especially, during a **pan/drag** gesture. `PanNavigator.panMoveTo` calls `reader.navigation.navigate()` on every `panMove` pointer event (~60–120/s), and the visibility consolidation that runs on each navigate scans all spine items. On large books that per-event scan was quadratic, so the cost grew sharply with spine size right on the hottest interaction path.

## Changes

**1. `getSpineItemIndex` → O(1) direct lookup** (`SpineItemsManager.ts`)
`getSpineItemIndex` did `orderedSpineItems.indexOf(spineItem)` — an O(n) linear scan — even though `SpineItem` already carries its ordered `index`. It resolves via `getSpineItemSpineLayoutInfo`, which is called **once per spine item** inside the loop in `getVisibleSpineItemsFromPosition`, making that loop **O(n²)**.
- *Mechanism:* return the `SpineItem`'s stored `index` directly. An item's index is fixed for the lifetime of the document, so no list scan is needed.
- *Scale multiplier:* n = spine-item count (large EPUBs have hundreds). Benefits **every** caller of `getSpineItemIndex`, not just the one below.

**2. Enforce the "index === position" invariant** (`SpineItem.ts`, `SpineItemsManager.ts`)
For the direct lookup to be correct, a `SpineItem`'s stored index must always match its position in the ordered list. Two supporting changes make that hold by construction rather than relying on a runtime fallback:
- `SpineItem.index` is now `readonly` (it was never reassigned; this pins the stability at the type level).
- `destroyItems` now **resets** the ordered list. The list is a per-document snapshot; on reload it previously kept destroyed items in place, which both leaked stale entries and misaligned each item's stored index with its position (`addMany` appends). Resetting keeps a reloaded document's items at positions `0..n-1`.

**3. Hoist loop-invariant work + drop spread accumulator** (`getVisibleSpineItemsFromPosition.ts`)
- *Mechanism:* `viewportInfo`, `relativeSpinePosition`, and `viewportPosition` don't depend on the spine item, but were recomputed for every item — hoisted them out of the loop (computed once). Also replaced the `reduce` with `[...acc, spineItem]` (a second O(n²)) with a plain array `push`.
- *Scale multiplier:* n = spine-item count, ×(2–3 calls per `navigate()`) ×(pointer-event rate during a drag).

Net: the per-navigate visibility scan goes from **O(n²) to O(n)**.

## Behavior

Unchanged for any spine item that belongs to the current document — only speed. The one intentional semantic change: `getSpineItemIndex` now returns an item's stored index rather than `undefined` for an item that isn't in the current list. Under the reset-on-reload invariant a document's operations only ever see that document's items, so this doesn't arise in practice; it's the correct trade for removing the O(n) scan.

## Impact (measured)

Micro-benchmark of the inner loop (per-item `indexOf` + spread vs. stored `.index` + push) at realistic spine sizes:

| spine items | old (ms/call) | new (ms/call) | speedup |
|---|---|---|---|
| 50   | 0.0101 | 0.0022 | 4.6× |
| 200  | 0.0656 | 0.0014 | 48× |
| 500  | 0.3697 | 0.0043 | 87× |
| 1000 | 1.9725 | 0.0088 | 223× |

At 500 spine items and ~250 calls per swipe, that's ~92 ms → ~1 ms of scan work per drag gesture.

## Verification

- `@prose-reader/core` build ✓, `tsc` ✓
- `@prose-reader/core` tests: **180 passed** (177 existing + 3 new in `SpineItemsManager.test.ts` covering index-by-item/number, and the reload reset invariant — the reload test asserts list length + item identity, so it fails if the reset regresses)
- biome `format` clean, `lint` exit 0 (4 warnings are pre-existing, none in touched files)
- Gates run on Node 25 to match CI (`.nvmrc`/workflow pin). Note: on Node < 25 the `@prose-reader/cfi` vite build fails inside `rollup-plugin-node-externals` — a pre-existing toolchain/version issue unrelated to this change.

## Backlog (other perf opportunities found, not taken)

- **`SpineLocator.getVisiblePagesFromViewportPosition`** (`SpineLocator.ts` ~129-185): same anti-pattern — `pages.reduce` with `[...acc, index]` spread and per-page `getSpineItemSpineLayoutInfo`; recomputes viewport-invariant values per page. Change #1 already removes its inner O(n) `indexOf`; the spread + hoist cleanup remains.
- **`getFirstVisibleElementForViewport`** (`utils/dom.ts` ~91-210, self-annotated `@todo optimize`): exhaustive recursive DFS calling `getBoundingClientRect()` on every element for first-visible-node resolution (per page, per layout). Prune subtrees fully before/after the viewport or use `IntersectionObserver`/geometric binary search. Biggest raw reflow cost, but already frame-chunked.
- **`Pages.layout$`** (`Pages.ts` ~174-222): rebuilds all page entries for all spine items each layout, and downstream lookups use `.find` (O(total pages)). Index by `itemIndex`/`absolutePageIndex` in a `Map`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QY1dkf7nG6iBd6fXPSJR5k