### PR TITLE
build(deps-dev): bump lint-staged from 17.0.8 to 17.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "autoprefixer": "^10.4.18",
         "husky": "^9.1.7",
         "lerna": "^9.0.7",
-        "lint-staged": "^17.0.5",
+        "lint-staged": "^17.1.0",
         "rollup-plugin-node-externals": "^9.0.0",
         "rxjs": "*",
         "serve": "^14.2.0",
@@ -8337,20 +8337,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/ansi-escapes": {
-      "version": "7.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "environment": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "license": "MIT",
@@ -9446,20 +9432,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-cursor": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cli-spinners": {
       "version": "2.6.1",
       "license": "MIT",
@@ -9468,61 +9440,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "slice-ansi": "^8.0.0",
-        "string-width": "^8.2.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "8.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/cli-width": {
@@ -10544,17 +10461,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/environment": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/err-code": {
       "version": "2.0.3",
       "dev": true,
@@ -10790,11 +10696,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "5.0.0",
@@ -11458,17 +11359,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -13850,12 +13740,13 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "17.0.8",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.1.0.tgz",
+      "integrity": "sha512-d7UQRu/9ZPgfu4+hu/k0wny5GEaIxo+2jb2LJqQDkE7cHRTm1HGqNUDq5UOwsGPpjpaNAFmgAsYo3TR+i9cSJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "listr2": "^10.2.1",
-        "picomatch": "^4.0.4",
+        "picomatch": "^4.0.5",
         "string-argv": "^0.3.2",
         "tinyexec": "^1.2.4"
       },
@@ -13870,88 +13761,6 @@
       },
       "optionalDependencies": {
         "yaml": "^2.9.0"
-      }
-    },
-    "node_modules/listr2": {
-      "version": "10.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cli-truncate": "^5.2.0",
-        "eventemitter3": "^5.0.4",
-        "log-update": "^6.1.0",
-        "rfdc": "^1.4.1",
-        "wrap-ansi": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=22.13.0"
-      }
-    },
-    "node_modules/listr2/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/listr2/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/listr2/node_modules/string-width": {
-      "version": "8.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/listr2/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/listr2/node_modules/wrap-ansi": {
-      "version": "10.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.3",
-        "string-width": "^8.2.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/load-json-file": {
@@ -14045,126 +13854,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^7.0.0",
-        "cli-cursor": "^5.0.0",
-        "slice-ansi": "^7.1.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/log-update/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/log-update/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/slice-ansi": {
-      "version": "7.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/log-update/node_modules/string-width": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/loose-envify": {
@@ -14827,17 +14516,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/mimic-function": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -17489,46 +17167,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^7.0.0",
-        "signal-exit": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/restore-cursor/node_modules/onetime": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/restore-cursor/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/retry": {
       "version": "0.12.0",
       "dev": true,
@@ -17536,11 +17174,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/rfdc": {
-      "version": "1.4.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.2.0",
@@ -18582,46 +18215,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/slice-ansi": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.3",
-        "is-fullwidth-code-point": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/slugify": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "autoprefixer": "^10.4.18",
     "husky": "^9.1.7",
     "lerna": "^9.0.7",
-    "lint-staged": "^17.0.5",
+    "lint-staged": "^17.1.0",
     "rollup-plugin-node-externals": "^9.0.0",
     "rxjs": "*",
     "serve": "^14.2.0",


### PR DESCRIPTION
## The update

| | |
|---|---|
| **Package** | `lint-staged` (root `devDependencies`) |
| **Version** | 17.0.8 → 17.1.0 |
| **Type** | minor, within the existing `^17` range |
| **Scope** | dev tooling only — the husky pre-commit hook. Not imported by any package and not invoked by any CI gate. |

**Changelog highlight:** 17.1.0 **drops the `listr2` dependency**, so its transitive subtree (`log-update`, `cli-truncate`, `slice-ansi`, `ansi-escapes`, `cli-cursor`, `restore-cursor`, `rfdc`, `eventemitter3`, …) is pruned from the lockfile. That is why the lockfile diff removes far more than it adds — it is a dependency-footprint reduction, not a functional change. `picomatch` also moves `^4.0.4 → ^4.0.5` inside lint-staged's own deps.

### Why this one
No security fix is applicable within the routine's rules this run (see below), so the pick fell to the highest-priority clean, in-range, non-major update. `lint-staged` was chosen as the smallest, lowest-risk reviewable unit: a same-major minor bump on a dev-only git-hook tool with zero public-library / runtime / documentation surface.

### Gates
Verified green on **Node 25 / npm 11** (matching CI's pinned runtime):

| Gate | Result |
|---|---|
| `biome format` | ✅ 772 files, no changes |
| `biome lint` | ✅ exit 0 (4 pre-existing warnings, unchanged) |
| `lerna run build` (libs) | ✅ 15 projects |
| `lerna run tsc` | ✅ 5 projects |
| `@prose-reader/core` vitest | ✅ 177 tests / 27 files |

The Playwright e2e gate was not run in this environment; `lint-staged` is a local pre-commit tool that no CI gate invokes, so it cannot influence e2e behavior.

---

## Pending queue (other outdated deps found this run)

### 🔴 Security advisories — all blocked within the routine's rules
The one-at-a-time rules forbid a breaking downgrade and forbid overriding a transitive package's declared constraint, so none of the current advisories can be resolved cleanly right now. They are surfaced here for a human to schedule:

| Severity | Package | Path | Advisory | Why blocked |
|---|---|---|---|---|
| **High** | `rollup` ≤2.79.2 | `@types/rollup-plugin-node-builtins` → `rollup` (dev types) | DOM-clobbering XSS (GHSA-gcx4-mw62-g8wm); path-traversal file write (GHSA-mw96-cpmx-2vgc) | **No fix available** per npm audit |
| Moderate | `js-yaml` 4.0.0–4.1.1 | `lerna` → `js-yaml` | Quadratic-complexity DoS via merge keys (GHSA-h67p-54hq-rp68) | Offered fix is `lerna@6.6.2` — a **downgrade** from `^9` (regression) |
| Moderate | `tar` ≤7.5.15 | `lerna` → `tar` | PAX size-override parser differential / file smuggling (GHSA-vmf3-w455-68vh) | Same `lerna@6.6.2` downgrade |
| Moderate | `uuid` <11.1.1 | `expo` → `@expo/config-plugins` → `xcode@3.0.1` (pins `uuid@^7`) | Missing buffer bounds check in v3/v5/v6 (GHSA-w5hq-g745-h8pq) | Fix needs an `overrides` forcing `uuid@11`, which **overrides xcode's declared `^7.0.3`** — disallowed |
| Moderate | `undici` (several), `brace-expansion`, `form-data`, `tmp`, `yaml` | transitive under `lerna` / `expo` build tooling | Various (TLS bypass, header injection, DoS, cache poisoning) | Fixes route through the `lerna` downgrade or deep expo-tree changes |

### 🟡 Clean in-range update (next candidate)
| Package | Current → Latest | Type | Location |
|---|---|---|---|
| `happy-dom` | 20.10.6 → 20.11.0 | minor (range `*`) | `@prose-reader/core` (test env) |

---

## Deferred majors (need a human to schedule)
Per the routine, non-security major bumps are listed, not applied:

| Package | Current → Latest | Location | Breaking-change note |
|---|---|---|---|
| `typescript` | 6.0.3 → 7.0.2 | monorepo-wide (`*`) | TS 7 major; monorepo-wide `tsc` blast radius — validate carefully |
| `pdfjs-dist` | 5.7.284 → 6.1.200 | enhancer-pdf, demo, tests | v6 API/worker changes; affects PDF enhancer |
| `react-router` | 7.18.1 → 8.2.0 | demo | v8 routing API changes (demo app only) |
| `react-dropzone` | 15.0.0 → 19.1.1 | demo | 4 majors behind; hook/prop API changes (demo app only) |
| `@babel/core` | 7.29.7 → 8.0.1 | demo | Babel 8 major |
| `@types/node` | 25.9.5 → 26.1.1 | root | Node 26 typings (repo pins Node 25) |
| `expo-file-system` | 56.0.8 → 57.0.1 | react-native | Expo SDK 57 file-system API rewrite |
| `xmldoc` | 2.0.3 → 3.0.0 | archive-reader, streamer | v3 major; used for EPUB XML parsing — verify parsing behavior |
| `buffer` | 5.7.1 → 6.0.3 | streamer | v6 major (a v5 instance still resolves in-tree) |

## Needs manual attention
None — the applied update passed all gates; nothing was skipped due to a gate failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188PbmpnUsKnVqq66iir5Zj

---
_Generated by [Claude Code](https://claude.ai/code/session_0188PbmpnUsKnVqq66iir5Zj)_