### PR TITLE
feat!: static spine item list — readonly items built at createReader(…

### DIFF
--- a/.github/workflows/_ts_react_native_demo.yml
+++ b/.github/workflows/_ts_react_native_demo.yml
@@ -1,0 +1,34 @@
+name: ts_react_native_demo
+
+on:
+  workflow_call:
+
+jobs:
+  ts_react_native_demo:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 25
+          cache: 'npm'
+
+      - uses: actions/cache@v5
+        id: nx-cache
+        with:
+          path: |
+            .nx
+          key: ${{ runner.os }}-nx-${{ hashFiles('**/package-lock.json') }}
+
+      # The demo consumes @prose-reader/* through file: links that resolve to
+      # each package's dist/, which is gitignored — build the libs first.
+      - name: Build libs
+        run: |
+          npm ci
+          npx lerna run build --stream --scope @prose-reader/*
+
+      - name: Typecheck demo
+        working-directory: prose-react-native-demo
+        run: |
+          npm ci
+          npm run tsc

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,5 +15,8 @@ jobs:
   ts:
     uses: ./.github/workflows/_ts.yml
 
+  ts_react_native_demo:
+    uses: ./.github/workflows/_ts_react_native_demo.yml
+
   tests:
     uses: ./.github/workflows/_test.yml

--- a/.github/workflows/check_publish_lib.yml
+++ b/.github/workflows/check_publish_lib.yml
@@ -33,11 +33,14 @@ jobs:
   ts:
     uses: ./.github/workflows/_ts.yml
 
+  ts_react_native_demo:
+    uses: ./.github/workflows/_ts_react_native_demo.yml
+
   tests:
     uses: ./.github/workflows/_test.yml
 
   publish:
-    needs: [lint, ts, tests, build]
+    needs: [lint, ts, ts_react_native_demo, tests, build]
     runs-on: macos-latest
 
     steps:

--- a/gitbook/archive-reader/README.md
+++ b/gitbook/archive-reader/README.md
@@ -70,7 +70,7 @@ A few rules of thumb:
 | `createArchiveFromText` | `@prose-reader/archive-reader` | a `string` or `Blob` of text | wraps plain text as a single-page reflowable book |
 | `createArchiveFromUrls` | `@prose-reader/archive-reader` | a list of image URLs | pre-paginated; URLs must be same-origin or CORS-enabled |
 | `createArchiveFromPdf` | `@prose-reader/enhancer-pdf` | a PDF `Blob` | see [PDF enhancer](../enhancers/pdf.md) |
-| `createArchiveFromExpoFileSystemNext` | `@prose-reader/react-native` | an `expo-file-system/next` `Directory` | see [React Native](../learn/streamer/react-native.md) |
+| `createArchiveFromExpoFileSystemNext` | `@prose-reader/react-native` | an `expo-file-system` `Directory` | see [React Native](../learn/streamer/react-native.md) |
 
 The `jszip`, `zip.js`, `libarchive.js`, `unzipper` and `node-unrar-js` creators ship as **subpath exports** so the underlying library stays an *optional* peer dependency — you only install (and bundle) the one you use.
 

--- a/gitbook/learn/streamer/react-native.md
+++ b/gitbook/learn/streamer/react-native.md
@@ -7,7 +7,7 @@ As one example, streaming from a directory on disk via `expo-file-system`:
 ```typescript
 import { createArchiveFromExpoFileSystemNext } from "@prose-reader/react-native"
 import { generateManifestFromArchive } from "@prose-reader/streamer"
-import { Directory, Paths } from "expo-file-system/next"
+import { Directory, Paths } from "expo-file-system"
 
 const directory = new Directory(Paths.document, "book")
 const archive = await createArchiveFromExpoFileSystemNext(directory, {

--- a/packages/core/src/enhancers/hotkeys.ts
+++ b/packages/core/src/enhancers/hotkeys.ts
@@ -54,26 +54,21 @@ export const hotkeysEnhancer =
 
     navigateOnKey(document).pipe(takeUntil(reader.$.destroy$)).subscribe()
 
-    reader.spineItemsManager.items$
-      .pipe(
-        switchMap((spineItems) =>
-          merge(
-            ...spineItems.map((item) =>
-              item.watch("isLoaded").pipe(
-                switchMap(() => {
-                  const element = item.renderer.getDocumentFrame()
+    merge(
+      ...reader.spineItemsManager.items.map((item) =>
+        item.watch("isLoaded").pipe(
+          switchMap(() => {
+            const element = item.renderer.getDocumentFrame()
 
-                  return element instanceof HTMLIFrameElement &&
-                    element?.contentDocument
-                    ? navigateOnKey(element.contentDocument)
-                    : EMPTY
-                }),
-              ),
-            ),
-          ),
+            return element instanceof HTMLIFrameElement &&
+              element?.contentDocument
+              ? navigateOnKey(element.contentDocument)
+              : EMPTY
+          }),
         ),
-        takeUntil(reader.$.destroy$),
-      )
+      ),
+    )
+      .pipe(takeUntil(reader.$.destroy$))
       .subscribe()
 
     return reader

--- a/packages/core/src/enhancers/html/links.ts
+++ b/packages/core/src/enhancers/html/links.ts
@@ -2,30 +2,27 @@ import { fromEvent, merge, NEVER, share, switchMap, tap } from "rxjs"
 import type { Reader } from "../../reader"
 
 export const handleLinks = (reader: Reader) => {
-  return reader.spine.spineItemsManager.items$.pipe(
-    switchMap((items) =>
-      merge(
-        ...items.map((item) => {
-          return item.watch("isLoaded").pipe(
-            switchMap(() => {
-              const frame = item.renderer.getDocumentFrame()
+  return merge(
+    ...reader.spine.spineItemsManager.items.map((item) => {
+      return item.watch("isLoaded").pipe(
+        switchMap(() => {
+          const frame = item.renderer.getDocumentFrame()
 
-              if (!frame?.contentDocument) return NEVER
+          if (!frame?.contentDocument) return NEVER
 
-              const anchorElements = Array.from(
-                frame.contentDocument.querySelectorAll(`a`),
-              )
-
-              const events$ = anchorElements.map((element) =>
-                fromEvent<MouseEvent>(element, `click`),
-              )
-
-              return merge(...events$)
-            }),
+          const anchorElements = Array.from(
+            frame.contentDocument.querySelectorAll(`a`),
           )
+
+          const events$ = anchorElements.map((element) =>
+            fromEvent<MouseEvent>(element, `click`),
+          )
+
+          return merge(...events$)
         }),
-      ),
-    ),
+      )
+    }),
+  ).pipe(
     tap((event) => {
       event.preventDefault()
     }),

--- a/packages/core/src/enhancers/layout/createPlaceholderPages.ts
+++ b/packages/core/src/enhancers/layout/createPlaceholderPages.ts
@@ -89,7 +89,7 @@ export const createPlaceholderPages = (
     },
   )
 
-  const itemError$ = reader.spineItemsObserver.states$.pipe(
+  const itemError$ = reader.spineItemsObserver.itemStateChange$.pipe(
     tap(({ item, isError, error }) => {
       if (!isError) return
 

--- a/packages/core/src/enhancers/layout/flagSpineItems.ts
+++ b/packages/core/src/enhancers/layout/flagSpineItems.ts
@@ -2,7 +2,7 @@ import { tap } from "rxjs"
 import type { Reader } from "../../reader"
 
 export const flagSpineItems = (reader: Reader) => {
-  return reader.spineItemsObserver.states$.pipe(
+  return reader.spineItemsObserver.itemStateChange$.pipe(
     tap(({ item, isReady, isDirty }) => {
       // biome-ignore lint/complexity/useLiteralKeys: TS needs it
       item.containerElement.dataset["isDirty"] = isDirty.toString()

--- a/packages/core/src/enhancers/layout/layoutEnhancer.ts
+++ b/packages/core/src/enhancers/layout/layoutEnhancer.ts
@@ -207,7 +207,7 @@ export const layoutEnhancer =
       }
     })
 
-    const revealItemOnReady$ = reader.spineItemsObserver.states$.pipe(
+    const revealItemOnReady$ = reader.spineItemsObserver.itemStateChange$.pipe(
       filter(({ isReady }) => isReady),
       tap(({ item }) => {
         const element = item.renderer.documentContainer

--- a/packages/core/src/enhancers/navigation/bookBoundary.test.ts
+++ b/packages/core/src/enhancers/navigation/bookBoundary.test.ts
@@ -4,7 +4,7 @@ import { CfiManager } from "../../cfi"
 import { Context } from "../../context/Context"
 import { HookManager } from "../../hooks/HookManager"
 import { createNavigator } from "../../navigation/Navigator"
-import { generateItems } from "../../navigation/tests/utils"
+import { mockSpineItemsLayout } from "../../navigation/tests/utils"
 import { Pagination } from "../../pagination/Pagination"
 import type { Reader } from "../../reader"
 import { ReaderSettingsManager } from "../../settings/ReaderSettingsManager"
@@ -12,7 +12,11 @@ import { Spine } from "../../spine/Spine"
 import { SpineItemsManager } from "../../spine/SpineItemsManager"
 import { SpinePosition } from "../../spine/types"
 import { createSpineItemLocator } from "../../spineItem/locationResolver"
-import { createTestManifest, waitFor } from "../../tests/utils"
+import {
+  createTestManifest,
+  createTestManifestSpineItems,
+  waitFor,
+} from "../../tests/utils"
 import { Viewport } from "../../viewport/Viewport"
 import {
   type BookBoundaryReachedEvent,
@@ -53,12 +57,21 @@ const createTestReader = ({
   itemSize?: number
   itemCount?: number
 } = {}) => {
-  const context = new Context(createTestManifest())
+  const context = new Context(
+    createTestManifest({
+      spineItems: createTestManifestSpineItems(itemCount),
+    }),
+  )
   const settings = new ReaderSettingsManager({}, context)
   const hookManager = new HookManager()
-  const spineItemsManager = new SpineItemsManager(context, settings)
-  const cfi = new CfiManager(hookManager, spineItemsManager)
   const viewport = new Viewport(context, settings)
+  const spineItemsManager = new SpineItemsManager(
+    context,
+    settings,
+    hookManager,
+    viewport,
+  )
+  const cfi = new CfiManager(hookManager, spineItemsManager)
   const pagination = new Pagination(context, spineItemsManager)
   const spineItemLocator = createSpineItemLocator({
     context,
@@ -71,7 +84,6 @@ const createTestReader = ({
     spineItemsManager,
     spineItemLocator,
     settings,
-    hookManager,
     viewport,
   )
   const navigator = createNavigator({
@@ -92,17 +104,7 @@ const createTestReader = ({
   )
   viewport.layout()
 
-  const items = generateItems(
-    itemSize,
-    itemCount,
-    context,
-    settings,
-    hookManager,
-    spine,
-    spineItemsManager,
-    viewport,
-  )
-  spineItemsManager.addMany(items)
+  mockSpineItemsLayout(itemSize, spine, spineItemsManager)
 
   const reader = {
     navigation: navigator,

--- a/packages/core/src/enhancers/navigation/boundary.test.ts
+++ b/packages/core/src/enhancers/navigation/boundary.test.ts
@@ -5,7 +5,7 @@ import { Context } from "../../context/Context"
 import { HookManager } from "../../hooks/HookManager"
 import { createNavigator } from "../../navigation/Navigator"
 import { observeSettledNavigation } from "../../navigation/operators"
-import { generateItems } from "../../navigation/tests/utils"
+import { mockSpineItemsLayout } from "../../navigation/tests/utils"
 import { Pagination } from "../../pagination/Pagination"
 import type { Reader } from "../../reader"
 import { ReaderSettingsManager } from "../../settings/ReaderSettingsManager"
@@ -17,7 +17,11 @@ import {
   UnboundSpinePosition,
 } from "../../spine/types"
 import { createSpineItemLocator } from "../../spineItem/locationResolver"
-import { createTestManifest, waitFor } from "../../tests/utils"
+import {
+  createTestManifest,
+  createTestManifestSpineItems,
+  waitFor,
+} from "../../tests/utils"
 import { Viewport } from "../../viewport/Viewport"
 import { type BoundaryReachedEvent, outOfSpineBoundary } from "./boundary"
 
@@ -30,12 +34,22 @@ const createTestReader = ({
   itemCount?: number
   readingDirection?: "ltr" | "rtl"
 } = {}) => {
-  const context = new Context(createTestManifest({ readingDirection }))
+  const context = new Context(
+    createTestManifest({
+      readingDirection,
+      spineItems: createTestManifestSpineItems(itemCount),
+    }),
+  )
   const settings = new ReaderSettingsManager({}, context)
   const hookManager = new HookManager()
-  const spineItemsManager = new SpineItemsManager(context, settings)
-  const cfi = new CfiManager(hookManager, spineItemsManager)
   const viewport = new Viewport(context, settings)
+  const spineItemsManager = new SpineItemsManager(
+    context,
+    settings,
+    hookManager,
+    viewport,
+  )
+  const cfi = new CfiManager(hookManager, spineItemsManager)
   const pagination = new Pagination(context, spineItemsManager)
   const spineItemLocator = createSpineItemLocator({
     context,
@@ -48,7 +62,6 @@ const createTestReader = ({
     spineItemsManager,
     spineItemLocator,
     settings,
-    hookManager,
     viewport,
   )
   const navigator = createNavigator({
@@ -69,17 +82,7 @@ const createTestReader = ({
   )
   viewport.layout()
 
-  const items = generateItems(
-    itemSize,
-    itemCount,
-    context,
-    settings,
-    hookManager,
-    spine,
-    spineItemsManager,
-    viewport,
-  )
-  spineItemsManager.addMany(items)
+  const items = mockSpineItemsLayout(itemSize, spine, spineItemsManager)
 
   // Cast: only the fields read by `outOfSpineBoundary` are wired up.
   const reader = {
@@ -463,7 +466,7 @@ describe("outOfSpineBoundary", () => {
           }),
       )
 
-      // `generateItems` already installed an LTR-layout spy on the same
+      // `mockSpineItemsLayout` already installed an LTR-layout spy on the same
       // method; reset before re-installing the RTL implementation so the
       // new mock fully replaces the old one (vi.spyOn returns the existing
       // spy when the prop is already spied — without the reset we'd end up

--- a/packages/core/src/enhancers/navigation/resolvers/getNavigationForRightOrBottomPage.test.ts
+++ b/packages/core/src/enhancers/navigation/resolvers/getNavigationForRightOrBottomPage.test.ts
@@ -12,14 +12,22 @@ import {
   UnboundSpinePosition,
 } from "../../../spine/types"
 import { createSpineItemLocator } from "../../../spineItem/locationResolver"
-import { SpineItem } from "../../../spineItem/SpineItem"
-import { createTestManifest } from "../../../tests/utils"
+import {
+  createTestManifest,
+  createTestManifestSpineItems,
+} from "../../../tests/utils"
 import { Viewport } from "../../../viewport/Viewport"
 import { getNavigationForLeftOrTopPage } from "./getNavigationForLeftOrTopPage"
 import { getNavigationForRightOrBottomPage } from "./getNavigationForRightOrBottomPage"
 
 const createContext = () => {
-  const context = new Context(createTestManifest())
+  const context = new Context(
+    createTestManifest({
+      spineItems: createTestManifestSpineItems([
+        { href: "item.xhtml", id: "item" },
+      ]),
+    }),
+  )
   const settings = new ReaderSettingsManager(
     {
       pageTurnMode: "scrollable",
@@ -27,9 +35,14 @@ const createContext = () => {
     context,
   )
   const hookManager = new HookManager()
-  const spineItemsManager = new SpineItemsManager(context, settings)
-  const cfi = new CfiManager(hookManager, spineItemsManager)
   const viewport = new Viewport(context, settings)
+  const spineItemsManager = new SpineItemsManager(
+    context,
+    settings,
+    hookManager,
+    viewport,
+  )
+  const cfi = new CfiManager(hookManager, spineItemsManager)
   const pagination = new Pagination(context, spineItemsManager)
   const spineItemLocator = createSpineItemLocator({
     context,
@@ -42,22 +55,12 @@ const createContext = () => {
     spineItemsManager,
     spineItemLocator,
     settings,
-    hookManager,
     viewport,
   )
-  const spineItem = new SpineItem(
-    {
-      href: "item.xhtml",
-      id: "item",
-      index: 0,
-    },
-    document.createElement("div"),
-    context,
-    settings,
-    hookManager,
-    0,
-    viewport,
-  )
+  const spineItem = spineItemsManager.items[0]
+
+  if (!spineItem) throw new Error("Expected one spine item from the manifest")
+
   const spineItemLayout = new SpineItemSpineLayout({
     bottom: 250,
     height: 250,
@@ -80,7 +83,6 @@ const createContext = () => {
   )
 
   viewport.layout()
-  spineItemsManager.addMany([spineItem])
 
   const navigationResolver = createNavigationResolver({
     cfi,

--- a/packages/core/src/enhancers/pagination/trackPaginationInfo.ts
+++ b/packages/core/src/enhancers/pagination/trackPaginationInfo.ts
@@ -112,7 +112,7 @@ const mapTotalsFromPagesState = ({
   items,
   pagesState,
 }: {
-  items: SpineItem[]
+  items: readonly SpineItem[]
   pagesState: PagesState
 }) => {
   const numberOfPagesPerItems = items.map(() => 0)
@@ -240,12 +240,12 @@ export const trackPaginationInfo = (reader: Reader & LayoutEnhancerOutput) => {
     distinctUntilChanged(),
   )
 
-  const totals$ = combineLatest([
-    pagesState$,
-    reader.spineItemsManager.items$,
-  ]).pipe(
-    map(([pagesState, items]) =>
-      mapTotalsFromPagesState({ items, pagesState }),
+  const totals$ = pagesState$.pipe(
+    map((pagesState) =>
+      mapTotalsFromPagesState({
+        items: reader.spineItemsManager.items,
+        pagesState,
+      }),
     ),
     distinctUntilChanged(areTotalsEqual),
   )

--- a/packages/core/src/enhancers/selection/selectionEnhancer.ts
+++ b/packages/core/src/enhancers/selection/selectionEnhancer.ts
@@ -62,26 +62,23 @@ export const selectionEnhancer =
     const reader = next(options)
     let lasSelection: SelectionValue
 
-    const trackedSelection$ = reader.spineItemsManager.items$.pipe(
-      switchMap((spineItems) => {
-        const instances = spineItems.map((spineItem) => {
-          const itemIndex =
-            reader.spineItemsManager.getSpineItemIndex(spineItem) ?? 0
+    const trackedSelection$ = merge(
+      ...reader.spineItemsManager.items.map((spineItem) => {
+        const itemIndex =
+          reader.spineItemsManager.getSpineItemIndex(spineItem) ?? 0
 
-          return trackSpineItemSelection(spineItem).pipe(
-            map((entry) => {
-              if (!entry) return undefined
+        return trackSpineItemSelection(spineItem).pipe(
+          map((entry) => {
+            if (!entry) return undefined
 
-              return {
-                ...entry,
-                itemIndex,
-              }
-            }),
-          )
-        })
-
-        return merge(...instances)
+            return {
+              ...entry,
+              itemIndex,
+            }
+          }),
+        )
       }),
+    ).pipe(
       startWith(undefined),
       distinctUntilChanged(),
       tap((value) => {

--- a/packages/core/src/enhancers/theme.ts
+++ b/packages/core/src/enhancers/theme.ts
@@ -132,21 +132,6 @@ export const themeEnhancer: ThemeEnhancer = (next) => (options) => {
     }
   })
 
-  /**
-   * Make sure to apply theme on item container (fixed layout)
-   * & loading element
-   */
-  reader.spineItemsManager.items$
-    .pipe(
-      tap((items) =>
-        items.map(({ element }) =>
-          applyChangeToSpineItemElement({ container: element }),
-        ),
-      ),
-      takeUntil(reader.$.destroy$),
-    )
-    .subscribe()
-
   currentThemeSubject$
     .pipe(
       tap(() => {

--- a/packages/core/src/navigation/InternalNavigator.test.ts
+++ b/packages/core/src/navigation/InternalNavigator.test.ts
@@ -9,19 +9,32 @@ import { Spine } from "../spine/Spine"
 import { SpineItemsManager } from "../spine/SpineItemsManager"
 import { SpinePosition } from "../spine/types"
 import { createSpineItemLocator } from "../spineItem/locationResolver"
-import { createTestManifest, waitFor } from "../tests/utils"
+import {
+  createTestManifest,
+  createTestManifestSpineItems,
+  waitFor,
+} from "../tests/utils"
 import { Viewport } from "../viewport/Viewport"
 import { createNavigator } from "./Navigator"
-import { generateItems } from "./tests/utils"
+import { mockSpineItemsLayout } from "./tests/utils"
 import type { InternalNavigationEntry } from "./types"
 
-const createNavigatorContext = () => {
-  const context = new Context(createTestManifest())
+const createNavigatorContext = (numberOfItems = 0) => {
+  const context = new Context(
+    createTestManifest({
+      spineItems: createTestManifestSpineItems(numberOfItems),
+    }),
+  )
   const settings = new ReaderSettingsManager({}, context)
   const hookManager = new HookManager()
-  const spineItemsManager = new SpineItemsManager(context, settings)
-  const cfi = new CfiManager(hookManager, spineItemsManager)
   const viewport = new Viewport(context, settings)
+  const spineItemsManager = new SpineItemsManager(
+    context,
+    settings,
+    hookManager,
+    viewport,
+  )
+  const cfi = new CfiManager(hookManager, spineItemsManager)
   const pagination = new Pagination(context, spineItemsManager)
   const spineItemLocator = createSpineItemLocator({
     context,
@@ -34,7 +47,6 @@ const createNavigatorContext = () => {
     spineItemsManager,
     spineItemLocator,
     settings,
-    hookManager,
     viewport,
   )
   const navigator = createNavigator({
@@ -131,29 +143,10 @@ describe(`Given unloaded book`, () => {
 describe(`Given loaded book`, () => {
   describe("Given invalid negative navigation spine item", () => {
     it(`should fallback to 0`, async () => {
-      const {
-        navigator,
-        spineItemsManager,
-        context,
-        settings,
-        hookManager,
-        spine,
-        viewport,
-      } = createNavigatorContext()
+      const { navigator, spineItemsManager, spine } = createNavigatorContext(2)
       const navigations: InternalNavigationEntry[] = []
 
-      const items = generateItems(
-        100,
-        2,
-        context,
-        settings,
-        hookManager,
-        spine,
-        spineItemsManager,
-        viewport,
-      )
-
-      spineItemsManager.addMany(items)
+      mockSpineItemsLayout(100, spine, spineItemsManager)
 
       const sub = navigator.internalNavigator.navigationSubject
         .pipe(skip(1))
@@ -183,29 +176,10 @@ describe(`Given loaded book`, () => {
 
   describe("Given invalid positive navigation spine item", () => {
     it(`should fallback to length - 1`, async () => {
-      const {
-        spine,
-        context,
-        settings,
-        hookManager,
-        navigator,
-        spineItemsManager,
-        viewport,
-      } = createNavigatorContext()
+      const { spine, navigator, spineItemsManager } = createNavigatorContext(2)
       const navigations: InternalNavigationEntry[] = []
 
-      const items = generateItems(
-        100,
-        2,
-        context,
-        settings,
-        hookManager,
-        spine,
-        spineItemsManager,
-        viewport,
-      )
-
-      spineItemsManager.addMany(items)
+      mockSpineItemsLayout(100, spine, spineItemsManager)
 
       spine.layout()
 
@@ -244,32 +218,14 @@ describe(`Given loaded book`, () => {
     ])(
       `should clamp to viewport-flush position in %s mode and preserve the raw request`,
       async (_label, computedPageTurnMode) => {
-        const {
-          spine,
-          context,
-          settings,
-          hookManager,
-          navigator,
-          spineItemsManager,
-          viewport,
-        } = createNavigatorContext()
+        const { spine, settings, navigator, spineItemsManager } =
+          createNavigatorContext(2)
 
         settings.update({ pageTurnMode: computedPageTurnMode })
 
         const navigations: InternalNavigationEntry[] = []
 
-        const items = generateItems(
-          100,
-          2,
-          context,
-          settings,
-          hookManager,
-          spine,
-          spineItemsManager,
-          viewport,
-        )
-
-        spineItemsManager.addMany(items)
+        mockSpineItemsLayout(100, spine, spineItemsManager)
 
         spine.layout()
 
@@ -307,30 +263,12 @@ describe(`Given loaded book`, () => {
     // between. A `position`-equality short-circuit before the active mode
     // controller dropped the second call and the user landed on the wrong page.
     it("should forward both to scrollNavigationController.navigate", async () => {
-      const {
-        spine,
-        context,
-        settings,
-        hookManager,
-        navigator,
-        spineItemsManager,
-        viewport,
-      } = createNavigatorContext()
+      const { spine, settings, navigator, spineItemsManager } =
+        createNavigatorContext(2)
 
       settings.update({ pageTurnMode: "scrollable" })
 
-      const items = generateItems(
-        100,
-        2,
-        context,
-        settings,
-        hookManager,
-        spine,
-        spineItemsManager,
-        viewport,
-      )
-
-      spineItemsManager.addMany(items)
+      mockSpineItemsLayout(100, spine, spineItemsManager)
 
       spine.layout()
 

--- a/packages/core/src/navigation/controllers/ControlledNavigationController.test.ts
+++ b/packages/core/src/navigation/controllers/ControlledNavigationController.test.ts
@@ -15,8 +15,13 @@ const createTestController = () => {
   const context = new Context(createTestManifest())
   const settings = new ReaderSettingsManager({}, context)
   const hookManager = new HookManager()
-  const spineItemsManager = new SpineItemsManager(context, settings)
   const viewport = new Viewport(context, settings)
+  const spineItemsManager = new SpineItemsManager(
+    context,
+    settings,
+    hookManager,
+    viewport,
+  )
   const pagination = new Pagination(context, spineItemsManager)
   const spineItemLocator = createSpineItemLocator({
     context,
@@ -29,7 +34,6 @@ const createTestController = () => {
     spineItemsManager,
     spineItemLocator,
     settings,
-    hookManager,
     viewport,
   )
 

--- a/packages/core/src/navigation/restoration/restoreNavigationForControlledPageTurnMode.test.ts
+++ b/packages/core/src/navigation/restoration/restoreNavigationForControlledPageTurnMode.test.ts
@@ -9,10 +9,13 @@ import { Spine } from "../../spine/Spine"
 import { SpineItemsManager } from "../../spine/SpineItemsManager"
 import { SpinePosition } from "../../spine/types"
 import { createSpineItemLocator } from "../../spineItem/locationResolver"
-import { createTestManifest } from "../../tests/utils"
+import {
+  createTestManifest,
+  createTestManifestSpineItems,
+} from "../../tests/utils"
 import { Viewport } from "../../viewport/Viewport"
 import { createNavigationResolver } from "../resolvers/NavigationResolver"
-import { generateItems } from "../tests/utils"
+import { mockSpineItemsLayout } from "../tests/utils"
 import type { InternalNavigationEntry, NavigationConsolidation } from "../types"
 import { restoreNavigationForControlledPageTurnMode } from "./restoreNavigationForControlledPageTurnMode"
 
@@ -20,14 +23,23 @@ describe(`Given a backward navigation to a new item`, () => {
   describe(`when item was unloaded`, () => {
     describe(`and item is bigger once loaded`, () => {
       it(`should restore position at the last page`, async () => {
-        const context = new Context(createTestManifest())
+        const context = new Context(
+          createTestManifest({
+            spineItems: createTestManifestSpineItems(2),
+          }),
+        )
         const settings = new ReaderSettingsManager({}, context)
         const hooksManager = new HookManager()
-        const spineItemsManager = new SpineItemsManager(context, settings)
+        const viewport = new Viewport(context, settings)
+        const spineItemsManager = new SpineItemsManager(
+          context,
+          settings,
+          hooksManager,
+          viewport,
+        )
         const cfiManager = new CfiManager(hooksManager, spineItemsManager)
         // biome-ignore lint/suspicious/noExplicitAny: TODO
         const pagination = new Pagination(context, spineItemsManager as any)
-        const viewport = new Viewport(context, settings)
         const spineItemLocator = createSpineItemLocator({
           context,
           settings,
@@ -40,7 +52,6 @@ describe(`Given a backward navigation to a new item`, () => {
           spineItemsManager as any,
           spineItemLocator,
           settings,
-          hooksManager,
           viewport,
         )
         const navigationResolver = createNavigationResolver({
@@ -63,18 +74,7 @@ describe(`Given a backward navigation to a new item`, () => {
         viewport.layout()
 
         // items of 2 pages
-        spineItemsManager.addMany(
-          generateItems(
-            100,
-            2,
-            context,
-            settings,
-            hooksManager,
-            spine,
-            spineItemsManager,
-            viewport,
-          ),
-        )
+        mockSpineItemsLayout(100, spine, spineItemsManager)
 
         spine.layout()
 

--- a/packages/core/src/navigation/tests/utils.ts
+++ b/packages/core/src/navigation/tests/utils.ts
@@ -1,65 +1,19 @@
 import { vi } from "vitest"
-import { SpineItem, type Viewport } from "../.."
-import type { Context } from "../../context/Context"
-import type { HookManager } from "../../hooks/HookManager"
-import type { ReaderSettingsManager } from "../../settings/ReaderSettingsManager"
 import type { Spine } from "../../spine/Spine"
 import type { SpineItemsManager } from "../../spine/SpineItemsManager"
 import { SpineItemSpineLayout } from "../../spine/types"
 
-const createSpineItem = (
-  item: {
-    left: number
-    top: number
-    right: number
-    bottom: number
-    width: number
-    height: number
-  },
-  context: Context,
-  index: number,
-  settings: ReaderSettingsManager,
-  hookManager: HookManager,
-  viewport: Viewport,
-) => {
-  const containerElement = document.createElement("div")
-
-  const spineItem = new SpineItem(
-    // biome-ignore lint/suspicious/noExplicitAny: TODO
-    {} as any,
-    containerElement,
-    context,
-    settings,
-    hookManager,
-    index,
-    viewport,
-  )
-
-  vi.spyOn(spineItem, "layoutInfo", "get").mockReturnValue({
-    // left: item.left,
-    // top: item.top,
-    width: item.width,
-    height: item.height,
-    // right: item.right,
-    // bottom: item.bottom,
-    // x: item.left,
-    // y: item.top,
-  })
-
-  return spineItem
-}
-
-export const generateItems = (
+/**
+ * Mock a horizontal LTR layout where every spine item is a `size` × `size`
+ * square laid out side by side. Operates on the items built by the manager
+ * from the manifest.
+ */
+export const mockSpineItemsLayout = (
   size: number,
-  number: number,
-  context: Context,
-  settings: ReaderSettingsManager,
-  hookManager: HookManager,
   spine: Spine,
   spineItemsManager: SpineItemsManager,
-  viewport: Viewport,
 ) => {
-  const layoutInfos: SpineItemSpineLayout[] = Array.from(Array(number)).map(
+  const layoutInfos = spineItemsManager.items.map(
     (_, index) =>
       new SpineItemSpineLayout({
         left: index * size,
@@ -73,24 +27,19 @@ export const generateItems = (
       }),
   )
 
-  const items = Array.from(Array(number)).map((_, index) =>
-    createSpineItem(
-      // biome-ignore lint/style/noNonNullAssertion: TODO
-      layoutInfos[index]!,
-      context,
-      index,
-      settings,
-      hookManager,
-      viewport,
-    ),
-  )
+  spineItemsManager.items.forEach((spineItem) => {
+    vi.spyOn(spineItem, "layoutInfo", "get").mockReturnValue({
+      width: size,
+      height: size,
+    })
+  })
 
   vi.spyOn(spine, "getSpineItemSpineLayoutInfo").mockImplementation((item) => {
     const itemIndex = spineItemsManager.getSpineItemIndex(item) ?? 0
 
-    // biome-ignore lint/style/noNonNullAssertion: TODO
+    // biome-ignore lint/style/noNonNullAssertion: index in range
     return layoutInfos[itemIndex]!
   })
 
-  return items
+  return spineItemsManager.items
 }

--- a/packages/core/src/reader.test.ts
+++ b/packages/core/src/reader.test.ts
@@ -17,6 +17,7 @@ import {
   HTML_PREFIX_SCROLL_NAVIGATOR,
 } from "./constants"
 import { createReader } from "./reader"
+import { waitFor } from "./tests/utils"
 
 window.__PROSE_READER_DEBUG = false
 
@@ -76,7 +77,48 @@ afterEach(() => {
   container.remove()
 })
 
+describe("Given a reader which is not mounted", () => {
+  /**
+   * Spine items exist from reader creation but rendering only starts at
+   * mount: containers are still detached and users may register hooks
+   * between `createReader()` and `mount()`.
+   */
+  it("does not load any spine item", async () => {
+    const reader = createTestReader()
+
+    const loadSpies = reader.spineItemsManager.items.map((item) =>
+      vi.spyOn(item.renderer, "load"),
+    )
+
+    // longer than the spine items loader debounce
+    await waitFor(200)
+
+    expect(loadSpies.map((spy) => spy.mock.calls.length)).toEqual([0])
+
+    reader.destroy()
+  })
+})
+
 describe("Given a mounted reader", () => {
+  it("loads visible spine items", async () => {
+    const reader = createTestReader()
+
+    const loadSpy = vi.spyOn(
+      // biome-ignore lint/style/noNonNullAssertion: manifest has one item
+      reader.spineItemsManager.items[0]!.renderer,
+      "load",
+    )
+
+    reader.mount(container)
+
+    // longer than the spine items loader debounce
+    await waitFor(200)
+
+    expect(loadSpy).toHaveBeenCalled()
+
+    reader.destroy()
+  })
+
   it("appends a single reader-owned subtree under the container", () => {
     const reader = createTestReader()
 

--- a/packages/core/src/reader.ts
+++ b/packages/core/src/reader.ts
@@ -67,9 +67,14 @@ export const createReader = ({
   const context = new Context(manifest)
   const settingsManager = new ReaderSettingsManager(inputSettings, context)
   const features = new Features(context, settingsManager)
-  const spineItemsManager = new SpineItemsManager(context, settingsManager)
-  const cfi = new CfiManager(hookManager, spineItemsManager)
   const viewport = new Viewport(context, settingsManager)
+  const spineItemsManager = new SpineItemsManager(
+    context,
+    settingsManager,
+    hookManager,
+    viewport,
+  )
+  const cfi = new CfiManager(hookManager, spineItemsManager)
   const spineItemLocator = createSpineItemLocator({
     context,
     settings: settingsManager,
@@ -82,7 +87,6 @@ export const createReader = ({
     spineItemsManager,
     spineItemLocator,
     settingsManager,
-    hookManager,
     viewport,
   )
   const navigator = createNavigator({

--- a/packages/core/src/spine/Spine.ts
+++ b/packages/core/src/spine/Spine.ts
@@ -2,11 +2,10 @@ import { BehaviorSubject, merge } from "rxjs"
 import { filter, takeUntil, tap } from "rxjs/operators"
 import { HTML_PREFIX } from "../constants"
 import type { Context } from "../context/Context"
-import type { HookManager } from "../hooks/HookManager"
 import type { Pagination } from "../pagination/Pagination"
 import type { ReaderSettingsManager } from "../settings/ReaderSettingsManager"
 import type { createSpineItemLocator as createSpineItemLocationResolver } from "../spineItem/locationResolver"
-import { SpineItem } from "../spineItem/SpineItem"
+import type { SpineItem } from "../spineItem/SpineItem"
 import { DestroyableClass } from "../utils/DestroyableClass"
 import { isDefined } from "../utils/isDefined"
 import type { Viewport } from "../viewport/Viewport"
@@ -35,7 +34,6 @@ export class Spine extends DestroyableClass {
     public spineItemsManager: SpineItemsManager,
     public spineItemLocator: ReturnType<typeof createSpineItemLocationResolver>,
     protected settings: ReaderSettingsManager,
-    protected hookManager: HookManager,
     protected viewport: Viewport,
   ) {
     super()
@@ -92,27 +90,16 @@ export class Spine extends DestroyableClass {
       }),
     )
 
-    const loadSpineItems$ = this.element$.pipe(
+    const attachSpineItems$ = this.element$.pipe(
       filter(isDefined),
       tap((element) => {
-        const spineItems = this.context.manifest.spineItems.map(
-          (resource, index) =>
-            new SpineItem(
-              resource,
-              element,
-              this.context,
-              this.settings,
-              this.hookManager,
-              index,
-              this.viewport,
-            ),
-        )
-
-        this.spineItemsManager.addMany(spineItems)
+        this.spineItemsManager.items.forEach((item) => {
+          item.attach(element)
+        })
       }),
     )
 
-    merge(loadSpineItems$, spineElementUpdate$)
+    merge(attachSpineItems$, spineElementUpdate$)
       .pipe(takeUntil(this.destroy$))
       .subscribe()
   }

--- a/packages/core/src/spine/SpineItemsManager.test.ts
+++ b/packages/core/src/spine/SpineItemsManager.test.ts
@@ -2,39 +2,64 @@ import { describe, expect, it } from "vitest"
 import { Context } from "../context/Context"
 import { HookManager } from "../hooks/HookManager"
 import { ReaderSettingsManager } from "../settings/ReaderSettingsManager"
-import { SpineItem } from "../spineItem/SpineItem"
-import { createTestManifest } from "../tests/utils"
+import {
+  createTestManifest,
+  createTestManifestSpineItems,
+} from "../tests/utils"
 import { Viewport } from "../viewport/Viewport"
 import { SpineItemsManager } from "./SpineItemsManager"
 
-const createManager = () => {
-  const context = new Context(createTestManifest())
+const createManager = (numberOfItems: number) => {
+  const context = new Context(
+    createTestManifest({
+      spineItems: createTestManifestSpineItems(numberOfItems),
+    }),
+  )
   const settings = new ReaderSettingsManager({}, context)
   const hookManager = new HookManager()
   const viewport = new Viewport(context, settings)
-  const spineItemsManager = new SpineItemsManager(context, settings)
+  const spineItemsManager = new SpineItemsManager(
+    context,
+    settings,
+    hookManager,
+    viewport,
+  )
 
-  const createSpineItem = (index: number) =>
-    new SpineItem(
-      // biome-ignore lint/suspicious/noExplicitAny: test does not need a real manifest item
-      {} as any,
-      document.createElement("div"),
-      context,
-      settings,
-      hookManager,
-      index,
-      viewport,
-    )
-
-  return { spineItemsManager, createSpineItem }
+  return { spineItemsManager, hookManager }
 }
+
+describe("items", () => {
+  it("should build one detached item per manifest spine item at construction", () => {
+    const { spineItemsManager } = createManager(3)
+
+    expect(spineItemsManager.items).toHaveLength(3)
+    expect(spineItemsManager.items.map(({ item }) => item.id)).toEqual([
+      "item-0",
+      "item-1",
+      "item-2",
+    ])
+    expect(
+      spineItemsManager.items.every(
+        (item) => item.element.parentElement === null,
+      ),
+    ).toBe(true)
+  })
+})
+
+describe("get", () => {
+  it("should resolve by numeric index and by id", () => {
+    const { spineItemsManager } = createManager(3)
+
+    expect(spineItemsManager.get(1)).toBe(spineItemsManager.items[1])
+    expect(spineItemsManager.get("item-2")).toBe(spineItemsManager.items[2])
+    expect(spineItemsManager.get(undefined)).toBeUndefined()
+  })
+})
 
 describe("getSpineItemIndex", () => {
   it("should return the stored index for each item in order", () => {
-    const { spineItemsManager, createSpineItem } = createManager()
-    const items = [0, 1, 2].map(createSpineItem)
-
-    spineItemsManager.addMany(items)
+    const { spineItemsManager } = createManager(3)
+    const items = spineItemsManager.items
 
     expect(spineItemsManager.getSpineItemIndex(items[0])).toBe(0)
     expect(spineItemsManager.getSpineItemIndex(items[1])).toBe(1)
@@ -42,47 +67,52 @@ describe("getSpineItemIndex", () => {
   })
 
   it("should resolve by numeric index and by id", () => {
-    const { spineItemsManager, createSpineItem } = createManager()
-    const items = [0, 1, 2].map(createSpineItem)
-
-    spineItemsManager.addMany(items)
+    const { spineItemsManager } = createManager(3)
 
     expect(spineItemsManager.getSpineItemIndex(1)).toBe(1)
+    expect(spineItemsManager.getSpineItemIndex("item-2")).toBe(2)
     expect(spineItemsManager.getSpineItemIndex(undefined)).toBeUndefined()
   })
+})
 
-  it("should keep index aligned with position after a reload", () => {
-    const { spineItemsManager, createSpineItem } = createManager()
+describe("attach", () => {
+  it("should run hooks registered after construction, before appending", () => {
+    const { spineItemsManager, hookManager } = createManager(1)
+    const parent = document.createElement("div")
+    const hookCalls: Array<{ id: string; parentAtHookTime: unknown }> = []
 
-    spineItemsManager.addMany([0, 1, 2].map(createSpineItem))
+    hookManager.register(
+      "item.onBeforeContainerAttach",
+      ({ element, item }) => {
+        hookCalls.push({ id: item.id, parentAtHookTime: element.parentElement })
+      },
+    )
 
-    spineItemsManager.destroyItems()
+    spineItemsManager.items.forEach((item) => {
+      item.attach(parent)
+    })
 
-    const reloaded = [0, 1].map(createSpineItem)
-    spineItemsManager.addMany(reloaded)
-
-    expect(spineItemsManager.items).toHaveLength(2)
-    expect(spineItemsManager.getSpineItemIndex(reloaded[0])).toBe(0)
-    expect(spineItemsManager.getSpineItemIndex(reloaded[1])).toBe(1)
-    expect(spineItemsManager.items[0]).toBe(reloaded[0])
-    expect(spineItemsManager.items[1]).toBe(reloaded[1])
+    expect(hookCalls).toEqual([{ id: "item-0", parentAtHookTime: null }])
+    expect(spineItemsManager.items[0]?.element.parentElement).toBe(parent)
   })
 })
 
 describe("destroy", () => {
   it("should destroy its items", () => {
-    const { spineItemsManager, createSpineItem } = createManager()
-    const items = [0, 1, 2].map(createSpineItem)
+    const { spineItemsManager } = createManager(3)
+    const parent = document.createElement("div")
+    const items = spineItemsManager.items
 
-    spineItemsManager.addMany(items)
+    items.forEach((item) => {
+      item.attach(parent)
+    })
 
-    expect(items.every((item) => item.element.parentElement !== null)).toBe(
+    expect(items.every((item) => item.element.parentElement === parent)).toBe(
       true,
     )
 
     spineItemsManager.destroy()
 
-    expect(spineItemsManager.items).toHaveLength(0)
     expect(items.every((item) => item.element.parentElement === null)).toBe(
       true,
     )

--- a/packages/core/src/spine/SpineItemsManager.ts
+++ b/packages/core/src/spine/SpineItemsManager.ts
@@ -1,29 +1,39 @@
-import { BehaviorSubject } from "rxjs"
 import type { Context } from "../context/Context"
+import type { HookManager } from "../hooks/HookManager"
 import type { ReaderSettingsManager } from "../settings/ReaderSettingsManager"
 import { SpineItem, type SpineItemReference } from "../spineItem/SpineItem"
 import { DestroyableClass } from "../utils/DestroyableClass"
+import type { Viewport } from "../viewport/Viewport"
 
 export class SpineItemsManager extends DestroyableClass {
+  /**
+   * A reader is tied to a single book so the spine item list is immutable,
+   * derived from the manifest at construction. Items are attached to the DOM
+   * later, once the spine element exists (see SpineItem.attach).
+   */
+  public readonly items: readonly SpineItem[]
+
   constructor(
     protected context: Context,
     protected settings: ReaderSettingsManager,
+    protected hookManager: HookManager,
+    protected viewport: Viewport,
   ) {
     super()
-  }
 
-  protected orderedSpineItemsSubject = new BehaviorSubject<SpineItem[]>([])
-  public items$ = this.orderedSpineItemsSubject.asObservable()
+    this.items = context.manifest.spineItems.map(
+      (item, index) =>
+        new SpineItem(item, context, settings, hookManager, index, viewport),
+    )
+  }
 
   get(indexOrId: SpineItemReference | undefined) {
     if (typeof indexOrId === "number") {
-      return this.orderedSpineItemsSubject.value[indexOrId]
+      return this.items[indexOrId]
     }
 
     if (typeof indexOrId === "string") {
-      return this.orderedSpineItemsSubject.value.find(
-        ({ item }) => item.id === indexOrId,
-      )
+      return this.items.find(({ item }) => item.id === indexOrId)
     }
 
     return indexOrId
@@ -49,34 +59,10 @@ export class SpineItemsManager extends DestroyableClass {
     return spineItem?.index
   }
 
-  addMany(spineItems: SpineItem[]) {
-    this.orderedSpineItemsSubject.next([
-      ...this.orderedSpineItemsSubject.getValue(),
-      ...spineItems,
-    ])
-  }
-
-  get items() {
-    return this.orderedSpineItemsSubject.value
-  }
-
-  /**
-   * @todo remove subscription to each items etc. See add()
-   */
-  destroyItems() {
-    const items = this.orderedSpineItemsSubject.value
-
-    items.forEach((item) => {
+  public destroy() {
+    this.items.forEach((item) => {
       item.destroy()
     })
-
-    if (items.length) {
-      this.orderedSpineItemsSubject.next([])
-    }
-  }
-
-  public destroy() {
-    this.destroyItems()
 
     super.destroy()
   }

--- a/packages/core/src/spine/SpineItemsObserver.test.ts
+++ b/packages/core/src/spine/SpineItemsObserver.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { Context } from "../context/Context"
+import { HookManager } from "../hooks/HookManager"
+import { ReaderSettingsManager } from "../settings/ReaderSettingsManager"
+import type { SpineItem } from "../spineItem/SpineItem"
+import {
+  createTestManifest,
+  createTestManifestSpineItems,
+} from "../tests/utils"
+import { Viewport } from "../viewport/Viewport"
+import { SpineItemsManager } from "./SpineItemsManager"
+import { SpineItemsObserver } from "./SpineItemsObserver"
+
+/**
+ * Mirrors the spec behavior this suite relies on: an observation only
+ * delivers entries for elements that are connected and rendered (a detached
+ * element has no box). Deliveries are triggered manually via
+ * `deliverToConnectedElements`.
+ */
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = []
+
+  static deliverToConnectedElements() {
+    FakeResizeObserver.instances.forEach((instance) => {
+      instance.observed.forEach((element) => {
+        if (element.isConnected) {
+          instance.callback(
+            // biome-ignore lint/suspicious/noExplicitAny: minimal entry, only `target` is consumed
+            [{ target: element } as any],
+            // biome-ignore lint/suspicious/noExplicitAny: fake observer
+            instance as any,
+          )
+        }
+      })
+    })
+  }
+
+  static get observedElements() {
+    return FakeResizeObserver.instances.flatMap(({ observed }) => observed)
+  }
+
+  observed: Element[] = []
+
+  constructor(private callback: ResizeObserverCallback) {
+    FakeResizeObserver.instances.push(this)
+  }
+
+  observe(element: Element) {
+    this.observed.push(element)
+  }
+
+  unobserve() {}
+
+  disconnect() {
+    this.observed = []
+  }
+}
+
+const createTestEnvironment = () => {
+  const context = new Context(
+    createTestManifest({
+      spineItems: createTestManifestSpineItems(2),
+    }),
+  )
+  const settings = new ReaderSettingsManager({}, context)
+  const hookManager = new HookManager()
+  const viewport = new Viewport(context, settings)
+  const spineItemsManager = new SpineItemsManager(
+    context,
+    settings,
+    hookManager,
+    viewport,
+  )
+  const spineItemsObserver = new SpineItemsObserver(spineItemsManager)
+
+  return { spineItemsManager, spineItemsObserver }
+}
+
+describe("itemResize$", () => {
+  beforeEach(() => {
+    FakeResizeObserver.instances = []
+    vi.stubGlobal("ResizeObserver", FakeResizeObserver)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("should observe every item on subscription but emit only once items are attached", () => {
+    const { spineItemsManager, spineItemsObserver } = createTestEnvironment()
+    const emissions: Array<{ item: SpineItem }> = []
+
+    const subscription = spineItemsObserver.itemResize$.subscribe((value) => {
+      emissions.push(value)
+    })
+
+    // observation starts right away, on the still detached elements, so a
+    // real ResizeObserver reports them as soon as they get attached at mount
+    expect(FakeResizeObserver.observedElements).toEqual(
+      spineItemsManager.items.map((item) => item.element),
+    )
+    // detached elements have no box, nothing is reported yet
+    expect(emissions).toEqual([])
+
+    const parent = document.createElement("div")
+    document.body.appendChild(parent)
+    spineItemsManager.items.forEach((item) => {
+      item.attach(parent)
+    })
+
+    FakeResizeObserver.deliverToConnectedElements()
+
+    expect(emissions.length).toBe(2)
+    expect(emissions[0]?.item).toBe(spineItemsManager.items[0])
+    expect(emissions[1]?.item).toBe(spineItemsManager.items[1])
+
+    subscription.unsubscribe()
+    parent.remove()
+  })
+})

--- a/packages/core/src/spine/SpineItemsObserver.ts
+++ b/packages/core/src/spine/SpineItemsObserver.ts
@@ -1,12 +1,5 @@
 import { isShallowEqual } from "@prose-reader/shared"
-import {
-  distinctUntilChanged,
-  map,
-  merge,
-  type Observable,
-  share,
-  switchMap,
-} from "rxjs"
+import { distinctUntilChanged, map, merge, type Observable, share } from "rxjs"
 import type { SpineItem, SpineItemState } from "../spineItem/SpineItem"
 import { DestroyableClass } from "../utils/DestroyableClass"
 import { observeResize } from "../utils/rxjs"
@@ -22,6 +15,9 @@ export class SpineItemsObserver extends DestroyableClass {
 
   /**
    * Observable directly plugged to ResizeObserver for each item.
+   *
+   * Items are only attached to the DOM at mount, and ResizeObserver does not
+   * report detached elements, so this starts emitting once items are attached.
    */
   public itemResize$: Observable<{
     item: SpineItem
@@ -34,47 +30,29 @@ export class SpineItemsObserver extends DestroyableClass {
   constructor(protected spineItemsManager: SpineItemsManager) {
     super()
 
-    this.states$ = this.spineItemsManager.items$.pipe(
-      switchMap((items) => {
-        return merge(
-          ...items.map((item) =>
-            item.pipe(
-              map((state) => ({ item, ...state })),
-              distinctUntilChanged(isShallowEqual),
-            ),
-          ),
-        )
-      }),
-      share(),
-    )
+    const items = spineItemsManager.items
 
-    this.itemResize$ = this.spineItemsManager.items$.pipe(
-      switchMap((items) => {
-        const resize$ = items.map((item) =>
-          observeResize(item.element).pipe(
-            map((entries) => ({ entries, item })),
-          ),
-        )
+    this.states$ = merge(
+      ...items.map((item) =>
+        item.pipe(
+          map((state) => ({ item, ...state })),
+          distinctUntilChanged(isShallowEqual),
+        ),
+      ),
+    ).pipe(share())
 
-        return merge(...resize$)
-      }),
-      share(),
-    )
+    this.itemResize$ = merge(
+      ...items.map((item) =>
+        observeResize(item.element).pipe(map((entries) => ({ entries, item }))),
+      ),
+    ).pipe(share())
 
-    this.itemLoad$ = this.spineItemsManager.items$.pipe(
-      switchMap((items) => {
-        return merge(...items.map((item) => item.loaded$.pipe(map(() => item))))
-      }),
-      share(),
-    )
+    this.itemLoad$ = merge(
+      ...items.map((item) => item.loaded$.pipe(map(() => item))),
+    ).pipe(share())
 
-    this.itemUnload$ = this.spineItemsManager.items$.pipe(
-      switchMap((items) => {
-        return merge(
-          ...items.map((item) => item.unloaded$.pipe(map(() => item))),
-        )
-      }),
-      share(),
-    )
+    this.itemUnload$ = merge(
+      ...items.map((item) => item.unloaded$.pipe(map(() => item))),
+    ).pipe(share())
   }
 }

--- a/packages/core/src/spine/SpineItemsObserver.ts
+++ b/packages/core/src/spine/SpineItemsObserver.ts
@@ -7,11 +7,12 @@ import type { SpineItemsManager } from "./SpineItemsManager"
 
 export class SpineItemsObserver extends DestroyableClass {
   /**
-   * Shared observable which emits every time a spine item state change.
+   * Shared observable which emits every time a spine item state changes.
    * As there can be lot of spine items and subscriptions can become costly it is
-   * encouraged to use this shared observable.
+   * encouraged to use this shared observable. Read `item.value` for a current
+   * snapshot rather than relying on this stream to replay on subscribe.
    */
-  public states$: Observable<{ item: SpineItem } & SpineItemState>
+  public itemStateChange$: Observable<{ item: SpineItem } & SpineItemState>
 
   /**
    * Observable directly plugged to ResizeObserver for each item.
@@ -32,7 +33,7 @@ export class SpineItemsObserver extends DestroyableClass {
 
     const items = spineItemsManager.items
 
-    this.states$ = merge(
+    this.itemStateChange$ = merge(
       ...items.map((item) =>
         item.pipe(
           map((state) => ({ item, ...state })),

--- a/packages/core/src/spine/SpineLayout.test.ts
+++ b/packages/core/src/spine/SpineLayout.test.ts
@@ -4,58 +4,25 @@ import { describe, expect, it, vi } from "vitest"
 import { Context } from "../context/Context"
 import { HookManager } from "../hooks/HookManager"
 import { ReaderSettingsManager } from "../settings/ReaderSettingsManager"
-import { SpineItem } from "../spineItem/SpineItem"
-import { createTestManifest } from "../tests/utils"
+import {
+  createTestManifest,
+  createTestManifestSpineItems,
+} from "../tests/utils"
 import { Viewport } from "../viewport/Viewport"
 import { SpineItemsManager } from "./SpineItemsManager"
 import { SpineItemsObserver } from "./SpineItemsObserver"
 import { SpineLayout } from "./SpineLayout"
 
-const createSpineItem = ({
-  context,
-  hookManager,
-  index,
-  itemOverrides = {},
-  parentElement,
-  settings,
-  viewport,
-}: {
-  context: Context
-  hookManager: HookManager
-  index: number
-  itemOverrides?: Partial<Manifest["spineItems"][number]>
-  parentElement: HTMLElement
-  settings: ReaderSettingsManager
-  viewport: Viewport
-}) => {
-  const item: Manifest["spineItems"][number] = {
-    href: `item-${index}.xhtml`,
-    id: `item-${index}`,
-    mediaType: `application/xhtml+xml`,
-    ...itemOverrides,
-    index,
-  }
-
-  return new SpineItem(
-    item,
-    parentElement,
-    context,
-    settings,
-    hookManager,
-    index,
-    viewport,
-  )
-}
-
 const createPrePaginatedManifest = (
   readingDirection: Manifest["readingDirection"],
+  items: Array<Partial<Manifest["spineItems"][number]> | undefined>,
 ): Manifest => ({
   filename: "",
   items: [],
   readingDirection,
   renditionLayout: "pre-paginated",
   renditionSpread: "auto",
-  spineItems: [],
+  spineItems: createTestManifestSpineItems(items),
   title: "",
 })
 
@@ -63,16 +30,25 @@ const createSpreadModeTestEnvironment = ({
   pageHeight,
   pageWidth,
   readingDirection,
+  items,
 }: {
   pageHeight: number
   pageWidth: number
   readingDirection: Manifest["readingDirection"]
+  items: Array<Partial<Manifest["spineItems"][number]> | undefined>
 }) => {
-  const context = new Context(createPrePaginatedManifest(readingDirection))
+  const context = new Context(
+    createPrePaginatedManifest(readingDirection, items),
+  )
   const settings = new ReaderSettingsManager({ spreadMode: true }, context)
   const hookManager = new HookManager()
   const viewport = new Viewport(context, settings)
-  const spineItemsManager = new SpineItemsManager(context, settings)
+  const spineItemsManager = new SpineItemsManager(
+    context,
+    settings,
+    hookManager,
+    viewport,
+  )
   const spineItemsObserver = new SpineItemsObserver(spineItemsManager)
   const spineLayout = new SpineLayout(
     spineItemsManager,
@@ -81,7 +57,6 @@ const createSpreadModeTestEnvironment = ({
     settings,
     viewport,
   )
-  const parentElement = document.createElement(`div`)
   const layoutRequests: Array<{
     blankPagePosition: "before" | "after" | "none"
     id: string
@@ -106,28 +81,9 @@ const createSpreadModeTestEnvironment = ({
   )
   viewport.layout()
 
-  const addItems = (
-    items: Array<Partial<Manifest["spineItems"][number]> | undefined>,
-  ) => {
-    spineItemsManager.addMany(
-      items.map((itemOverrides, index) =>
-        createSpineItem({
-          context,
-          hookManager,
-          index,
-          itemOverrides: itemOverrides ?? {},
-          parentElement,
-          settings,
-          viewport,
-        }),
-      ),
-    )
-  }
-
   const destroy = () => {
     spineLayout.destroy()
     spineItemsObserver.destroy()
-    spineItemsManager.destroyItems()
     spineItemsManager.destroy()
     viewport.destroy()
     settings.destroy()
@@ -135,7 +91,6 @@ const createSpreadModeTestEnvironment = ({
   }
 
   return {
-    addItems,
     destroy,
     layoutRequests,
     spineLayout,
@@ -143,11 +98,18 @@ const createSpreadModeTestEnvironment = ({
 }
 
 const createTestSpineLayout = () => {
-  const context = new Context(createTestManifest())
+  const context = new Context(
+    createTestManifest({ spineItems: createTestManifestSpineItems(1) }),
+  )
   const settings = new ReaderSettingsManager({}, context)
   const hookManager = new HookManager()
   const viewport = new Viewport(context, settings)
-  const spineItemsManager = new SpineItemsManager(context, settings)
+  const spineItemsManager = new SpineItemsManager(
+    context,
+    settings,
+    hookManager,
+    viewport,
+  )
   const spineItemsObserver = new SpineItemsObserver(spineItemsManager)
   const spineLayout = new SpineLayout(
     spineItemsManager,
@@ -156,27 +118,14 @@ const createTestSpineLayout = () => {
     settings,
     viewport,
   )
-  const parentElement = document.createElement(`div`)
 
   vi.spyOn(viewport.value.element, "clientWidth", "get").mockReturnValue(100)
   vi.spyOn(viewport.value.element, "clientHeight", "get").mockReturnValue(100)
   viewport.layout()
 
-  spineItemsManager.addMany([
-    createSpineItem({
-      context,
-      hookManager,
-      index: 0,
-      parentElement,
-      settings,
-      viewport,
-    }),
-  ])
-
   const destroy = () => {
     spineLayout.destroy()
     spineItemsObserver.destroy()
-    spineItemsManager.destroyItems()
     spineItemsManager.destroy()
     viewport.destroy()
     settings.destroy()
@@ -231,20 +180,19 @@ describe("SpineLayout", () => {
   })
 
   it("keeps RTL right-left spread pairs together after an odd number of pages", async () => {
-    const { addItems, destroy, layoutRequests, spineLayout } =
+    const { destroy, layoutRequests, spineLayout } =
       createSpreadModeTestEnvironment({
         pageHeight: 100,
         pageWidth: 100,
         readingDirection: "rtl",
+        items: [
+          undefined,
+          undefined,
+          undefined,
+          { pageSpreadRight: true, renditionLayout: "pre-paginated" },
+          { pageSpreadLeft: true, renditionLayout: "pre-paginated" },
+        ],
       })
-
-    addItems([
-      undefined,
-      undefined,
-      undefined,
-      { pageSpreadRight: true, renditionLayout: "pre-paginated" },
-      { pageSpreadLeft: true, renditionLayout: "pre-paginated" },
-    ])
 
     try {
       const layoutDone = firstValueFrom(spineLayout.layout$)
@@ -270,20 +218,19 @@ describe("SpineLayout", () => {
   })
 
   it("keeps LTR left-right spread pairs together after an odd number of pages", async () => {
-    const { addItems, destroy, layoutRequests, spineLayout } =
+    const { destroy, layoutRequests, spineLayout } =
       createSpreadModeTestEnvironment({
         pageHeight: 100,
         pageWidth: 100,
         readingDirection: "ltr",
+        items: [
+          undefined,
+          undefined,
+          undefined,
+          { pageSpreadLeft: true, renditionLayout: "pre-paginated" },
+          { pageSpreadRight: true, renditionLayout: "pre-paginated" },
+        ],
       })
-
-    addItems([
-      undefined,
-      undefined,
-      undefined,
-      { pageSpreadLeft: true, renditionLayout: "pre-paginated" },
-      { pageSpreadRight: true, renditionLayout: "pre-paginated" },
-    ])
 
     try {
       const layoutDone = firstValueFrom(spineLayout.layout$)

--- a/packages/core/src/spine/loader/SpineItemsLoader.test.ts
+++ b/packages/core/src/spine/loader/SpineItemsLoader.test.ts
@@ -14,6 +14,10 @@ describe("SpineItemsLoader", () => {
   describe("Given the viewport geometry changes without a position change", () => {
     it("reloads visible spine items from the current relative viewport", async () => {
       const context = new Context(createTestManifest())
+
+      // the loader only runs once mounted
+      context.update({ rootElement: document.createElement("div") })
+
       const settings = new ReaderSettingsManager(
         { numberOfAdjacentSpineItemToPreLoad: 0 },
         context,

--- a/packages/core/src/spine/loader/SpineItemsLoader.ts
+++ b/packages/core/src/spine/loader/SpineItemsLoader.ts
@@ -3,6 +3,7 @@ import {
   BehaviorSubject,
   debounceTime,
   distinctUntilChanged,
+  filter,
   map,
   merge,
   shareReplay,
@@ -13,6 +14,7 @@ import type { Context } from "../../context/Context"
 import type { ReaderSettingsManager } from "../../settings/ReaderSettingsManager"
 import type { SpineItem } from "../../spineItem/SpineItem"
 import { DestroyableClass } from "../../utils/DestroyableClass"
+import { isDefined } from "../../utils/isDefined"
 import { waitForSwitch } from "../../utils/rxjs"
 import type { Viewport } from "../../viewport/Viewport"
 import type { SpineLocator } from "../locator/SpineLocator"
@@ -68,6 +70,11 @@ export class SpineItemsLoader extends DestroyableClass {
       // Ideally loading faster is better but loading too close to user navigating can
       // be dangerous.
       debounceTime(100),
+      // Spine items exist from construction but must not render before mount
+      // (their containers are detached and users may still register hooks).
+      // Dropping pre-mount events is safe: mounting triggers a layout which
+      // re-fires this stream.
+      filter(() => isDefined(this.context.value.rootElement)),
       waitForSwitch(this.context.bridgeEvent.viewportFree$),
       withLatestFrom(this.context.bridgeEvent.position$, forcedOpen$),
       map(([, position, forcedOpenIndexes]) => {

--- a/packages/core/src/spine/locator/getVisibleSpineItemsFromPosition.test.ts
+++ b/packages/core/src/spine/locator/getVisibleSpineItemsFromPosition.test.ts
@@ -1,16 +1,18 @@
 import { firstValueFrom } from "rxjs"
 import { describe, expect, it, vi } from "vitest"
-import { HookManager, SpineItem, SpineItemsObserver } from "../.."
+import { HookManager } from "../.."
 import { Context } from "../../context/Context"
 import { ReaderSettingsManager } from "../../settings/ReaderSettingsManager"
-import { createTestManifest } from "../../tests/utils"
+import {
+  createTestManifest,
+  createTestManifestSpineItems,
+} from "../../tests/utils"
 import { Viewport } from "../../viewport/Viewport"
 import { SpineItemsManager } from "../SpineItemsManager"
+import { SpineItemsObserver } from "../SpineItemsObserver"
 import { SpineLayout } from "../SpineLayout"
 import { SpinePosition } from "../types"
 import { getVisibleSpineItemsFromPosition } from "./getVisibleSpineItemsFromPosition"
-
-const context = new Context(createTestManifest())
 
 const singlePageItems = [
   {
@@ -31,73 +33,54 @@ const singlePageItems = [
   },
 ]
 
-const createSpineItem = (
-  item: (typeof singlePageItems)[number],
-  index: number,
-  settings: ReaderSettingsManager,
-  hookManager: HookManager,
-  viewport: Viewport,
-) => {
-  const containerElement = document.createElement("div")
-
-  const spineItem = new SpineItem(
-    // biome-ignore lint/suspicious/noExplicitAny: TODO
-    {} as any,
-    containerElement,
+const createTestEnvironment = () => {
+  const context = new Context(
+    createTestManifest({
+      spineItems: createTestManifestSpineItems(singlePageItems.length),
+    }),
+  )
+  const settings = new ReaderSettingsManager({}, context)
+  const hookManager = new HookManager()
+  const viewport = new Viewport(context, settings)
+  const spineItemsManager = new SpineItemsManager(
     context,
     settings,
     hookManager,
-    index,
+    viewport,
+  )
+  const spineItemsObserver = new SpineItemsObserver(spineItemsManager)
+  const spineLayout = new SpineLayout(
+    // biome-ignore lint/suspicious/noExplicitAny: TODO
+    spineItemsManager as any,
+    spineItemsObserver,
+    context,
+    settings,
     viewport,
   )
 
-  vi.spyOn(spineItem, "layoutInfo", "get").mockReturnValue({
-    // left: item.left,
-    // top: item.top,
-    width: item.width,
-    height: item.height,
-    // right: item.right,
-    // bottom: item.bottom,
-    // x: item.left,
-    // y: item.top,
+  vi.spyOn(viewport.value.element, "clientWidth", "get").mockReturnValue(100)
+  vi.spyOn(viewport.value.element, "clientHeight", "get").mockReturnValue(100)
+
+  viewport.layout()
+
+  spineItemsManager.items.forEach((spineItem, index) => {
+    vi.spyOn(spineItem, "layoutInfo", "get").mockReturnValue({
+      // biome-ignore lint/style/noNonNullAssertion: index in range
+      width: singlePageItems[index]!.width,
+      // biome-ignore lint/style/noNonNullAssertion: index in range
+      height: singlePageItems[index]!.height,
+    })
   })
 
-  return spineItem
+  return { settings, spineItemsManager, spineLayout, viewport }
 }
 
 describe("Given single page items and no spread", () => {
   describe("when position is in half of the first item", () => {
     describe("and threshold of 0.51", () => {
       it("should not recognize second item", () => {
-        const context = new Context(createTestManifest())
-        const settings = new ReaderSettingsManager({}, context)
-        const spineItemsManager = new SpineItemsManager(context, settings)
-        const hookManager = new HookManager()
-        const viewport = new Viewport(context, settings)
-        const spineItemsObserver = new SpineItemsObserver(spineItemsManager)
-        const spineLayout = new SpineLayout(
-          // biome-ignore lint/suspicious/noExplicitAny: TODO
-          spineItemsManager as any,
-          spineItemsObserver,
-          context,
-          settings,
-          viewport,
-        )
-
-        vi.spyOn(viewport.value.element, "clientWidth", "get").mockReturnValue(
-          100,
-        )
-        vi.spyOn(viewport.value.element, "clientHeight", "get").mockReturnValue(
-          100,
-        )
-
-        viewport.layout()
-
-        const spineItems = singlePageItems.map((item, index) =>
-          createSpineItem(item, index, settings, hookManager, viewport),
-        )
-
-        spineItemsManager.addMany(spineItems)
+        const { settings, spineItemsManager, spineLayout, viewport } =
+          createTestEnvironment()
 
         spineLayout.layout()
 
@@ -120,35 +103,8 @@ describe("Given single page items and no spread", () => {
 
     describe("and threshold of 0.50", () => {
       it("should not recognize second item", () => {
-        const context = new Context(createTestManifest())
-        const settings = new ReaderSettingsManager({}, context)
-        const spineItemsManager = new SpineItemsManager(context, settings)
-        const hookManager = new HookManager()
-        const viewport = new Viewport(context, settings)
-        const spineItemsObserver = new SpineItemsObserver(spineItemsManager)
-        const spineLayout = new SpineLayout(
-          // biome-ignore lint/suspicious/noExplicitAny: TODO
-          spineItemsManager as any,
-          spineItemsObserver,
-          context,
-          settings,
-          viewport,
-        )
-
-        vi.spyOn(viewport.value.element, "clientWidth", "get").mockReturnValue(
-          100,
-        )
-        vi.spyOn(viewport.value.element, "clientHeight", "get").mockReturnValue(
-          100,
-        )
-
-        viewport.layout()
-
-        const spineItems = singlePageItems.map((item, index) =>
-          createSpineItem(item, index, settings, hookManager, viewport),
-        )
-
-        spineItemsManager.addMany(spineItems)
+        const { settings, spineItemsManager, spineLayout, viewport } =
+          createTestEnvironment()
 
         spineLayout.layout()
 
@@ -171,35 +127,8 @@ describe("Given single page items and no spread", () => {
 
     describe("and threshold of 0.49", () => {
       it("should recognize second item", async () => {
-        const context = new Context(createTestManifest())
-        const settings = new ReaderSettingsManager({}, context)
-        const spineItemsManager = new SpineItemsManager(context, settings)
-        const hookManager = new HookManager()
-        const viewport = new Viewport(context, settings)
-        const spineItemsObserver = new SpineItemsObserver(spineItemsManager)
-        const spineLayout = new SpineLayout(
-          // biome-ignore lint/suspicious/noExplicitAny: TODO
-          spineItemsManager as any,
-          spineItemsObserver,
-          context,
-          settings,
-          viewport,
-        )
-
-        vi.spyOn(viewport.value.element, "clientWidth", "get").mockReturnValue(
-          100,
-        )
-        vi.spyOn(viewport.value.element, "clientHeight", "get").mockReturnValue(
-          100,
-        )
-
-        viewport.layout()
-
-        const spineItems = singlePageItems.map((item, index) =>
-          createSpineItem(item, index, settings, hookManager, viewport),
-        )
-
-        spineItemsManager.addMany(spineItems)
+        const { settings, spineItemsManager, spineLayout, viewport } =
+          createTestEnvironment()
 
         spineLayout.layout()
 

--- a/packages/core/src/spineItem/SpineItem.ts
+++ b/packages/core/src/spineItem/SpineItem.ts
@@ -48,7 +48,6 @@ export class SpineItem extends ReactiveEntity<SpineItemState> {
 
   constructor(
     public item: Manifest[`spineItems`][number],
-    public parentElement: HTMLElement,
     public context: Context,
     public settings: ReaderSettingsManager,
     public hookManager: HookManager,
@@ -63,13 +62,7 @@ export class SpineItem extends ReactiveEntity<SpineItemState> {
       error: undefined,
     })
 
-    this.containerElement = createContainerElement(
-      parentElement,
-      item,
-      hookManager,
-    )
-
-    parentElement.appendChild(this.containerElement)
+    this.containerElement = createContainerElement(item)
 
     const rendererFactory = this.settings.values.getRenderer?.(item)
 
@@ -131,6 +124,21 @@ export class SpineItem extends ReactiveEntity<SpineItemState> {
     )
       .pipe(takeUntil(this.destroy$))
       .subscribe()
+  }
+
+  /**
+   * Attach the item container to the spine element. Deferred from construction
+   * so that `item.onBeforeContainerAttach` hooks registered between
+   * `createReader()` and `mount()` are honored. `appendChild` adopts the
+   * container into the parent's document when mounting into another document.
+   */
+  attach = (parentElement: HTMLElement) => {
+    this.hookManager.execute(`item.onBeforeContainerAttach`, {
+      element: this.containerElement,
+      item: this.item,
+    })
+
+    parentElement.appendChild(this.containerElement)
   }
 
   load = () => {
@@ -225,13 +233,8 @@ export class SpineItem extends ReactiveEntity<SpineItemState> {
   }
 }
 
-const createContainerElement = (
-  containerElement: HTMLElement,
-  item: Manifest[`spineItems`][number],
-  hookManager: HookManager,
-) => {
-  const element: HTMLElement =
-    containerElement.ownerDocument.createElement(`div`)
+const createContainerElement = (item: Manifest[`spineItems`][number]) => {
+  const element: HTMLElement = document.createElement(`div`)
   element.setAttribute(`data-${HTML_PREFIX_SPINE_ITEM}`, "")
   element.classList.add(`spineItem`)
   element.classList.add(`spineItem-${item.renditionLayout ?? "reflowable"}`)
@@ -241,8 +244,6 @@ const createContainerElement = (
   `
   // biome-ignore lint/complexity/useLiteralKeys: TODO
   element.dataset["isReady"] = `false`
-
-  hookManager.execute("item.onBeforeContainerAttach", { element, item })
 
   return element
 }

--- a/packages/core/src/tests/utils.ts
+++ b/packages/core/src/tests/utils.ts
@@ -3,6 +3,23 @@ import type { Manifest } from "@prose-reader/shared"
 export const waitFor = async (timeout: number) =>
   await new Promise((resolve) => setTimeout(resolve, timeout))
 
+export const createTestManifestSpineItems = (
+  items: number | Array<Partial<Manifest["spineItems"][number]> | undefined>,
+): Manifest["spineItems"] => {
+  const itemsOverrides =
+    typeof items === "number"
+      ? Array.from({ length: items }, () => undefined)
+      : items
+
+  return itemsOverrides.map((overrides, index) => ({
+    href: `item-${index}.xhtml`,
+    id: `item-${index}`,
+    mediaType: `application/xhtml+xml`,
+    ...overrides,
+    index,
+  }))
+}
+
 export const createTestManifest = (
   manifest: Partial<Manifest> = {},
 ): Manifest => ({

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "start": "vite build --watch --mode development",
     "build": "vite build",
+    "tsc": "tsc --noEmit -p tsconfig.rn.json && tsc --noEmit -p tsconfig.web.json",
     "test": "vitest run --coverage"
   },
   "devDependencies": {

--- a/packages/react-native/src/native/createArchiveFromExpoFileSystemNext.ts
+++ b/packages/react-native/src/native/createArchiveFromExpoFileSystemNext.ts
@@ -4,7 +4,7 @@ import {
   createArchive,
 } from "@prose-reader/archive-reader"
 import { getUriBasename, sortByTitleComparator } from "@prose-reader/shared"
-import { Directory, type File } from "expo-file-system/next"
+import { Directory, type File } from "expo-file-system"
 
 export const createArchiveFromExpoFileSystemNext = async (
   directory: Directory,

--- a/packages/react-reader/src/common/Spine.tsx
+++ b/packages/react-reader/src/common/Spine.tsx
@@ -10,10 +10,7 @@ export const Spine = memo(({ children }: { children: React.ReactNode }) => {
     () => reader?.spine.element$,
     [reader],
   )
-  const { data: spineItems } = useObserve(
-    () => reader?.spine.spineItemsManager.items$,
-    [reader],
-  )
+  const spineItems = reader?.spineItemsManager.items
 
   if (!spineElement) return null
 

--- a/packages/react-reader/src/gallery/GalleryDialog.tsx
+++ b/packages/react-reader/src/gallery/GalleryDialog.tsx
@@ -66,10 +66,7 @@ const GalleryItem = memo(
 export const GalleryDialog = memo(
   ({ open, setOpen }: { open: boolean; setOpen: (open: boolean) => void }) => {
     const reader = useReader()
-    const { data: items } = useObserve(
-      () => reader?.spineItemsManager.items$,
-      [reader],
-    )
+    const items = reader?.spineItemsManager.items
 
     return (
       <AppDialog

--- a/packages/react-reader/src/navigation/SpreadRotationHint.tsx
+++ b/packages/react-reader/src/navigation/SpreadRotationHint.tsx
@@ -124,11 +124,11 @@ const observeBeginSpineItem = ({
   pagination$: Observable<HintPagination>
   reader: ReaderWithSpreadHintStreams
 }) =>
-  combineLatest([pagination$, reader.spineItemsManager.items$]).pipe(
-    map(([{ beginSpineItemIndex }, spineItems]) =>
+  pagination$.pipe(
+    map(({ beginSpineItemIndex }) =>
       beginSpineItemIndex === undefined
         ? undefined
-        : spineItems[beginSpineItemIndex],
+        : reader.spineItemsManager.items[beginSpineItemIndex],
     ),
     distinctUntilChanged(),
     switchMap((spineItem) =>

--- a/prose-react-native-demo/components/constants.ts
+++ b/prose-react-native-demo/components/constants.ts
@@ -1,4 +1,4 @@
-import { Directory, Paths } from "expo-file-system/next"
+import { Directory, Paths } from "expo-file-system"
 
 export const epubsDestination = new Directory(Paths.cache, "epubs")
 export const epubsDownloadsDestination = new Directory(

--- a/prose-react-native-demo/components/reader/Reader.tsx
+++ b/prose-react-native-demo/components/reader/Reader.tsx
@@ -1,5 +1,5 @@
 import { ReaderProvider, useCreateReader } from "@prose-reader/react-native"
-import type { Directory } from "expo-file-system/next"
+import type { Directory } from "expo-file-system"
 import { useEffect, useState } from "react"
 import { StyleSheet, View } from "react-native"
 import { BottomMenu } from "./BottomMenu"

--- a/prose-react-native-demo/components/reader/Streamer.ts
+++ b/prose-react-native-demo/components/reader/Streamer.ts
@@ -1,8 +1,8 @@
 import {
-  ReactNativeStreamer,
   createArchiveFromExpoFileSystemNext,
+  ReactNativeStreamer,
 } from "@prose-reader/react-native"
-import { Directory } from "expo-file-system/next"
+import { Directory } from "expo-file-system"
 import { unzippedDestination } from "../constants"
 
 export const streamer = new ReactNativeStreamer({

--- a/prose-react-native-demo/components/useDownloadFile.ts
+++ b/prose-react-native-demo/components/useDownloadFile.ts
@@ -1,4 +1,4 @@
-import { File } from "expo-file-system/next"
+import { File } from "expo-file-system"
 import { useEffect, useState } from "react"
 import { epubsDownloadsDestination } from "./constants"
 

--- a/prose-react-native-demo/components/useUnzipFile.ts
+++ b/prose-react-native-demo/components/useUnzipFile.ts
@@ -1,4 +1,4 @@
-import { Directory, type File } from "expo-file-system/next"
+import { Directory, type File } from "expo-file-system"
 import { useEffect, useState } from "react"
 import { unzip } from "react-native-zip-archive"
 import { unzippedDestination } from "./constants"

--- a/prose-react-native-demo/package-lock.json
+++ b/prose-react-native-demo/package-lock.json
@@ -23,7 +23,7 @@
         "expo-build-properties": "~0.14.6",
         "expo-constants": "~17.1.6",
         "expo-dev-client": "~5.1.8",
-        "expo-file-system": "~18.1.10",
+        "expo-file-system": "^56.0.7",
         "expo-font": "~13.3.1",
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.1.7",
@@ -44,31 +44,32 @@
         "react-native-web": "~0.20.0",
         "react-native-webview": "13.13.5",
         "react-native-zip-archive": "^7.0.1",
-         "reactjrx": "^1.126.0",
+        "reactjrx": "^1.126.0",
         "rxjs": "^7.8.2",
         "xmldoc": "^2.0.1"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
-        "@types/react": "~19.0.10",
+        "@types/react": "~19.2.0",
         "concurrently": "^9.0.1",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~9.2.0",
-        "typescript": "~5.8.3",
-        "vite": "^6.2.0",
-        "vite-plugin-singlefile": "^2.1.0"
+        "typescript": "*",
+        "vite": "^8",
+        "vite-plugin-singlefile": "^2.3.3"
       }
     },
     "../packages/core": {
       "name": "@prose-reader/core",
-      "version": "1.217.0",
+      "version": "1.324.0",
       "license": "MIT",
       "dependencies": {
-        "@prose-reader/cfi": "^1.217.0",
-        "@prose-reader/shared": "^1.217.0"
+        "@prose-reader/cfi": "^1.324.0",
+        "@prose-reader/shared": "^1.324.0"
       },
       "devDependencies": {
-        "happy-dom": "*"
+        "happy-dom": "*",
+        "sass-embedded": "^1.90.0"
       },
       "peerDependencies": {
         "rxjs": "*"
@@ -76,41 +77,38 @@
     },
     "../packages/react-native": {
       "name": "@prose-reader/react-native",
-      "version": "1.215.0",
+      "version": "1.324.0",
       "license": "MIT",
       "devDependencies": {
         "@webview-bridge/react-native": "^1.7.7"
       },
       "peerDependencies": {
+        "@prose-reader/archive-reader": "^1.320.0",
         "@prose-reader/core": "^1.215.0",
-        "@prose-reader/shared": "^1.215.0",
+        "@prose-reader/shared": "^1.320.0",
         "@prose-reader/streamer": "^1.215.0",
         "@webview-bridge/react-native": "^1.7.7",
         "@webview-bridge/web": "^1.7.7",
-        "expo-file-system": "^18.1.10",
+        "expo-file-system": "^56.0.7",
         "react": "19.x",
         "rxjs": "*"
       }
     },
     "../packages/shared": {
       "name": "@prose-reader/shared",
-      "version": "1.217.0",
+      "version": "1.324.0",
       "license": "MIT"
     },
     "../packages/streamer": {
       "name": "@prose-reader/streamer",
-      "version": "1.217.0",
+      "version": "1.324.0",
       "license": "MIT",
       "dependencies": {
-        "@prose-reader/shared": "^1.217.0",
+        "@prose-reader/archive-reader": "^1.324.0",
+        "@prose-reader/shared": "^1.324.0",
         "xmldoc": "^2.0.0"
       },
-      "devDependencies": {
-        "buffer": "^6.0.3",
-        "isomorphic-fetch": "^3.0.0"
-      },
       "peerDependencies": {
-        "buffer": "^6.0.3",
         "rxjs": "*"
       }
     },
@@ -1604,21 +1602,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
-      "integrity": "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.0.2",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
-      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1627,439 +1625,14 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz",
-      "integrity": "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3209,6 +2782,16 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3644,24 +3227,10 @@
         "nanoid": "^3.3.11"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.41.1.tgz",
-      "integrity": "sha512-NELNvyEWZ6R9QMkiytB4/L4zSEaBC03KIXEghptLGLZWJ6VPrL63ooZQCOnlx36aQPGhzuOMwDerC1Eb2VmrLw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.41.1.tgz",
-      "integrity": "sha512-DXdQe1BJ6TK47ukAoZLehRHhfKnKg9BjnQYUu9gzhI8Mwa1d2fzxA1aw2JixHVl403bwp1+/o/NhhHtxWJBgEA==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
@@ -3670,12 +3239,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.41.1.tgz",
-      "integrity": "sha512-5afxvwszzdulsU2w8JKWwY8/sJOLPzf0e1bFuvcW5h9zsEg+RQAojdW0ux2zyYAz7R8HvvzKCjLNJhVq965U7w==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
@@ -3684,12 +3256,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.41.1.tgz",
-      "integrity": "sha512-egpJACny8QOdHNNMZKf8xY0Is6gIMz+tuqXlusxquWu3F833DcMwmGM7WlvCO9sB3OsPjdC4U0wHw5FabzCGZg==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
@@ -3698,26 +3273,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.41.1.tgz",
-      "integrity": "sha512-DBVMZH5vbjgRk3r0OzgjS38z+atlupJ7xfKIDJdZZL6sM6wjfDNo64aowcLPKIx7LMQi8vybB56uh1Ftck/Atg==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.41.1.tgz",
-      "integrity": "sha512-3FkydeohozEskBxNWEIbPfOE0aqQgB6ttTkJ159uWOFn42VLyfAiyD9UK5mhu+ItWzft60DycIN1Xdgiy8o/SA==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
@@ -3726,12 +3290,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.41.1.tgz",
-      "integrity": "sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
@@ -3740,152 +3307,201 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.41.1.tgz",
-      "integrity": "sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.41.1.tgz",
-      "integrity": "sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.41.1.tgz",
-      "integrity": "sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.41.1.tgz",
-      "integrity": "sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==",
-      "cpu": [
-        "loong64"
+      "libc": [
+        "musl"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.41.1.tgz",
-      "integrity": "sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.41.1.tgz",
-      "integrity": "sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==",
-      "cpu": [
-        "riscv64"
+      "libc": [
+        "glibc"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.41.1.tgz",
-      "integrity": "sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==",
-      "cpu": [
-        "riscv64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.41.1.tgz",
-      "integrity": "sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.41.1.tgz",
-      "integrity": "sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
       ],
       "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
-        "linux"
-      ]
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.41.1.tgz",
-      "integrity": "sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
       "cpu": [
-        "x64"
+        "wasm32"
       ],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.41.1.tgz",
-      "integrity": "sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==",
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
@@ -3894,26 +3510,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.41.1.tgz",
-      "integrity": "sha512-+psFT9+pIh2iuGsxFYYa/LhS5MFKmuivRsx9iPJWNSGbh2XVEjk90fmpUEjCnILPEPJnikAU6SFDiEUyOv90Pg==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.41.1.tgz",
-      "integrity": "sha512-Wq2zpapRYLfi4aKxf2Xff0tN+7slj2d4R87WEzqw7ZLsVvO5zwYCIuEGSZYiK41+GlwUo1HiR+GdkLEJnCKTCw==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
@@ -3922,7 +3527,17 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -4104,13 +3719,13 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.0.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.14.tgz",
-      "integrity": "sha512-ixLZ7zG7j1fM0DijL9hDArwhwcCb4vqmePgwtV0GfnkHRSCUEv4LvzarcTdhoqgyMznUx/EhoTUv31CKZzkQlw==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -6081,9 +5696,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -6570,47 +6185,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.5",
-        "@esbuild/android-arm": "0.25.5",
-        "@esbuild/android-arm64": "0.25.5",
-        "@esbuild/android-x64": "0.25.5",
-        "@esbuild/darwin-arm64": "0.25.5",
-        "@esbuild/darwin-x64": "0.25.5",
-        "@esbuild/freebsd-arm64": "0.25.5",
-        "@esbuild/freebsd-x64": "0.25.5",
-        "@esbuild/linux-arm": "0.25.5",
-        "@esbuild/linux-arm64": "0.25.5",
-        "@esbuild/linux-ia32": "0.25.5",
-        "@esbuild/linux-loong64": "0.25.5",
-        "@esbuild/linux-mips64el": "0.25.5",
-        "@esbuild/linux-ppc64": "0.25.5",
-        "@esbuild/linux-riscv64": "0.25.5",
-        "@esbuild/linux-s390x": "0.25.5",
-        "@esbuild/linux-x64": "0.25.5",
-        "@esbuild/netbsd-arm64": "0.25.5",
-        "@esbuild/netbsd-x64": "0.25.5",
-        "@esbuild/openbsd-arm64": "0.25.5",
-        "@esbuild/openbsd-x64": "0.25.5",
-        "@esbuild/sunos-x64": "0.25.5",
-        "@esbuild/win32-arm64": "0.25.5",
-        "@esbuild/win32-ia32": "0.25.5",
-        "@esbuild/win32-x64": "0.25.5"
       }
     },
     "node_modules/escalade": {
@@ -7286,9 +6860,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "18.1.10",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.10.tgz",
-      "integrity": "sha512-SyaWg+HitScLuyEeSG9gMSDT0hIxbM9jiZjSBP9l9zMnwZjmQwsusE6+7qGiddxJzdOhTP4YGUfvEzeeS0YL3Q==",
+      "version": "56.0.8",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-56.0.8.tgz",
+      "integrity": "sha512-NrH41/8snGIBSbYicwVLB4txPdgCATd7ZYhMAGS3YJZ9GbnduhlAoV4/YCbGayjrbpE9bJb/6wegPL/zmvRMnQ==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -7535,6 +7109,16 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo/node_modules/expo-file-system": {
+      "version": "18.1.11",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.11.tgz",
+      "integrity": "sha512-HJw/m0nVOKeqeRjPjGdvm+zBi5/NxcdPf8M8P3G2JFvH5Z8vBWqVDic2O58jnT1OFEy0XXzoH9UqFu7cHg9DTQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/exponential-backoff": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
@@ -7656,11 +7240,14 @@
       }
     },
     "node_modules/fdir": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
-      "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -9349,6 +8936,27 @@
         "lightningcss-win32-x64-msvc": "1.27.0"
       }
     },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.27.0.tgz",
@@ -10221,9 +9829,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -11484,13 +11092,13 @@
       }
     },
     "node_modules/reactjrx": {
-      "version": "1.123.1",
-      "resolved": "https://registry.npmjs.org/reactjrx/-/reactjrx-1.123.1.tgz",
-      "integrity": "sha512-meqO7oOi/4rXyKPXPbIKz7M6NBKp5PJM5vYo6J+YZziEL7S/5O4Y0N4rHbiVdcxVOreT/us5zMPDfm9LT5RYkA==",
+      "version": "1.141.2",
+      "resolved": "https://registry.npmjs.org/reactjrx/-/reactjrx-1.141.2.tgz",
+      "integrity": "sha512-Ofth9DtpSdMET6HKJiU7GBI45R3e0INVxaWcXtKhEH25TdXHfKEsaLJBSxaPJpEmNaEaWFHKuoqEj9dYQVK0NA==",
       "peerDependencies": {
         "@tanstack/react-query": "5.x",
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19",
+        "react": "19.x",
+        "react-dom": "19.x",
         "rxjs": "*"
       }
     },
@@ -11770,44 +11378,38 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.41.1.tgz",
-      "integrity": "sha512-cPmwD3FnFv8rKMBc1MxWCwVQFxwf1JEmSX3iQXrRVVG15zerAIXRjMFVWnd5Q5QvgKF7Aj+5ykXFhUl+QGnyOw==",
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.7"
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.41.1",
-        "@rollup/rollup-android-arm64": "4.41.1",
-        "@rollup/rollup-darwin-arm64": "4.41.1",
-        "@rollup/rollup-darwin-x64": "4.41.1",
-        "@rollup/rollup-freebsd-arm64": "4.41.1",
-        "@rollup/rollup-freebsd-x64": "4.41.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.41.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.41.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.41.1",
-        "@rollup/rollup-linux-arm64-musl": "4.41.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.41.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.41.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.41.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.41.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.41.1",
-        "@rollup/rollup-linux-x64-gnu": "4.41.1",
-        "@rollup/rollup-linux-x64-musl": "4.41.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.41.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.41.1",
-        "@rollup/rollup-win32-x64-msvc": "4.41.1",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/run-parallel": {
@@ -13011,14 +12613,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -13028,9 +12630,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13505,24 +13107,23 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -13531,14 +13132,15 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -13547,13 +13149,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -13580,9 +13185,9 @@
       }
     },
     "node_modules/vite-plugin-singlefile": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-2.2.0.tgz",
-      "integrity": "sha512-Ik1wXmJaGzeQtUeIV7JprDUqqy6DlLzXAY27Blei5peE4c9VJF+Kp9xWDJeuX0RJUZmFbIAuw1/RAh06A+Ql7w==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-2.3.3.tgz",
+      "integrity": "sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13592,14 +13197,281 @@
         "node": ">18.0.0"
       },
       "peerDependencies": {
-        "rollup": "^4.35.0",
-        "vite": "^5.4.11 || ^6.0.0"
+        "rollup": "^4.59.0",
+        "vite": "^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13610,9 +13482,9 @@
       }
     },
     "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
-      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -13630,7 +13502,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/prose-react-native-demo/package.json
+++ b/prose-react-native-demo/package.json
@@ -9,6 +9,7 @@
     "android": "npm run web:build && expo run:android",
     "ios": "npm run web:build && expo run:ios",
     "lint": "expo lint",
+    "tsc": "tsc --noEmit",
     "web:dev": "vite web",
     "web:build": "tsc && vite build web",
     "web:preview": "vite preview web"
@@ -56,13 +57,13 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
-    "@types/react": "~19.0.10",
+    "@types/react": "~19.2.0",
     "concurrently": "^9.0.1",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
     "typescript": "*",
     "vite": "^8",
-    "vite-plugin-singlefile": "^2.1.0"
+    "vite-plugin-singlefile": "^2.3.3"
   },
   "private": true
 }

--- a/prose-react-native-demo/tsconfig.json
+++ b/prose-react-native-demo/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "strict": true,
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "expo-file-system": ["./node_modules/expo-file-system"],
+      "expo-file-system/*": ["./node_modules/expo-file-system/*"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]


### PR DESCRIPTION
…), items$ removed

The spine item list is immutable manifest-derived data since one reader maps to one book, so SpineItemsManager now builds a plain readonly array at construction instead of exposing a BehaviorSubject. items$, addMany and destroyItems are gone; per-item observables stay reactive.

- SpineItem: constructor is DOM-light (container from global document, no append, no hook); new attach(parentElement) runs the item.onBeforeContainerAttach hook then appends, preserving hook registration between createReader() and mount()
- SpineItemsObserver: streams are eager merges over the static list
- SpineItemsLoader: gated on mount — items now exist pre-mount and must not load into detached containers (pinned by tests)
- enhancers + react-reader read items directly instead of items$
- getRenderer factories now run at createReader() instead of mount