### PR TITLE
perf(tests): parallelize Playwright on CI + cache browsers

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -27,7 +27,15 @@ jobs:
         run: |
           npx lerna run build --stream --scope @prose-reader/*
 
+      - uses: actions/cache@v5
+        id: playwright-cache
+        with:
+          path: ~/Library/Caches/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+
       - name: Install Playwright Browsers
+        # On a cache hit the browsers are already present; install still runs to
+        # verify/refresh them but skips the multi-hundred-MB download.
         run: npx playwright install --with-deps
 
       - name: Test

--- a/apps/tests/playwright.config.ts
+++ b/apps/tests/playwright.config.ts
@@ -19,8 +19,13 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Use half the available cores on CI; unlimited (Playwright default) locally. */
-  workers: process.env.CI ? "50%" : undefined,
+  /*
+   * The CI runner (macos-latest) has 3 cores, so Playwright's "50%" default
+   * floors to a single worker. Pin an explicit count instead: 2 workers give
+   * real parallelism while leaving a core for the Vite dev server + the
+   * orchestrator, keeping the screenshot tests stable under load.
+   */
+  workers: process.env.CI ? 2 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/apps/tests/playwright.config.ts
+++ b/apps/tests/playwright.config.ts
@@ -19,8 +19,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* Use half the available cores on CI; unlimited (Playwright default) locally. */
+  workers: process.env.CI ? "50%" : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
## Problem

The Playwright suite dominates CI. Step timings from a prior run:

| Step | Duration |
|---|---|
| npm ci | 45s |
| Build | 63s |
| Install Playwright browsers | 39s |
| **Test** | **~7m30s** |

The CI log showed the real cause:

```
Running 195 tests using 1 worker
```

`macos-latest` has **3 cores**, and Playwright floors `"50%"` to a single worker — so the suite was fully serialized (195 runs = 39 tests × 5 browser projects).

## Changes

1. **Pin `workers: 2`** in [`playwright.config.ts`](apps/tests/playwright.config.ts) — an explicit count instead of `"50%"`, which floored to 1 on this 3-core runner. 2 workers give real parallelism while leaving a core for the Vite dev server + orchestrator, keeping the screenshot tests stable under load.
2. **Cache `~/Library/Caches/ms-playwright`** in [`_test.yml`](.github/workflows/_test.yml) — skips the ~40s browser download on cache hits.

## Why still macOS (not Ubuntu)

There are 30 committed `-darwin` screenshot baselines (`toHaveScreenshot` / `toMatchSnapshot` in gallery/text/pdf/prepaginated). Linux renders fonts/subpixels differently, so an Ubuntu switch would fail every visual test until all baselines were regenerated — out of scope here.

## Expected impact

Playwright execution ~7m30s → ~3.5–4min; setup ~40s faster on warm cache.

## Risk

If `workers: 2` surfaces screenshot flakiness under load, `retries: 2` absorbs it; dial to 1 if needed. Further speedups available if wanted: shard across parallel jobs, or trim the 5-engine matrix for logic-only tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)