### PR TITLE
feat!: reader creates its DOM in an explicit document (ownerDocument)

### DIFF
--- a/gitbook/get-started/getting-started.md
+++ b/gitbook/get-started/getting-started.md
@@ -160,6 +160,10 @@ async function run() {
   /**
    * Finally we can mount the reader into the DOM. This is a one-shot
    * operation: the reader starts rendering the book into the container.
+   *
+   * The container must belong to the reader's document. By default that is
+   * the ambient `document`; to render inside a foreign document (eg: an
+   * iframe's `contentDocument`) pass it as `ownerDocument` to `createReader`.
    */
   reader.mount(document.getElementById(`app`)!)
 }

--- a/packages/core/src/cfi/resolve.ts
+++ b/packages/core/src/cfi/resolve.ts
@@ -2,6 +2,7 @@ import { resolve } from "@prose-reader/cfi"
 import { Report } from "../report"
 import type { SpineItemsManager } from "../spine/SpineItemsManager"
 import type { SpineItem } from "../spineItem/SpineItem"
+import { isHtmlTagElement } from "../utils/dom"
 import { parseCfi } from "./parse"
 
 /**
@@ -38,7 +39,7 @@ export const resolveCfi = ({
 
   const rendererElement = spineItem.renderer.getDocumentFrame()
 
-  if (rendererElement instanceof HTMLIFrameElement) {
+  if (isHtmlTagElement(rendererElement, "iframe")) {
     const doc = rendererElement.contentWindow?.document
 
     if (doc) {

--- a/packages/core/src/context/Context.ts
+++ b/packages/core/src/context/Context.ts
@@ -14,12 +14,25 @@ export type ContextState = {
 export class Context extends ReactiveEntity<ContextState> {
   public bridgeEvent = new BridgeEvent()
 
-  constructor(manifest: Manifest) {
+  /**
+   * The document the reader creates all of its DOM in. This is the single
+   * source of truth for DOM creation so the reader can be rendered inside a
+   * foreign document (eg: an iframe's `contentDocument`). Defaults to the
+   * ambient document; the container passed to `mount` must belong to it.
+   */
+  public readonly document: Document
+
+  constructor(
+    manifest: Manifest,
+    ownerDocument: Document = globalThis.document,
+  ) {
     super({
       manifest,
       assumedRenditionLayout: manifest.renditionLayout ?? "reflowable",
       isFullyPrePaginated: isFullyPrePaginated(manifest),
     })
+
+    this.document = ownerDocument
   }
 
   /**

--- a/packages/core/src/enhancers/accessibility.ts
+++ b/packages/core/src/enhancers/accessibility.ts
@@ -12,7 +12,11 @@ export const accessibilityEnhancer =
   (options: InheritOptions): InheritOutput => {
     const reader = next(options)
 
-    const observer = new IntersectionObserver((entries) => {
+    const IntersectionObserverCtor =
+      reader.context.document.defaultView?.IntersectionObserver ??
+      IntersectionObserver
+
+    const observer = new IntersectionObserverCtor((entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           removeAttributeIfPresent(entry.target, `tab-index`)

--- a/packages/core/src/enhancers/events/normalizeEventForViewport.ts
+++ b/packages/core/src/enhancers/events/normalizeEventForViewport.ts
@@ -1,5 +1,10 @@
 import type { SpineLocator } from "../../spine/locator/SpineLocator"
-import { isMouseEvent, isPointerEvent, isTouchEvent } from "../../utils/dom"
+import {
+  isHtmlTagElement,
+  isMouseEvent,
+  isPointerEvent,
+  isTouchEvent,
+} from "../../utils/dom"
 import type { Viewport } from "../../viewport/Viewport"
 import { translateFramePositionIntoPage } from "./translateFramePositionIntoPage"
 
@@ -19,7 +24,7 @@ export const normalizeEventForViewport = <
   const frameElement = originalFrame
   const { height: pageHeight, width: pageWidth } = viewport.pageSize
 
-  if (!spineItem || !(frameElement instanceof HTMLIFrameElement)) return event
+  if (!spineItem || !isHtmlTagElement(frameElement, "iframe")) return event
 
   if (isPointerEvent(event)) {
     const { clientX, clientY } = translateFramePositionIntoPage({

--- a/packages/core/src/enhancers/hotkeys.ts
+++ b/packages/core/src/enhancers/hotkeys.ts
@@ -1,5 +1,6 @@
 import type { KeyboardEvent } from "react"
 import { EMPTY, fromEvent, map, merge, switchMap, takeUntil } from "rxjs"
+import { isHtmlTagElement } from "../utils/dom"
 import type { NavigationEnhancerOutput } from "./navigation/types"
 import type {
   EnhancerOptions,
@@ -52,7 +53,9 @@ export const hotkeysEnhancer =
         }),
       )
 
-    navigateOnKey(document).pipe(takeUntil(reader.$.destroy$)).subscribe()
+    navigateOnKey(reader.context.document)
+      .pipe(takeUntil(reader.$.destroy$))
+      .subscribe()
 
     merge(
       ...reader.spineItemsManager.items.map((item) =>
@@ -60,8 +63,8 @@ export const hotkeysEnhancer =
           switchMap(() => {
             const element = item.renderer.getDocumentFrame()
 
-            return element instanceof HTMLIFrameElement &&
-              element?.contentDocument
+            return isHtmlTagElement(element, "iframe") &&
+              element.contentDocument
               ? navigateOnKey(element.contentDocument)
               : EMPTY
           }),

--- a/packages/core/src/enhancers/html/renderer/HtmlRenderer.ts
+++ b/packages/core/src/enhancers/html/renderer/HtmlRenderer.ts
@@ -1,7 +1,7 @@
 import { detectMimeTypeFromName } from "@prose-reader/shared"
 import { from, map, of, switchMap, tap } from "rxjs"
 import { DocumentRenderer } from "../../../spineItem/renderer/DocumentRenderer"
-import { setAttributeIfChanged } from "../../../utils/dom"
+import { isHtmlTagElement, setAttributeIfChanged } from "../../../utils/dom"
 import {
   upsertCSSToFrame,
   waitForFrameLoad,
@@ -217,7 +217,7 @@ export class HtmlRenderer extends DocumentRenderer {
   private getFrameElement() {
     const frame = this.documentContainer
 
-    if (!(frame instanceof HTMLIFrameElement)) return
+    if (!isHtmlTagElement(frame, "iframe")) return
 
     return frame
   }

--- a/packages/core/src/enhancers/html/renderer/HtmlRenderer.ts
+++ b/packages/core/src/enhancers/html/renderer/HtmlRenderer.ts
@@ -18,7 +18,7 @@ import { renderReflowable } from "./reflowable/renderReflowable"
 
 export class HtmlRenderer extends DocumentRenderer {
   onCreateDocument() {
-    const frameElement = createFrameElement()
+    const frameElement = createFrameElement(this.context.document)
 
     this.setDocumentContainer(frameElement)
 

--- a/packages/core/src/enhancers/html/renderer/createFrameElement.ts
+++ b/packages/core/src/enhancers/html/renderer/createFrameElement.ts
@@ -1,7 +1,8 @@
-export const createFrameElement = () => {
-  // we force undefined because otherwise the load method will believe it's defined after this call but the code is async and
-  // the iframe could be undefined later
-  const frame = document.createElement(`iframe`)
+export const createFrameElement = (ownerDocument: Document) => {
+  // The iframe must be created directly in the mount document. Creating it in
+  // another document and then adopting it (via appendChild) reloads the frame,
+  // so the caller passes the document the frame will live in.
+  const frame = ownerDocument.createElement(`iframe`)
   frame.frameBorder = `no`
   frame.tabIndex = 0
   frame.setAttribute(

--- a/packages/core/src/enhancers/layout/createPlaceholderPages.ts
+++ b/packages/core/src/enhancers/layout/createPlaceholderPages.ts
@@ -4,6 +4,7 @@ import { tap } from "rxjs/operators"
 import { HTML_PREFIX as HTML_PREFIX_CORE } from "../../constants"
 import type { Reader } from "../../reader"
 import {
+  isHtmlElement,
   setPropertyIfChanged,
   setStylePropertyIfChanged,
 } from "../../utils/dom"
@@ -100,7 +101,7 @@ export const createPlaceholderPages = (
       const detailsElement = loadingElementContainer.querySelector(
         `[data-details-element]`,
       )
-      if (detailsElement instanceof HTMLElement) {
+      if (isHtmlElement(detailsElement)) {
         setPropertyIfChanged(
           detailsElement,
           `innerText`,

--- a/packages/core/src/enhancers/layout/fixReflowable.ts
+++ b/packages/core/src/enhancers/layout/fixReflowable.ts
@@ -1,5 +1,5 @@
 import type { Reader } from "../../reader"
-import { setStylePropertyIfChanged } from "../../utils/dom"
+import { isHtmlTagElement, setStylePropertyIfChanged } from "../../utils/dom"
 import { getFrameViewportInfo } from "../../utils/frames"
 
 export const fixReflowable = (reader: Reader) => {
@@ -33,7 +33,7 @@ export const fixReflowable = (reader: Reader) => {
 
       if (
         !(spineItem?.renditionLayout === `reflowable`) ||
-        !(element instanceof HTMLIFrameElement)
+        !isHtmlTagElement(element, "iframe")
       )
         return
 
@@ -48,7 +48,7 @@ export const fixReflowable = (reader: Reader) => {
         if (
           noBlankPageAsked &&
           spineManagerWantAFullWidthItem &&
-          frameElement instanceof HTMLIFrameElement
+          isHtmlTagElement(frameElement, "iframe")
         ) {
           setStylePropertyIfChanged(
             frameElement.style,

--- a/packages/core/src/enhancers/media/media.ts
+++ b/packages/core/src/enhancers/media/media.ts
@@ -14,7 +14,11 @@ export const mediaEnhancer =
   (options: InheritOptions): InheritOutput => {
     const reader = next(options)
 
-    const frameObserver = new IntersectionObserver(
+    const IntersectionObserverCtor =
+      reader.context.document.defaultView?.IntersectionObserver ??
+      IntersectionObserver
+
+    const frameObserver = new IntersectionObserverCtor(
       (entries) => {
         entries.forEach((entry) => {
           const frame = entry.target as HTMLIFrameElement
@@ -45,7 +49,7 @@ export const mediaEnhancer =
       },
     )
 
-    const elementObserver = new IntersectionObserver(
+    const elementObserver = new IntersectionObserverCtor(
       (entries) => {
         entries.forEach((entry) => {
           if (entry.target.tagName === `video`) {

--- a/packages/core/src/navigation/controllers/ControlledNavigationController.ts
+++ b/packages/core/src/navigation/controllers/ControlledNavigationController.ts
@@ -298,8 +298,9 @@ export class ControlledNavigationController
   public get viewportPosition(): SpinePosition {
     const element = this.element$.getValue()
 
-    const computedStyle = window.getComputedStyle(element)
-    const transform = computedStyle.transform || computedStyle.webkitTransform
+    const computedStyle =
+      element.ownerDocument.defaultView?.getComputedStyle(element)
+    const transform = computedStyle?.transform || computedStyle?.webkitTransform
 
     if (!transform || transform === "none") {
       return new SpinePosition({ x: 0, y: 0 })

--- a/packages/core/src/navigation/controllers/ControlledNavigationController.ts
+++ b/packages/core/src/navigation/controllers/ControlledNavigationController.ts
@@ -53,9 +53,7 @@ export class ControlledNavigationController
 {
   protected navigateSubject = new Subject<ControlledNavigationEntry>()
 
-  public readonly element$ = new BehaviorSubject<HTMLElement>(
-    document.createElement(`div`),
-  )
+  public readonly element$: BehaviorSubject<HTMLElement>
   public isNavigating$: Observable<boolean>
   public layout$: Observable<unknown>
 
@@ -67,6 +65,10 @@ export class ControlledNavigationController
     protected viewport: Viewport,
   ) {
     super()
+
+    this.element$ = new BehaviorSubject<HTMLElement>(
+      context.document.createElement(`div`),
+    )
 
     const elementInit$ = this.spine.element$.pipe(
       filter(isDefined),

--- a/packages/core/src/navigation/controllers/ScrollNavigationController.ts
+++ b/packages/core/src/navigation/controllers/ScrollNavigationController.ts
@@ -71,7 +71,7 @@ export class ScrollNavigationController
       tap(({ rootElement }) => {
         if (!rootElement) return
 
-        const element = document.createElement(`div`)
+        const element = this.context.document.createElement(`div`)
         element.setAttribute(`data-${HTML_PREFIX_SCROLL_NAVIGATOR}`, "")
         element.appendChild(this.viewport.value.element)
         rootElement.appendChild(element)

--- a/packages/core/src/navigation/resolvers/getNavigationForUrl.ts
+++ b/packages/core/src/navigation/resolvers/getNavigationForUrl.ts
@@ -5,13 +5,14 @@ import type { SpineItemsManager } from "../../spine/SpineItemsManager"
 import type { SpinePosition } from "../../spine/types"
 import type { SpineItem } from "../../spineItem/SpineItem"
 import { SpineItemPosition } from "../../spineItem/types"
+import { isHtmlTagElement } from "../../utils/dom"
 import { getAdjustedPositionForSpread } from "./getAdjustedPositionForSpread"
 
 const getNodeFromSelector = (
   selector: string,
   frameElement?: HTMLIFrameElement,
 ) => {
-  if (frameElement && frameElement instanceof HTMLIFrameElement) {
+  if (isHtmlTagElement(frameElement, "iframe")) {
     const contentDocument = frameElement.contentDocument
     const normalizedSelector = selector.trim()
 

--- a/packages/core/src/reader.test.ts
+++ b/packages/core/src/reader.test.ts
@@ -15,6 +15,7 @@ import {
   HTML_ATTRIBUTE_DATA_READER_ID,
   HTML_PREFIX,
   HTML_PREFIX_SCROLL_NAVIGATOR,
+  HTML_STYLE_PREFIX,
 } from "./constants"
 import { createReader } from "./reader"
 import { waitFor } from "./tests/utils"
@@ -160,5 +161,53 @@ describe("Given a mounted reader", () => {
 
       second.destroy()
     })
+  })
+})
+
+describe("Given a reader mounted into a foreign document", () => {
+  it("builds its subtree and stylesheet in the mount document, not the global one", () => {
+    const foreignDocument = document.implementation.createHTMLDocument()
+    const foreignContainer = foreignDocument.createElement("div")
+    foreignDocument.body.appendChild(foreignContainer)
+
+    const reader = createReader({
+      getResource: () => of(new Response("", { status: 200 })),
+      manifest: MANIFEST,
+      ownerDocument: foreignDocument,
+    })
+    const stylesId = `${HTML_STYLE_PREFIX}-core-${reader.id}`
+
+    reader.mount(foreignContainer)
+
+    // the stylesheet is injected into the mount document only
+    expect(foreignDocument.getElementById(stylesId)).not.toBeNull()
+    expect(document.getElementById(stylesId)).toBeNull()
+
+    // the whole reader-owned subtree lives in the mount document
+    const scrollNavigator = foreignContainer.querySelector(
+      `[data-${HTML_PREFIX_SCROLL_NAVIGATOR}]`,
+    )
+    expect(scrollNavigator?.ownerDocument).toBe(foreignDocument)
+    expect(reader.viewport.value.element.ownerDocument).toBe(foreignDocument)
+    expect(reader.spine.element?.ownerDocument).toBe(foreignDocument)
+    expect(reader.spineItemsManager.items[0]?.element.ownerDocument).toBe(
+      foreignDocument,
+    )
+
+    reader.destroy()
+
+    // and it is removed from the mount document on destroy
+    expect(foreignDocument.getElementById(stylesId)).toBeNull()
+  })
+
+  it("throws when the container does not belong to the reader's document", () => {
+    const foreignDocument = document.implementation.createHTMLDocument()
+    const reader = createTestReader()
+
+    expect(() =>
+      reader.mount(foreignDocument.createElement("div")),
+    ).toThrowError(/must belong to the reader's document/)
+
+    reader.destroy()
   })
 })

--- a/packages/core/src/reader.ts
+++ b/packages/core/src/reader.ts
@@ -37,6 +37,13 @@ export type CreateReaderOptions = Partial<CoreInputSettings> & {
    * once mounted. This is handled by the navigation enhancer.
    */
   cfi?: string
+  /**
+   * The document the reader creates all of its DOM in. Defaults to the ambient
+   * `globalThis.document`. Provide a foreign document (eg: an iframe's
+   * `contentDocument`) to render the reader inside it; the container passed to
+   * `mount` must belong to this document.
+   */
+  ownerDocument?: Document
 }
 
 export type CreateReaderParameters = CreateReaderOptions
@@ -53,6 +60,7 @@ export const createReader = ({
   manifest,
   // handled by the navigation enhancer, extracted so it does not leak into settings
   cfi: _cfi,
+  ownerDocument = globalThis.document,
   ...inputSettings
 }: CreateReaderOptions) => {
   const id = crypto.randomUUID()
@@ -64,7 +72,7 @@ export const createReader = ({
   const layoutSubject = new Subject<ReaderLayoutOptions>()
   const destroy$ = new Subject<void>()
   const hookManager = new HookManager()
-  const context = new Context(manifest)
+  const context = new Context(manifest, ownerDocument)
   const settingsManager = new ReaderSettingsManager(inputSettings, context)
   const features = new Features(context, settingsManager)
   const viewport = new Viewport(context, settingsManager)
@@ -133,9 +141,15 @@ export const createReader = ({
       )
     }
 
+    if (containerElement.ownerDocument !== context.document) {
+      throw new Error(
+        `The container element must belong to the reader's document. Pass \`ownerDocument\` to \`createReader\` when mounting into a foreign document (eg: an iframe's contentDocument).`,
+      )
+    }
+
     Report.log(`mount`, { containerElement })
 
-    injectCSS(document, stylesId, styles)
+    injectCSS(context.document, stylesId, styles)
 
     const element = wrapContainer(containerElement, id)
 
@@ -179,9 +193,9 @@ export const createReader = ({
   const destroy = () => {
     const containerElement = context.value.rootElement
 
-    removeCSS(document, stylesId)
-
+    // The stylesheet is only injected at mount, so only remove it if mounted.
     if (containerElement) {
+      removeCSS(context.document, stylesId)
       unwrapContainer(containerElement)
     }
 

--- a/packages/core/src/spine/Spine.ts
+++ b/packages/core/src/spine/Spine.ts
@@ -77,9 +77,8 @@ export class Spine extends DestroyableClass {
 
     const spineElementUpdate$ = context.watch(`rootElement`).pipe(
       filter(isDefined),
-      tap((rootElement) => {
-        const element: HTMLElement =
-          rootElement.ownerDocument.createElement(`div`)
+      tap(() => {
+        const element: HTMLElement = this.context.document.createElement(`div`)
         element.style.cssText = `
           height: 100%;
           position: relative;

--- a/packages/core/src/spine/SpineItemsManager.test.ts
+++ b/packages/core/src/spine/SpineItemsManager.test.ts
@@ -9,11 +9,12 @@ import {
 import { Viewport } from "../viewport/Viewport"
 import { SpineItemsManager } from "./SpineItemsManager"
 
-const createManager = (numberOfItems: number) => {
+const createManager = (numberOfItems: number, ownerDocument?: Document) => {
   const context = new Context(
     createTestManifest({
       spineItems: createTestManifestSpineItems(numberOfItems),
     }),
+    ownerDocument,
   )
   const settings = new ReaderSettingsManager({}, context)
   const hookManager = new HookManager()
@@ -94,6 +95,27 @@ describe("attach", () => {
 
     expect(hookCalls).toEqual([{ id: "item-0", parentAtHookTime: null }])
     expect(spineItemsManager.items[0]?.element.parentElement).toBe(parent)
+  })
+
+  it("builds the container in the reader's document so hooks see it immediately", () => {
+    const foreignDocument = document.implementation.createHTMLDocument()
+    const { spineItemsManager, hookManager } = createManager(1, foreignDocument)
+    const parent = foreignDocument.createElement("div")
+    const ownerDocumentsAtHookTime: Document[] = []
+
+    hookManager.register("item.onBeforeContainerAttach", ({ element }) => {
+      ownerDocumentsAtHookTime.push(element.ownerDocument)
+    })
+
+    const item = spineItemsManager.items[0]
+
+    // the container is born in the reader's document, before any attach
+    expect(item?.element.ownerDocument).toBe(foreignDocument)
+
+    item?.attach(parent)
+
+    expect(ownerDocumentsAtHookTime).toEqual([foreignDocument])
+    expect(item?.element.parentElement).toBe(parent)
   })
 })
 

--- a/packages/core/src/spineItem/SpineItem.ts
+++ b/packages/core/src/spineItem/SpineItem.ts
@@ -62,7 +62,7 @@ export class SpineItem extends ReactiveEntity<SpineItemState> {
       error: undefined,
     })
 
-    this.containerElement = createContainerElement(item)
+    this.containerElement = createContainerElement(item, context.document)
 
     const rendererFactory = this.settings.values.getRenderer?.(item)
 
@@ -129,8 +129,9 @@ export class SpineItem extends ReactiveEntity<SpineItemState> {
   /**
    * Attach the item container to the spine element. Deferred from construction
    * so that `item.onBeforeContainerAttach` hooks registered between
-   * `createReader()` and `mount()` are honored. `appendChild` adopts the
-   * container into the parent's document when mounting into another document.
+   * `createReader()` and `mount()` are honored. The container is built in the
+   * reader's document (see `context.document`), so it already belongs to the
+   * mount document when the hook runs.
    */
   attach = (parentElement: HTMLElement) => {
     this.hookManager.execute(`item.onBeforeContainerAttach`, {
@@ -233,8 +234,11 @@ export class SpineItem extends ReactiveEntity<SpineItemState> {
   }
 }
 
-const createContainerElement = (item: Manifest[`spineItems`][number]) => {
-  const element: HTMLElement = document.createElement(`div`)
+const createContainerElement = (
+  item: Manifest[`spineItems`][number],
+  ownerDocument: Document,
+) => {
+  const element: HTMLElement = ownerDocument.createElement(`div`)
   element.setAttribute(`data-${HTML_PREFIX_SPINE_ITEM}`, "")
   element.classList.add(`spineItem`)
   element.classList.add(`spineItem-${item.renditionLayout ?? "reflowable"}`)

--- a/packages/core/src/spineItem/renderer/DefaultRenderer.ts
+++ b/packages/core/src/spineItem/renderer/DefaultRenderer.ts
@@ -5,7 +5,7 @@ export class DefaultRenderer extends DocumentRenderer {
   onUnload() {}
 
   onCreateDocument() {
-    return of(document.createElement("div"))
+    return of(this.context.document.createElement("div"))
   }
 
   onLoadDocument() {

--- a/packages/core/src/utils/rxjs.ts
+++ b/packages/core/src/utils/rxjs.ts
@@ -19,7 +19,11 @@ export function observeResize(
   element: HTMLElement,
 ): Observable<ResizeObserverEntry[]> {
   return new Observable<ResizeObserverEntry[]>((observer) => {
-    const resizeObserver = new ResizeObserver((entries) => {
+    // Use the observed element's own realm so observation is correct even
+    // when the reader is mounted into a foreign document.
+    const Ctor =
+      element.ownerDocument.defaultView?.ResizeObserver ?? ResizeObserver
+    const resizeObserver = new Ctor((entries) => {
       observer.next(entries)
     })
 
@@ -91,7 +95,9 @@ export const observeMutation = (
   options?: MutationObserverInit,
 ) => {
   return new Observable<MutationRecord[]>((subscriber) => {
-    const observer = new MutationObserver((mutations) => {
+    const Ctor =
+      target.ownerDocument?.defaultView?.MutationObserver ?? MutationObserver
+    const observer = new Ctor((mutations) => {
       subscriber.next(mutations)
     })
 
@@ -106,7 +112,10 @@ export function observeIntersection(
   options?: IntersectionObserverInit,
 ): Observable<IntersectionObserverEntry[]> {
   return new Observable<IntersectionObserverEntry[]>((observer) => {
-    const intersectionObserver = new IntersectionObserver((entries) => {
+    const Ctor =
+      element.ownerDocument.defaultView?.IntersectionObserver ??
+      IntersectionObserver
+    const intersectionObserver = new Ctor((entries) => {
       observer.next(entries)
     }, options)
 

--- a/packages/core/src/viewport/Viewport.ts
+++ b/packages/core/src/viewport/Viewport.ts
@@ -42,7 +42,7 @@ export class Viewport extends ReactiveEntity<State> {
     protected context: Context,
     protected settingsManager: ReaderSettingsManager,
   ) {
-    const element = document.createElement("div")
+    const element = context.document.createElement("div")
 
     element.setAttribute(`data-${HTML_PREFIX_VIEWPORT}`, "")
 


### PR DESCRIPTION
## Summary

Removes the global-`document` assumption from the core reader so it can render into a **foreign document** (eg: an iframe's `contentDocument`). Previously the reader created DOM in the ambient `document` at `createReader()` time and relied on `appendChild` adoption at mount — which silently **reloads iframes** and gives `onBeforeContainerAttach` hooks the wrong `ownerDocument`.

The reader is now bound to one explicit document, established at construction:

- `Context` exposes a readonly `document` — the single source of truth for DOM creation (defaults to `globalThis.document`).
- `createReader({ ..., ownerDocument })` sets it.
- Every element (viewport, spine item containers, controlled/scroll nav, spine element, renderer documents, content iframe) is **born** in `context.document` — nothing is created in one document and migrated to another (no `adoptNode`, no iframe reload).
- `mount()` validates that the container belongs to the reader's document.

## Why this approach

Two alternatives were considered and rejected:

- **Defer DOM creation to mount** — would force `item.renderer`, `containerElement`, and `viewport.element` to become optional across ~25 enhancer/consumer sites, and `item.renderer` must exist eagerly (read by ~15 enhancers + `reader.renderHeadless`, used by enhancer-search).
- **Adopt elements into the mount document at mount** (`adoptNode`) — works, but leaves the design smell (born in the wrong realm, migrated later). Declaring the document up front removes the root cause.

## Breaking change

`mount()` now throws if the container element does not belong to the reader's document. Pass `ownerDocument` to `createReader` for foreign-document mounts. The common case — `createReader({ manifest })` + `mount(el)` where `el` is in the ambient document — is unchanged.

## Tests

- `SpineItemsManager.test.ts`: the container is born in the reader's document; `onBeforeContainerAttach` sees it.
- `reader.test.ts`: full mount into a foreign document via `ownerDocument` (subtree + stylesheet land there, not in the global document, removed on destroy); `mount` throws on a document mismatch.
- Full `packages/core` unit suite (186), monorepo build (17 projects), and Playwright e2e suite all pass.

## Docs

- `gitbook/get-started/getting-started.md`: the mount step now notes the container-realm requirement and the `ownerDocument` escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
