### PR TITLE
refactor(core): dedupe turn direction navigation in ManualNavigator

### DIFF
--- a/packages/core/src/enhancers/navigation/navigators/manualNavigator.ts
+++ b/packages/core/src/enhancers/navigation/navigators/manualNavigator.ts
@@ -29,13 +29,17 @@ export class ManualNavigator {
     return this.turnRightOrBottom()
   }
 
-  turnRightOrBottom() {
+  protected turnWith(
+    getNavigationForPage:
+      | typeof getNavigationForLeftOrTopPage
+      | typeof getNavigationForRightOrBottomPage,
+  ) {
     const navigation = this.reader.navigation.getNavigation()
     const spineItem = this.reader.spineItemsManager.get(navigation.spineItem)
 
     if (!spineItem) return
 
-    const position = getNavigationForRightOrBottomPage({
+    const position = getNavigationForPage({
       context: this.reader.context,
       navigationResolver: this.reader.navigation.navigationResolver,
       position: navigation.position,
@@ -53,28 +57,12 @@ export class ManualNavigator {
     })
   }
 
+  turnRightOrBottom() {
+    return this.turnWith(getNavigationForRightOrBottomPage)
+  }
+
   turnLeftOrTop() {
-    const navigation = this.reader.navigation.getNavigation()
-    const spineItem = this.reader.spineItemsManager.get(navigation.spineItem)
-
-    if (!spineItem) return
-
-    const position = getNavigationForLeftOrTopPage({
-      context: this.reader.context,
-      navigationResolver: this.reader.navigation.navigationResolver,
-      position: navigation.position,
-      computedPageTurnDirection:
-        this.reader.settings.values.computedPageTurnDirection,
-      spineItem,
-      spineItemsManager: this.reader.spineItemsManager,
-      spineLocator: this.reader.spine.locator,
-      viewport: this.reader.viewport,
-      settings: this.reader.settings,
-    })
-
-    return this.reader.navigation.navigate({
-      position,
-    })
+    return this.turnWith(getNavigationForLeftOrTopPage)
   }
 
   goToCfi(cfi: string, options: { animate: boolean } = { animate: true }) {


### PR DESCRIPTION
## Consolidation: `ManualNavigator.turnRightOrBottom` / `turnLeftOrTop`

**What was duplicated**

In `packages/core/src/enhancers/navigation/navigators/manualNavigator.ts`, the two public methods `turnRightOrBottom()` and `turnLeftOrTop()` were byte-for-byte identical except for the single page-navigation resolver each called:

- `turnRightOrBottom` → `getNavigationForRightOrBottomPage`
- `turnLeftOrTop` → `getNavigationForLeftOrTopPage`

Both surrounding flows were the same: read the current navigation, resolve + guard the current spine item, build the target `position` from an identical argument object (9 fields), then `navigate({ position })`.

**What it became**

A single `protected turnWith(getNavigationForPage)` helper holds the shared flow, and both public methods delegate to it by passing the direction-specific resolver as a strategy argument. The two resolvers share the same signature, so no flags or conditionals were introduced — the genuinely direction-specific logic stays inside those separate resolver functions, untouched.

**Why these are the same concept**

The methods implement one behavior — "turn the page in a direction" — parameterized only by which resolver computes the next position. The duplication was the get-navigation/guard/navigate scaffolding, not the direction logic. Consolidating removes the risk of the two copies drifting (e.g. a fix to the guard or the argument object being applied to only one).

**Net LOC delta:** −12 (11 insertions, 23 deletions), 1 file.

**Behavior-preserving:** the public methods `turnRightOrBottom` / `turnLeftOrTop` keep the same names, signatures, and return values; `turnWith` is `protected`, so there is no public API change. No documentation update needed (public surface unchanged).

## Verification

Run under Node 25 (per `.nvmrc` / CI):

- `biome format` + `biome lint` on the changed file — clean
- `tsc` for `@prose-reader/core` — passes (matched clean baseline)
- `vitest run src/enhancers/navigation` — 27/27 pass

## Notes for future consolidation runs

Other candidates were considered and deliberately skipped because unifying them would require direction/mode parameters over genuinely divergent logic (the left/right mirror in `getNavigationForLeftOrTopPage` vs `getNavigationForRightOrBottomPage`, `getNavigationForLeftSinglePage` vs `getNavigationForRightOrBottomSinglePage`, and the `getSpineItemPositionFor{Left,Right}Page` pair). The per-package `report.ts` wrappers and the `isShallowEqual`/`objects` utilities are already consolidated via `@prose-reader/shared`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157o2Q7VjKZ9tgHaoYU4m4H

---
_Generated by [Claude Code](https://claude.ai/code/session_0157o2Q7VjKZ9tgHaoYU4m4H)_