### PR TITLE
perf(search): compile search regexp once per document instead of per text node

### DIFF
--- a/packages/enhancer-search/src/search.ts
+++ b/packages/enhancer-search/src/search.ts
@@ -4,12 +4,27 @@ import type { ResultItem } from "./types"
 
 export type SearchResult = ResultItem[]
 
-const searchNodeContainingText = (node: Node, text: string) => {
+/**
+ * Walk the subtree accumulating ranges for every match of `regexp`.
+ *
+ * A full-book search runs this over the rendered document of *every* spine
+ * item, so the text-node loop below is the hot path (thousands of text nodes
+ * per large chapter). Two things are hoisted out of it to keep the work
+ * proportional to the number of matches rather than the number of nodes:
+ * - the search regexp is compiled once by the caller and reused across every
+ *   node (only its `lastIndex` is reset), instead of recompiling per text node,
+ * - matches are pushed into a single shared array instead of allocating a new
+ *   array at each node and spreading child results upward.
+ */
+const collectMatchingRanges = (
+  node: Node,
+  regexp: RegExp,
+  matchLength: number,
+  rangeList: Range[],
+) => {
+  if (node.nodeName === `head`) return
+
   const nodeList = node.childNodes
-
-  if (node.nodeName === `head`) return []
-
-  const rangeList: Range[] = []
 
   for (let i = 0; i < nodeList.length; i++) {
     const subNode = nodeList[i]
@@ -18,22 +33,22 @@ const searchNodeContainingText = (node: Node, text: string) => {
       continue
     }
 
-    if (subNode?.hasChildNodes()) {
-      rangeList.push(...searchNodeContainingText(subNode, text))
+    if (subNode.hasChildNodes()) {
+      collectMatchingRanges(subNode, regexp, matchLength, rangeList)
     }
 
     if (subNode.nodeType === 3) {
       const content = (subNode as Text).data.toLowerCase()
       if (content) {
         let match: RegExpExecArray | null = null
-        const regexp = RegExp(`(${text})`, `gi`)
+        regexp.lastIndex = 0
 
         // biome-ignore lint/suspicious/noAssignInExpressions: TODO
         while ((match = regexp.exec(content)) !== null) {
           if (match.index >= 0 && subNode.ownerDocument) {
             const range = subNode.ownerDocument.createRange()
             range.setStart(subNode, match.index)
-            range.setEnd(subNode, match.index + text.length)
+            range.setEnd(subNode, match.index + matchLength)
 
             rangeList.push(range)
           }
@@ -41,6 +56,12 @@ const searchNodeContainingText = (node: Node, text: string) => {
       }
     }
   }
+}
+
+const searchNodeContainingText = (node: Node, text: string) => {
+  const rangeList: Range[] = []
+
+  collectMatchingRanges(node, RegExp(`(${text})`, `gi`), text.length, rangeList)
 
   return rangeList
 }


### PR DESCRIPTION
## Target

**Subsystem:** `@prose-reader/enhancer-search` — full-text search.

**User-visible symptom:** `search(text)` maps over **every** spine item in the manifest and runs `searchInDocument` → `searchNodeContainingText` on each rendered document (`packages/enhancer-search/src/index.ts:61-66`). A full-book search therefore walks the entire book's DOM. The innermost loop touches every text node in every chapter — the largest data set this library handles (a novel like the `moby-dick` fixture referenced elsewhere in the codebase renders on the order of tens of thousands of text nodes). Work multiplied by that count is main-thread time the user waits on before results appear, and it re-runs on each incremental search query.

## The change

Both fixes are in the same function (`searchNodeContainingText`) and are invisible except in speed:

1. **Compile the search regexp once, not once per text node.** The old code built `RegExp(`(${text})`, 'gi')` inside the per-text-node branch. The `RegExp` *constructor* (unlike a regex literal) is never compilation-cached, so this recompiled the pattern for every text node in the book. Mechanism: hoist the regexp to a single compilation per document and reset only its `lastIndex` before each node's `exec` loop. **Multiplier:** number of text nodes across the whole book → one compilation instead of O(text-nodes).

2. **Accumulate into one shared array instead of per-node arrays + spread.** The old recursion allocated a fresh `rangeList` at every node and did `rangeList.push(...searchNodeContainingText(subNode))`, copying child results upward at each level. Mechanism: thread a single results array through the recursion. **Multiplier:** one allocation + O(depth×matches) copies per node → a single array.

Output is unchanged: the ranges (same `startContainer`, `startOffset`, `endOffset`, same order, including overlapping matches like `whalewhale`) are byte-for-byte identical.

## Impact (measured)

Isolated benchmark of the delta the change removes (regex compilation + array churn; DOM `Range` creation is identical in both versions), 20,000 text nodes (~one large novel), query `"whale"`, Node on this Linux runner:

```
matches (sanity, must be equal): old=400 new=400
per full-book search over 20000 text nodes:
  old (recompile per node): 4.44 ms
  new (compile once):       1.67 ms
  speedup: 2.66x  (2.77 ms saved)
```

~2.8 ms of pure main-thread CPU removed per full-book search on a fast desktop; proportionally more on the mobile targets this reading engine serves. This is O(text-nodes) work replaced by O(1) compilation — the saving grows with book size and with query frequency (incremental search).

## Equivalence verification

A jsdom harness runs the original and new traversals over the same document and compares the emitted ranges for queries `whale`, `the`, `zzz` (no match), and `l` (single char):

```
text="whale": old=12 new=12 ranges  identical=true
text="the":   old=4  new=4  ranges  identical=true
text="zzz":   old=0  new=0  ranges  identical=true
text="l":     old=16 new=16 ranges  identical=true
```

## Gates

- `biome format` + `biome lint` on the changed file: clean (also enforced by the repo's husky/lint-staged pre-commit hook, which passed).
- The change is type-clean: the only `tsc` diagnostic on `search.ts` is `Cannot find module '@prose-reader/core'`, i.e. missing built workspace deps, not an error in the edited code.
- **Pre-existing baseline failure (not introduced here):** `npm run build` fails in this environment during the *vite* step of `@prose-reader/cfi` (a package this PR does not touch) with `rollup-plugin-node-externals` throwing `TypeError: undefined is not a function` against the installed rolldown/vite. This is a toolchain-version issue independent of this one-file change; CI (node 25, fresh `npm ci` on the committed lock) runs the real build/tsc/test gates.

## Backlog (other performance opportunities found, not taken)

- **`getFirstVisibleElementForViewport` in `packages/core/src/utils/dom.ts`** recursively calls `getBoundingClientRect()` on *every* element in a document with no early-out for fully out-of-viewport subtrees (by design, per the in-code comment). It's already marked `@todo optimize` and chunked at 10 pages/frame in `Pages.ts`, but it remains an O(all-elements) layout-read hot path — a candidate for an `IntersectionObserver`-based rewrite (AGENTS.md explicitly flags this pattern).
- **`SpineItemsManager.get(id)` (`packages/core/src/spine/SpineItemsManager.ts:36`)** does `this.items.find(({item}) => item.id === id)` — O(n) per lookup. If any hot path resolves items by string id in a loop this is O(n²); a `Map<id, SpineItem>` built once at construction would make it O(1) (mirrors the intent of #222).
- **CFI generation** (`packages/cfi/src/generate.ts`) rebuilds `Array.from(parentNode.childNodes)` + `indexOf`/`slice().filter()` at each ancestor level; called once per search result, so a search returning many hits pays it repeatedly. Lower multiplier than the fix above, but worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpAggFJEdnFNerwZdyvvfk

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpAggFJEdnFNerwZdyvvfk)_