### PR TITLE
chore: dead-code sweep — remove unused test setup + dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12836,15 +12836,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "dev": true,
@@ -15149,25 +15140,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
     },
     "node_modules/node-forge": {
       "version": "1.4.0",
@@ -19468,11 +19440,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "dev": true,
@@ -20621,11 +20588,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "dev": true,
@@ -20641,15 +20603,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/whatwg-url-minimum": {
@@ -21590,9 +21543,6 @@
         "@prose-reader/archive-reader": "^1.320.0",
         "@prose-reader/shared": "^1.320.0",
         "xmldoc": "^2.0.0"
-      },
-      "devDependencies": {
-        "isomorphic-fetch": "^3.0.0"
       },
       "peerDependencies": {
         "rxjs": "*"

--- a/packages/streamer/package.json
+++ b/packages/streamer/package.json
@@ -31,8 +31,5 @@
   "peerDependencies": {
     "rxjs": "*"
   },
-  "gitHead": "4601e14dcacf50b2295cb343582a7ef2c7e1eedc",
-  "devDependencies": {
-    "isomorphic-fetch": "^3.0.0"
-  }
+  "gitHead": "4601e14dcacf50b2295cb343582a7ef2c7e1eedc"
 }

--- a/packages/streamer/src/tests/setupTests.ts
+++ b/packages/streamer/src/tests/setupTests.ts
@@ -1,1 +1,0 @@
-import "isomorphic-fetch"


### PR DESCRIPTION
Automated strict dead-code sweep. Only genuinely unreferenced code was removed; each item was grep-verified across the whole repo (excluding `node_modules`/`dist`).

## Removed

- **`packages/streamer/src/tests/setupTests.ts`** — Never imported and never wired into any Vitest config. `packages/streamer/vite.config.ts` only sets `coverage`; there is no `setupFiles` entry pointing at it anywhere. Grep for `setupTests` across the repo returns no references, so the file is never loaded. (Sibling files `waitFor.ts` and `tocWithPrefix/` in the same dir are still used and were kept.)

- **`isomorphic-fetch` devDependency (`packages/streamer/package.json`)** — Its only reference in the entire repo was the `import "isomorphic-fetch"` inside the deleted `setupTests.ts`. After that deletion it is completely unreferenced (grep confirms no other usage), so it was removed from the manifest.

- **`package-lock.json`** — Pruned `isomorphic-fetch` and its now-orphaned transitive-only deps (`node-fetch@2.7.0`, `whatwg-url@5.0.0`, `tr46@0.0.3`, `webidl-conversions@3.0.1`). `whatwg-fetch` was **kept** because it is still required by another package. The lockfile was edited surgically (no normalization churn) and validated with `npm ci` (exit 0).

## Gates

- `biome lint` / `biome format`: pass, identical pre-existing warning count to the baseline (4 warnings, 1 info).
- `npm ci`: passes with the updated lockfile.
- Build/`tsc`/Vitest: this repo currently fails `npm run build` on `@prose-reader/archive-parser` under an older Node (a pre-existing `rollup-plugin-node-externals` + Vite 8 incompatibility), unrelated to and untouched by this change. The removed file was never loaded and the removed dep was never imported, so test/build behavior is unchanged.

## Considered but left in (not strict dead code)

- `packages/*/src/components/ui/*.tsx`, `apps/*/src/components/ui/*.tsx` — Chakra UI snippet-kit components. Unused in-repo but a deliberately kept UI-kit / speculative surface, so left alone.
- `apps/demo/src/types.ts` — A `declare global` Window augmentation; TS global-augmentation semantics make removal risky, so left alone.
- `packages/streamer/src/archives/createArchiveFrom*.ts` and the react-native `src/{native,web,shared}/index.ts` — Flagged by the detector only because package `exports` map to `dist/`; these are **public API** (declared subpath/entry exports) consumed outside this repo.
- `apps/tests/tests/**/index.tsx` — Real Playwright fixture entry points loaded via co-located `index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmA7nNAmgB84T4zdb77FnR)_