### PR TITLE
fix(cfi): compare step indices before step types when sorting CFIs

### DIFF
--- a/packages/cfi/src/compare.test.ts
+++ b/packages/cfi/src/compare.test.ts
@@ -111,6 +111,34 @@ describe("EPUB CFI Sorting", () => {
     })
   })
 
+  describe("Step indices win over step types (rule 3 & 4 before rule 9)", () => {
+    it("should order by step index when only one side has a character offset", () => {
+      // Text node step /7 (with offset) comes after element step /6 in
+      // document order, no matter what follows /6.
+      const a = "epubcfi(/4[body01]/7:5)"
+      const b = "epubcfi(/4[body01]/6/2)"
+
+      expect(compare(a, b)).toBe(1)
+      expect(compare(b, a)).toBe(-1)
+    })
+
+    it("should order sibling steps by index when one carries an offset", () => {
+      const a = "epubcfi(/4[body01]/10:3)"
+      const b = "epubcfi(/4[body01]/2)"
+
+      expect(compare(a, b)).toBe(1)
+      expect(compare(b, a)).toBe(-1)
+    })
+
+    it("should order by step index when only one side has a temporal position", () => {
+      const a = "epubcfi(/4[body01]/16[svgimg]~5.2)"
+      const b = "epubcfi(/4[body01]/18[svgimg2])"
+
+      expect(compare(a, b)).toBe(-1)
+      expect(compare(b, a)).toBe(1)
+    })
+  })
+
   describe("Complex comparisons", () => {
     it("should handle complex CFIs with multiple attributes", () => {
       // CFI with mixed attributes

--- a/packages/cfi/src/compare.ts
+++ b/packages/cfi/src/compare.ts
@@ -65,7 +65,14 @@ export function compare(a: ParsedCfi | string, b: ParsedCfi | string): number {
       if (!x) return -1
       if (!y) return 1
 
-      // Compare step types (rule 9)
+      // Compare element indices (rule 3 & 4)
+      // The step index locates the node in the document, so it always wins.
+      if (x.index > y.index) return 1
+      if (x.index < y.index) return -1
+
+      // Compare step types (rule 9), only as a tie-breaker between steps at
+      // the same index (eg: an offset terminating at a node vs a child step
+      // descending into it)
       // character offset (:) < child (/) < temporal-spatial (~ or @) < reference (!)
       const xStepType = getStepTypeWeight(x)
       const yStepType = getStepTypeWeight(y)
@@ -73,10 +80,6 @@ export function compare(a: ParsedCfi | string, b: ParsedCfi | string): number {
       if (xStepType !== yStepType) {
         return xStepType - yStepType
       }
-
-      // Compare element indices (rule 3 & 4)
-      if (x.index > y.index) return 1
-      if (x.index < y.index) return -1
 
       // Compare temporal positions (rule 7 & 8)
       // Temporal is more important than spatial


### PR DESCRIPTION
## The bug

`compare()` from `@prose-reader/cfi` (public API, documented in `gitbook/cfi/about.md` as sorting "according to the EPUB CFI specification sorting rules") returns an **inverted ordering** whenever one CFI's terminal step carries a character offset and the other CFI has a different step index at that depth.

Observable on the current master:

```ts
compare("epubcfi(/4/7:5)", "epubcfi(/4/6/2)") // → -1, wrong: step /7 comes after step /6
compare("epubcfi(/4/7)",   "epubcfi(/4/6/2)") // → 1, correct once the offset is dropped
compare("epubcfi(/4/10:3)", "epubcfi(/4/2)")  // → -1, wrong: /10 is after /2
```

Merely attaching a character offset to a text location flips the result. Since every text-position CFI (bookmark, annotation, reading-position anchor) ends in an offset step, sorting such CFIs against element CFIs (chapter anchors, block-level positions) produces wrong document order.

## Root cause

In `packages/cfi/src/compare.ts`, the per-step loop applied the step-**type** precedence (rule 9: character offset `<` child `<` temporal-spatial `<` reference) *before* comparing step indices, and returned as soon as the type weights differed. `getStepTypeWeight` returns weight 1 for any part carrying an offset, so an offset-bearing step always sorted before a plain child step — even when its index placed it later in the document.

The step index locates the node in the document, so it must be compared first; the type precedence is only meaningful as a tie-breaker between steps at the *same* index (e.g. an offset terminating at a node vs a child step descending into it).

## The fix

Move the index comparison (`x.index` / `y.index`) ahead of the step-type comparison in the loop. The step-type tie-break, temporal/spatial comparison, and terminal offset comparison are unchanged. All existing rule-9 orderings are preserved — every prior test in `compare.test.ts` only exercises type precedence between steps with *equal* indices, and the full suite confirms none of them changed.

## Verification

- New regression tests in `packages/cfi/src/compare.test.ts`: the two offset cases **fail before the fix** (`-1` where document order requires `1`) and pass after. A third test pins the temporal-position case at the correct behavior (it already passed, because `getStepTypeWeight` checks `index` before `temporal` — the inversion only manifests through offsets).
- `@prose-reader/cfi` suite: 100 passed / 2 pre-existing skips.
- Repo gates on Node 25 (matching CI): `lerna run build` (17 projects), `npm run tsc`, `biome format` + `lint` clean, `lerna run test` green for all 12 packages with test targets. Playwright e2e not run in this environment (macOS screenshot baselines + multi-engine matrix); the change is a pure function in `@prose-reader/cfi` fully covered by its unit suite.
- Docs checked: `gitbook/cfi/about.md` documents `compare` by its spec contract (−1/0/1 per spec sorting rules), which this change restores rather than alters — no doc update needed.

## Other findings (not addressed in this PR)

Confirmed by code-trace while hunting; left untouched to keep this PR single-purpose:

1. **NCX TOC entries resolve against the OPF directory instead of the NCX file's own directory** — `packages/archive-reader/src/toc/ncx.ts` joins `content@src` with `opfBasePath`, while the nav-document strategy (`toc/nav.ts:103-109`) correctly uses the TOC file's own base path with an explicit comment that links are relative to the TOC document. An NCX at `OEBPS/nav/toc.ncx` with `src="chapter1.xhtml"` yields `OEBPS/chapter1.xhtml` instead of `OEBPS/nav/chapter1.xhtml`, so TOC links point at non-existent resources.
2. **`generate()` emits an even CFI step for text nodes preceded by an element** — `packages/cfi/src/generate.ts` (both `generatePoint` and `generateRelativePath`) computes the text-node step as raw `childNodes` index + 1. In `<p><span>x</span>hello</p>` the text node gets step `/2`, which collides with the `<span>` element step; `resolve()` then maps the generated CFI back to the `<span>`, not the text node. Per spec, text nodes take odd steps (`/3` here). Fixing requires touching generate *and* resolve together (both use raw indexing), and changes the meaning of previously stored CFIs — deliberately not bundled into this PR.
3. **Streamer manifest hrefs don't escape `#`/`?` in resource paths** — `packages/streamer/src/generators/manifest/createManifestResourceHref.ts` uses bare `encodeURI`, which leaves `#`/`?` intact, so a CBZ entry named `page#1.jpg` produces an href whose fragment/query breaks resource resolution. The TOC side already escapes these (`archive-reader/src/toc/folders.ts:100-103` with an enforcing test), so the manifest is internally inconsistent for the same file.
4. **Percent-encoded OPF hrefs never match archive records** — `packages/archive-reader/src/readingOrder/resolveArchiveReadingOrder.ts` (and `opf/getSpineItemFilesFromArchive.ts`) look up records by exact string match of the OPF href, but OPF hrefs are percent-encoded per spec while zip record URIs are raw (`chapter%201.xhtml` vs `chapter 1.xhtml`). Sizes/progression weights silently fall back to equal weighting for spec-compliant EPUBs with spaces or non-ASCII in filenames.
5. **Video pause/autoplay on intersection is dead code for HTML-parsed content** — `packages/core/src/enhancers/media/media.ts:55` gates on `entry.target.tagName === "video"`, but `tagName` is uppercase (`"VIDEO"`) in HTML documents, so off-screen videos are never paused. Only observes `<video>` elements, so the guard should be case-insensitive (cf. `utils/dom.ts` `isHtmlTagElement`). Latent for correctly-typed XHTML spine items, where `tagName` stays lowercase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XhywW2pmt43nyWQk3ffqA

---
_Generated by [Claude Code](https://claude.ai/code/session_016XhywW2pmt43nyWQk3ffqA)_