### PR TITLE
feat(archive-reader): resolve cover and page count into metadata

### DIFF
--- a/gitbook/archive-reader/README.md
+++ b/gitbook/archive-reader/README.md
@@ -163,7 +163,7 @@ import { resolveArchive } from "@prose-reader/archive-reader"
 const resolved = await resolveArchive(archive)
 // {
 //   version: 1,
-//   metadata: { title, contributors, readingDirection, renditionLayout, belongsTo, … },
+//   metadata: { title, cover?, numberOfPages?, contributors, renditionLayout, belongsTo, … },
 //   readingOrder: [{ uri, id?, mediaType?, size?, renditionLayout?, progressionWeight, … }],
 //   toc: [{ title, path, containerHref, contents }],
 // }
@@ -177,7 +177,7 @@ Everything is **container-relative** (reading-order `uri`s, toc `containerHref`s
 
 | Token | Cost |
 | --- | --- |
-| `metadata` | sidecar XML reads (OPF, ComicInfo.xml, Apple/Kobo display options) — cheap |
+| `metadata` | sidecar XML reads (OPF, ComicInfo.xml, Apple/Kobo display options) — cheap. Also derives `cover` and the counted `numberOfPages`, which for a package-less container costs an in-memory reading-order scan |
 | `readingOrder` | the OPF read at most — cheap |
 | `toc` | one nav or NCX document read+parse on top — medium |
 | `sources` | same reads as `metadata` — the verbatim parser outputs, for provenance and single-format needs |
@@ -233,11 +233,28 @@ if (comicInfo) {
 }
 ```
 
+{% hint style="info" %}
+`resolveArchiveMetadata` and `resolveMetadata` see only parsed source documents, so they never populate the container-derived fields — `metadata.cover` and the counted `numberOfPages` fallback. Those need the file listing and come from `resolveArchive` (or `resolveArchiveCover`).
+{% endhint %}
+
 Malformed documents throw from the single-file readers (`readArchiveComicInfo`, `readArchiveApple`, `readArchiveOpf`) so you decide how lenient to be; `readArchiveKobo` merges every matching sidecar and skips unparseable ones. The lower-level pieces (`parseOpf`, `parseComicInfo`, `getArchiveOpfInfo`, `getArchiveHasComicInfo`, …) stay exported for advanced use.
 
 ## Resolving the reading order
 
 `resolveArchiveReadingOrder(archive, options?)` is the standalone building block behind `resolveArchive`'s `readingOrder` token: the OPF spine when a usable package document exists (container-relative `uri`s, per-itemref layout hints, size-proportional `progressionWeight`), the archive's file listing otherwise — including when the package document is missing or unparseable — (sidecars like `ComicInfo.xml`/display-options and OS litter like `Thumbs.db` excluded, equal weights, discrete media marked `pre-paginated`). It always returns an array; a malformed OPF is treated as no OPF rather than throwing. Pass `{ opf }` to skip the internal OPF lookup.
+
+## Resolving the cover
+
+`resolveArchiveCover(archive, options?)` is the standalone building block behind `metadata.cover`: the OPF-declared cover image rebased to a container-relative `uri` (`confidence: "derived"`), else the first image of the reading order for image-content containers — comics, image archives, synthetic image-spine OPFs such as `createArchiveFromUrls` lists (`confidence: "assumed"`). It returns `undefined` when no cover is derivable: an authored reflowable EPUB (text spine, so an interior illustration is never promoted) or an audiobook/video archive has none.
+
+```typescript
+import { resolveArchiveCover } from "@prose-reader/archive-reader"
+
+const cover = await resolveArchiveCover(archive)
+// { uri: "OEBPS/cover.jpg", mediaType: "image/jpeg", confidence: "derived" } | undefined
+```
+
+Pass `{ opf }` and/or `{ readingOrder }` (already-resolved parts) to skip the internal lookups — `resolveArchive` threads both in.
 
 ## Resolving a table of contents
 

--- a/gitbook/archive-reader/resolved-metadata.md
+++ b/gitbook/archive-reader/resolved-metadata.md
@@ -13,8 +13,20 @@
 ## The vocabulary
 
 ```typescript
+/** "derived" = declared or properly computed; "assumed" = a best-effort convention */
+type ResolvedConfidence = "derived" | "assumed"
+
+type ResolvedCover = {
+  /** container-relative uri of the cover image (rebase like reading-order uris) */
+  uri: string
+  mediaType?: string
+  confidence: ResolvedConfidence
+}
+
 type ResolvedMetadata = {
   title?: string
+  /** the cover image; resolved against the container, so `resolveArchive` only */
+  cover?: ResolvedCover
   description?: string
   publisher?: string
   imprint?: string
@@ -27,6 +39,7 @@ type ResolvedMetadata = {
   renditionLayout?: "reflowable" | "pre-paginated"
   renditionFlow?: "scrolled-continuous" | "scrolled-doc" | "paginated" | "auto"
   renditionSpread?: "none" | "landscape" | "portrait" | "both" | "auto"
+  /** declared count, else counted page-like pages; `resolveArchive` only when counted */
   numberOfPages?: number
   gtin?: string
   isbn?: string
@@ -44,6 +57,13 @@ type ResolvedMetadata = {
 }
 ```
 
+### Cover and page count
+
+Two fields are resolved for the whole **container**, not just its descriptive sidecars, so they are populated by `resolveArchive` and left absent by the source-level `resolveMetadata` / `resolveArchiveMetadata`, which never see the file listing:
+
+- **`cover`** — the OPF-declared cover image (EPUB 3 `cover-image` property, the EPUB 2 `<meta name="cover">` convention, or a `cover`-ish image id), rebased onto a container-relative `uri` (`confidence: "derived"`); else the first image of the reading order for image-content containers — comics, image archives, synthetic image-spine OPFs such as `createArchiveFromUrls` lists (`confidence: "assumed"`). It stays absent when nothing image-like is a reading resource: an authored reflowable EPUB (text spine, so an interior illustration is never promoted) or an audiobook/video archive has no cover.
+- **`numberOfPages`** — the declared ComicInfo `PageCount`, else the count of page-like reading-order items (images and fixed-layout documents). Reflowable documents are not pages, and audio/video tracks are not pages, so both are excluded: a reflowable book or an audiobook has no page count.
+
 ### Contributor roles
 
 Roles use the Readium terms our sources can express — `author`, `translator`, `editor`, `artist`, `illustrator`, `letterer`, `penciler`, `colorist`, `inker`, `narrator`, `contributor` — plus the prose-reader extension `coverArtist` (ComicInfo `CoverArtist`; Readium has no cover-art term). Well-known MARC relator codes from OPF (`aut`, `trl`, `edt`, `art`, `ill`, `clr`, `nrt`, `ctb`) are normalized to those terms; unknown tokens pass through verbatim. A role-less `dc:creator` defaults to `author`, a role-less `dc:contributor` to `contributor`.
@@ -58,11 +78,13 @@ When several sources are present, `resolveMetadata` merges field-wise:
 | `readingDirection` | **ComicInfo wins over OPF** (`Manga` beats `page-progression-direction`) — deliberate, preserving the historical pipeline behavior |
 | `renditionLayout` | **OPF explicit → Apple → Kobo**, first defined wins; the [`layoutScan`](README.md#resolving-a-publication) promotion applies on top, inside the resolver |
 | `identifiers` | concatenated, OPF first (identifier systems coexist) |
-| corners (`comic`, `apple`, `kobo`) and single-source fields (`rights`, `properties`, `imprint`, `numberOfPages`) | from their only producer |
+| `cover` | OPF-declared cover, else the first-image fallback for image-content containers (`resolveArchive` only) |
+| `numberOfPages` | declared ComicInfo `PageCount`, else the counted page-like reading-order items (`resolveArchive` only) |
+| corners (`comic`, `apple`, `kobo`) and single-source fields (`rights`, `properties`, `imprint`) | from their only producer |
 
 ## Mapping tables
 
-These mirror the compile-enforced tables shipped next to each resolver — the losslessness audit trail. Dotted paths address the scoped corners; `readingOrder`/`toc` mean the field feeds a sibling part of the resolved entity; `cover` and `guide` are reserved homes still only reachable through `sources`.
+These mirror the compile-enforced tables shipped next to each resolver — the losslessness audit trail. Dotted paths address the scoped corners; `readingOrder`/`toc` mean the field feeds a sibling part of the resolved entity; `cover` is the `metadata.cover` field (resolved against the container by `resolveArchive`); `guide` is a reserved home still only reachable through `sources`.
 
 ### ComicInfo → metadata
 
@@ -84,7 +106,7 @@ These mirror the compile-enforced tables shipped next to each resolver — the l
 | `Translator` | `contributors` | role `translator` |
 | `Year`, `Month`, `Day` | `published` | independent optional components |
 | `Manga` | `readingDirection` | `YesAndRightToLeft` → `rtl`; also `comic.manga` |
-| `PageCount` | `numberOfPages` | |
+| `PageCount` | `numberOfPages` | declared count; a page-like container without it is counted at the archive level |
 | `GTIN` | `identifiers` | scheme `GTIN`; also `gtin`/`isbn` normalization |
 | `Series`, `Number`, `Count` | `belongsTo.series` | name / position / total |
 | `SeriesGroup` | `belongsTo.collection` | comma-split |
@@ -126,7 +148,7 @@ These mirror the compile-enforced tables shipped next to each resolver — the l
 | every `<meta>` | `properties` | verbatim, the open-world channel |
 | manifest items, spine itemrefs | `readingOrder` | structural |
 | spine `toc` idref | `toc` | structural |
-| cover heuristics (`coverHref`) | `cover` | reserved — `sources.opf` only today |
+| cover heuristics (`coverHref`) | `cover` | the `metadata.cover` field; `basePath`-resolved by `resolveArchive`, `confidence: "derived"` |
 | `<guide>` | `guide` | reserved — `sources.opf` only today |
 
 ### Apple / Kobo → metadata

--- a/packages/archive-reader/src/cover/resolveArchiveCover.test.ts
+++ b/packages/archive-reader/src/cover/resolveArchiveCover.test.ts
@@ -137,6 +137,39 @@ describe(`Given an EPUB whose OPF declares no cover`, () => {
   })
 })
 
+describe(`Given a synthetic image-spine OPF (URL list, no cover marker)`, () => {
+  it(`assumes the first spine image as the cover`, async () => {
+    // shape produced by createArchiveFromUrls: a generated OPF whose spine is
+    // the image list, with no cover-image property — the first image is still
+    // the natural cover
+    const archive = archiveWith(
+      [
+        textRecord(
+          `content.opf`,
+          `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:title>x</dc:title></metadata>
+  <manifest>
+    <item id="i1" href="001.jpg" media-type="image/jpeg"/>
+    <item id="i2" href="002.jpg" media-type="image/jpeg"/>
+  </manifest>
+  <spine><itemref idref="i1"/><itemref idref="i2"/></spine>
+</package>`,
+        ),
+        textRecord(`001.jpg`, ``, { encodingFormat: `image/jpeg` }),
+        textRecord(`002.jpg`, ``, { encodingFormat: `image/jpeg` }),
+      ],
+      `urls`,
+    )
+
+    expect(await resolveArchiveCover(archive)).toEqual({
+      uri: `001.jpg`,
+      mediaType: `image/jpeg`,
+      confidence: `assumed`,
+    })
+  })
+})
+
 describe(`Given a package-less container`, () => {
   it(`falls back to the first reading-order resource, sidecars excluded`, async () => {
     const archive = archiveWith(

--- a/packages/archive-reader/src/cover/resolveArchiveCover.test.ts
+++ b/packages/archive-reader/src/cover/resolveArchiveCover.test.ts
@@ -91,6 +91,39 @@ describe(`Given an EPUB with an OPF cover`, () => {
       confidence: `derived`,
     })
   })
+
+  it(`resolves dot segments in the cover href against the OPF directory`, async () => {
+    // OPF nested under OEBPS/Text, cover a sibling folder up via `../Images`.
+    // EPUB resolves this to OEBPS/Images/cover.jpg — the real record uri —
+    // not the verbatim OEBPS/Text/../Images/cover.jpg concatenation.
+    const archive = archiveWith(
+      [
+        textRecord(
+          `OEBPS/Text/content.opf`,
+          `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:title>x</dc:title></metadata>
+  <manifest>
+    <item id="c" href="../Images/cover.jpg" media-type="image/jpeg" properties="cover-image"/>
+    <item id="p1" href="page1.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine><itemref idref="p1"/></spine>
+</package>`,
+        ),
+        textRecord(`OEBPS/Text/page1.xhtml`, `<html/>`),
+        textRecord(`OEBPS/Images/cover.jpg`, ``, {
+          encodingFormat: `image/jpeg`,
+        }),
+      ],
+      `book.epub`,
+    )
+
+    expect(await resolveArchiveCover(archive)).toEqual({
+      uri: `OEBPS/Images/cover.jpg`,
+      mediaType: `image/jpeg`,
+      confidence: `derived`,
+    })
+  })
 })
 
 describe(`Given an EPUB whose OPF declares no cover`, () => {

--- a/packages/archive-reader/src/cover/resolveArchiveCover.test.ts
+++ b/packages/archive-reader/src/cover/resolveArchiveCover.test.ts
@@ -155,17 +155,46 @@ describe(`Given a package-less container`, () => {
     })
   })
 
+  it(`skips non-image reading-order items to reach the cover image`, async () => {
+    const archive = archiveWith(
+      [
+        textRecord(`intro.mp3`, ``, { encodingFormat: `audio/mpeg` }),
+        textRecord(`cover.png`, ``, { encodingFormat: `image/png` }),
+      ],
+      `mixed.zip`,
+    )
+
+    expect(await resolveArchiveCover(archive)).toEqual({
+      uri: `cover.png`,
+      mediaType: `image/png`,
+      confidence: `assumed`,
+    })
+  })
+
+  it(`returns undefined when no reading-order item is an image`, async () => {
+    const archive = archiveWith(
+      [
+        textRecord(`track01.mp3`, ``, { encodingFormat: `audio/mpeg` }),
+        textRecord(`track02.mp3`, ``, { encodingFormat: `audio/mpeg` }),
+      ],
+      `audiobook.zip`,
+    )
+
+    expect(await resolveArchiveCover(archive)).toBeUndefined()
+  })
+
   it(`returns undefined for an empty container`, async () => {
     expect(await resolveArchiveCover(archiveWith([]))).toBeUndefined()
   })
 })
 
 describe(`Given a malformed OPF`, () => {
-  it(`degrades to the first-page fallback rather than throwing`, async () => {
+  it(`degrades to the first image of the file listing rather than throwing`, async () => {
     const archive = archiveWith(
       [
         // mismatched close tag: parseOpf's XmlDocument rejects it, so the opf
-        // read throws and the cover degrades to the file-listing fallback
+        // read throws and the cover degrades to the file-listing fallback —
+        // which skips the .opf (not an image) and lands on the first image
         textRecord(
           `content.opf`,
           `<?xml version="1.0"?><package><spine></package>`,
@@ -176,7 +205,8 @@ describe(`Given a malformed OPF`, () => {
     )
 
     expect(await resolveArchiveCover(archive)).toEqual({
-      uri: `content.opf`,
+      uri: `page_001.jpg`,
+      mediaType: `image/jpeg`,
       confidence: `assumed`,
     })
   })

--- a/packages/archive-reader/src/cover/resolveArchiveCover.test.ts
+++ b/packages/archive-reader/src/cover/resolveArchiveCover.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest"
+import { createArchive } from "../archives/createArchive"
+import { blobFileAccessors } from "../archives/fileAccessors"
+import { readArchiveOpf } from "../opf/readArchiveOpf"
+import { resolveArchiveCover } from "./resolveArchiveCover"
+
+const textRecord = (
+  uri: string,
+  content = ``,
+  { encodingFormat }: { encodingFormat?: string } = {},
+) => ({
+  dir: false as const,
+  basename: uri.split(`/`).pop() ?? uri,
+  uri,
+  size: content.length,
+  ...(encodingFormat !== undefined ? { encodingFormat } : {}),
+  ...blobFileAccessors(() => Promise.resolve(new Blob([content]))),
+})
+
+const archiveWith = (
+  records: ReturnType<typeof textRecord>[],
+  filename = `archive`,
+) =>
+  createArchive({
+    filename,
+    records,
+    close: () => Promise.resolve(),
+  })
+
+const epubWith = (manifest: string, metadata = ``, basePath = `OEBPS`) => {
+  const prefix = basePath === `` ? `` : `${basePath}/`
+  const opf = `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>My Book</dc:title>
+    ${metadata}
+  </metadata>
+  <manifest>${manifest}</manifest>
+  <spine><itemref idref="p1"/></spine>
+</package>`
+
+  return archiveWith(
+    [
+      textRecord(`${prefix}content.opf`, opf),
+      textRecord(`${prefix}page1.xhtml`, `<html/>`),
+      textRecord(`${prefix}cover.jpg`, ``, { encodingFormat: `image/jpeg` }),
+    ],
+    `book.epub`,
+  )
+}
+
+describe(`Given an EPUB with an OPF cover`, () => {
+  it(`resolves the EPUB 3 cover-image item, rebased onto the base path`, async () => {
+    const archive = epubWith(
+      `<item id="c" href="cover.jpg" media-type="image/jpeg" properties="cover-image"/>` +
+        `<item id="p1" href="page1.xhtml" media-type="application/xhtml+xml"/>`,
+    )
+
+    expect(await resolveArchiveCover(archive)).toEqual({
+      uri: `OEBPS/cover.jpg`,
+      mediaType: `image/jpeg`,
+      confidence: `derived`,
+    })
+  })
+
+  it(`resolves the EPUB 2 <meta name="cover"> convention`, async () => {
+    const archive = epubWith(
+      `<item id="cover-img" href="cover.jpg" media-type="image/jpeg"/>` +
+        `<item id="p1" href="page1.xhtml" media-type="application/xhtml+xml"/>`,
+      `<meta name="cover" content="cover-img"/>`,
+    )
+
+    expect(await resolveArchiveCover(archive)).toEqual({
+      uri: `OEBPS/cover.jpg`,
+      mediaType: `image/jpeg`,
+      confidence: `derived`,
+    })
+  })
+
+  it(`does not prefix a base path when the OPF sits at the root`, async () => {
+    const archive = epubWith(
+      `<item id="c" href="cover.jpg" media-type="image/jpeg" properties="cover-image"/>` +
+        `<item id="p1" href="page1.xhtml" media-type="application/xhtml+xml"/>`,
+      ``,
+      ``,
+    )
+
+    expect(await resolveArchiveCover(archive)).toEqual({
+      uri: `cover.jpg`,
+      mediaType: `image/jpeg`,
+      confidence: `derived`,
+    })
+  })
+})
+
+describe(`Given an EPUB whose OPF declares no cover`, () => {
+  it(`returns undefined rather than promoting an interior image`, async () => {
+    const archive = epubWith(
+      `<item id="p1" href="page1.xhtml" media-type="application/xhtml+xml"/>` +
+        `<item id="i" href="cover.jpg" media-type="image/jpeg"/>`,
+    )
+
+    expect(await resolveArchiveCover(archive)).toBeUndefined()
+  })
+})
+
+describe(`Given a package-less container`, () => {
+  it(`falls back to the first reading-order resource, sidecars excluded`, async () => {
+    const archive = archiveWith(
+      [
+        textRecord(`ComicInfo.xml`, `<?xml version="1.0"?><ComicInfo/>`),
+        textRecord(`page_001.jpg`, ``, { encodingFormat: `image/jpeg` }),
+        textRecord(`page_002.jpg`, ``, { encodingFormat: `image/jpeg` }),
+      ],
+      `comic.cbz`,
+    )
+
+    expect(await resolveArchiveCover(archive)).toEqual({
+      uri: `page_001.jpg`,
+      mediaType: `image/jpeg`,
+      confidence: `assumed`,
+    })
+  })
+
+  it(`returns undefined for an empty container`, async () => {
+    expect(await resolveArchiveCover(archiveWith([]))).toBeUndefined()
+  })
+})
+
+describe(`Given a malformed OPF`, () => {
+  it(`degrades to the first-page fallback rather than throwing`, async () => {
+    const archive = archiveWith(
+      [
+        // mismatched close tag: parseOpf's XmlDocument rejects it, so the opf
+        // read throws and the cover degrades to the file-listing fallback
+        textRecord(
+          `content.opf`,
+          `<?xml version="1.0"?><package><spine></package>`,
+        ),
+        textRecord(`page_001.jpg`, ``, { encodingFormat: `image/jpeg` }),
+      ],
+      `book.epub`,
+    )
+
+    expect(await resolveArchiveCover(archive)).toEqual({
+      uri: `content.opf`,
+      confidence: `assumed`,
+    })
+  })
+})
+
+describe(`Given an already parsed opf`, () => {
+  it(`uses it without re-reading the archive`, async () => {
+    const archive = epubWith(
+      `<item id="c" href="cover.jpg" media-type="image/jpeg" properties="cover-image"/>` +
+        `<item id="p1" href="page1.xhtml" media-type="application/xhtml+xml"/>`,
+    )
+    const opf = await readArchiveOpf(archive)
+
+    expect(await resolveArchiveCover(archive, { opf })).toEqual({
+      uri: `OEBPS/cover.jpg`,
+      mediaType: `image/jpeg`,
+      confidence: `derived`,
+    })
+  })
+})

--- a/packages/archive-reader/src/cover/resolveArchiveCover.ts
+++ b/packages/archive-reader/src/cover/resolveArchiveCover.ts
@@ -71,14 +71,20 @@ export const resolveArchiveCover = async (
   }
 
   const order = readingOrder ?? (await resolveArchiveReadingOrder(archive))
-  const first = order[0]
 
-  if (first === undefined) return undefined
+  // a cover is an image: the first-page convention only holds for image
+  // content, so skip audio/video reading orders (a package-less audiobook or
+  // video archive starts with a track that must not be published as a cover)
+  const firstImage = order.find(
+    (item) => item.mediaType?.startsWith("image/") === true,
+  )
+
+  if (firstImage === undefined) return undefined
 
   // the reading order already computed the media type the same way
   return omitUndefined({
-    uri: first.uri,
-    mediaType: first.mediaType,
+    uri: firstImage.uri,
+    mediaType: firstImage.mediaType,
     confidence: "assumed" as const,
   })
 }

--- a/packages/archive-reader/src/cover/resolveArchiveCover.ts
+++ b/packages/archive-reader/src/cover/resolveArchiveCover.ts
@@ -56,12 +56,9 @@ export const resolveArchiveCover = async (
   const archiveOpf =
     opf ?? (await readArchiveOpf(archive).catch(() => undefined))
 
-  if (archiveOpf !== undefined) {
-    const coverHref = archiveOpf.opf.coverHref
-
-    if (coverHref === undefined) return undefined
-
-    const uri = toContainerUri(coverHref, archiveOpf.basePath)
+  // 1. an OPF-declared cover is authoritative.
+  if (archiveOpf !== undefined && archiveOpf.opf.coverHref !== undefined) {
+    const uri = toContainerUri(archiveOpf.opf.coverHref, archiveOpf.basePath)
 
     return omitUndefined({
       uri,
@@ -70,11 +67,17 @@ export const resolveArchiveCover = async (
     })
   }
 
-  const order = readingOrder ?? (await resolveArchiveReadingOrder(archive))
-
-  // a cover is an image: the first-page convention only holds for image
-  // content, so skip audio/video reading orders (a package-less audiobook or
-  // video archive starts with a track that must not be published as a cover)
+  // 2. no declared cover — assume the first image of the reading order. This
+  // holds whether or not a package document exists: an authored reflowable
+  // EPUB has a text spine with no image items, so it stays undefined rather
+  // than promoting an interior illustration (a manifest resource, not a spine
+  // item); only image-content publications resolve a cover here — comics,
+  // image archives, and synthetic image-spine OPFs (e.g. createArchiveFromUrls
+  // lists, whose generated OPF carries no cover marker). Audio/video are
+  // pre-paginated discrete media but not images, so they are skipped too.
+  const order =
+    readingOrder ??
+    (await resolveArchiveReadingOrder(archive, { opf: archiveOpf }))
   const firstImage = order.find(
     (item) => item.mediaType?.startsWith("image/") === true,
   )

--- a/packages/archive-reader/src/cover/resolveArchiveCover.ts
+++ b/packages/archive-reader/src/cover/resolveArchiveCover.ts
@@ -1,0 +1,84 @@
+import { detectMimeTypeFromName, parseContentType } from "@prose-reader/shared"
+import type { Archive } from "../archives/types"
+import { getArchiveFileRecordByUri } from "../archives/types"
+import type { ArchiveOpfParsed } from "../opf/readArchiveOpf"
+import { readArchiveOpf } from "../opf/readArchiveOpf"
+import type { ArchiveReadingOrderItem } from "../readingOrder/resolveArchiveReadingOrder"
+import { resolveArchiveReadingOrder } from "../readingOrder/resolveArchiveReadingOrder"
+import type { ResolvedCover } from "../types/resolvedMetadata"
+import { omitUndefined } from "../utils/omitUndefined"
+import { toContainerUri } from "../utils/toContainerUri"
+
+const mediaTypeForUri = (archive: Archive, uri: string): string | undefined => {
+  const record = getArchiveFileRecordByUri(archive, uri)
+
+  if (record === undefined) return undefined
+
+  return (
+    parseContentType(record.encodingFormat ?? "") ||
+    detectMimeTypeFromName(record.basename)
+  )
+}
+
+/**
+ * Resolves the publication's cover resource.
+ *
+ * Resolution order:
+ *
+ *  1. **OPF cover** — the manifest cover image (`cover-image` property, the
+ *     EPUB 2 `<meta name="cover">` convention, or a `cover`-ish image id; see
+ *     {@link OpfMetadata.coverHref}), rebased onto the package document's base
+ *     path. A package document that declares no cover is authoritative: no
+ *     interior image is promoted to cover, so the result is `undefined`.
+ *  2. **Package-less containers** (CBZ, folder of images, URL list) — the
+ *     first reading-order resource, the conventional first page. Sidecars and
+ *     OS litter are already excluded from the reading order, so this never
+ *     picks `ComicInfo.xml` or `Thumbs.db`.
+ *
+ * `undefined` when neither applies (an empty container, or an OPF without a
+ * declared cover). Costs one OPF read at most — pass an already parsed `opf`
+ * and/or the already resolved `readingOrder` to skip the internal lookups
+ * (e.g. alongside `resolveArchive`).
+ */
+export const resolveArchiveCover = async (
+  archive: Archive,
+  {
+    opf,
+    readingOrder,
+  }: {
+    opf?: ArchiveOpfParsed
+    readingOrder?: ArchiveReadingOrderItem[]
+  } = {},
+): Promise<ResolvedCover | undefined> => {
+  // A malformed package document is treated as no package document, mirroring
+  // resolveArchiveReadingOrder: the cover degrades to the first-page fallback
+  // rather than throwing (books in the wild are dirty).
+  const archiveOpf =
+    opf ?? (await readArchiveOpf(archive).catch(() => undefined))
+
+  if (archiveOpf !== undefined) {
+    const coverHref = archiveOpf.opf.coverHref
+
+    if (coverHref === undefined) return undefined
+
+    const uri = toContainerUri(coverHref, archiveOpf.basePath)
+
+    return omitUndefined({
+      uri,
+      mediaType: mediaTypeForUri(archive, uri),
+      confidence: "derived" as const,
+    })
+  }
+
+  const order = readingOrder ?? (await resolveArchiveReadingOrder(archive))
+  const first = order[0]
+
+  if (first === undefined) return undefined
+
+  // the reading order already computed the media type the same way
+  return omitUndefined({
+    uri: first.uri,
+    mediaType: first.mediaType,
+    confidence: "assumed" as const,
+  })
+}

--- a/packages/archive-reader/src/index.ts
+++ b/packages/archive-reader/src/index.ts
@@ -55,6 +55,7 @@ export {
 } from "./comicInfo/parse"
 export { readArchiveComicInfo } from "./comicInfo/readArchiveComicInfo"
 export { comicInfoMetadataHomes } from "./comicInfo/resolve"
+export { resolveArchiveCover } from "./cover/resolveArchiveCover"
 export type { KoboMetadata } from "./kobo/parse"
 export { KOBO_DISPLAY_OPTIONS_FILENAME, parseKoboXml } from "./kobo/parse"
 export { readArchiveKobo } from "./kobo/readArchiveKobo"
@@ -95,8 +96,10 @@ export type {
   ResolvedAppleMetadata,
   ResolvedCollection,
   ResolvedComicMetadata,
+  ResolvedConfidence,
   ResolvedContributor,
   ResolvedContributorRole,
+  ResolvedCover,
   ResolvedDate,
   ResolvedKoboMetadata,
   ResolvedMetadata,

--- a/packages/archive-reader/src/readingOrder/resolveArchiveReadingOrder.test.ts
+++ b/packages/archive-reader/src/readingOrder/resolveArchiveReadingOrder.test.ts
@@ -85,6 +85,25 @@ describe(`Given an EPUB with the OPF in a subfolder`, () => {
       await resolveArchiveReadingOrder(archive),
     )
   })
+
+  it(`should resolve dot segments in spine hrefs against the OPF directory`, async () => {
+    const nestedOpf = `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <manifest>
+    <item id="p1" href="../Text/page1.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine><itemref idref="p1"/></spine>
+</package>`
+
+    const archive = archiveWith([
+      textRecord(`OEBPS/OPF/content.opf`, nestedOpf),
+      textRecord(`OEBPS/Text/page1.xhtml`, ``, { size: 100 }),
+    ])
+
+    expect(
+      (await resolveArchiveReadingOrder(archive)).map((item) => item.uri),
+    ).toEqual([`OEBPS/Text/page1.xhtml`])
+  })
 })
 
 describe(`Given an EPUB whose spine records are missing sizes`, () => {

--- a/packages/archive-reader/src/readingOrder/resolveArchiveReadingOrder.ts
+++ b/packages/archive-reader/src/readingOrder/resolveArchiveReadingOrder.ts
@@ -11,6 +11,7 @@ import { KOBO_DISPLAY_OPTIONS_FILENAME } from "../kobo/parse"
 import type { ArchiveOpfParsed } from "../opf/readArchiveOpf"
 import { readArchiveOpf } from "../opf/readArchiveOpf"
 import { omitUndefined } from "../utils/omitUndefined"
+import { toContainerUri } from "../utils/toContainerUri"
 
 /**
  * One resource of the publication's default reading sequence, in the
@@ -57,15 +58,6 @@ const validatedPackageLayout = (
   return v === "reflowable" || v === "pre-paginated" ? v : undefined
 }
 
-const containerUriForSpineHref = (
-  href: string,
-  opfBasePath: string,
-): string => {
-  // absolute URLs (the URL-list pseudo-archives) are their own record uri
-  if (/^https?:\/\//.test(href)) return href
-  return opfBasePath ? `${opfBasePath}/${href}` : href
-}
-
 const readingOrderFromOpf = (
   archive: Archive,
   { opf, basePath }: ArchiveOpfParsed,
@@ -73,7 +65,7 @@ const readingOrderFromOpf = (
   const packageLayout = validatedPackageLayout(opf.renditionLayoutMeta)
 
   const rows = opf.spineRows.map((row) => {
-    const uri = containerUriForSpineHref(row.href, basePath)
+    const uri = toContainerUri(row.href, basePath)
     const record = getArchiveFileRecordByUri(archive, uri)
 
     return { row, uri, record }

--- a/packages/archive-reader/src/resolveArchive.test.ts
+++ b/packages/archive-reader/src/resolveArchive.test.ts
@@ -199,8 +199,12 @@ describe(`Given an EPUB with a malformed OPF`, () => {
   it(`should swallow the parse error and keep resolving`, async () => {
     const resolved = await resolveArchive(malformedOpfArchive())
 
-    // the malformed OPF does not contribute
-    expect(resolved.metadata).toEqual({})
+    // the malformed OPF contributes no descriptive metadata; with no package
+    // document the cover degrades (assumed) to the first file-listing entry,
+    // same as the reading order below. No pre-paginated pages → no page count.
+    expect(resolved.metadata).toEqual({
+      cover: { uri: `OEBPS/content.opf`, confidence: `assumed` },
+    })
     // reading order degrades to the file listing rather than failing the
     // resolve — the whole point of the lenient per-source policy
     expect(resolved.readingOrder.map((item) => item.uri)).toEqual([
@@ -298,6 +302,14 @@ describe(`Given a CBZ with a ComicInfo sidecar`, () => {
 
     expect(resolved.metadata).toEqual({
       title: `Vol 1`,
+      // resolved for the whole archive: the cover is the first page (assumed,
+      // the sidecar declared none) and the page count is the image count
+      cover: {
+        uri: `page_001.jpg`,
+        mediaType: `image/jpeg`,
+        confidence: `assumed`,
+      },
+      numberOfPages: 2,
       readingDirection: `rtl`,
       contributors: [{ name: `Jane Author`, roles: [`author`] }],
       belongsTo: { series: [{ name: `My Comics`, position: 3 }] },
@@ -326,7 +338,16 @@ describe(`Given a CBZ with a ComicInfo sidecar`, () => {
   it(`should swallow a malformed sidecar and keep resolving`, async () => {
     const resolved = await resolveArchive(comicArchive(`not xml`))
 
-    expect(resolved.metadata).toEqual({})
+    // the malformed sidecar contributes no descriptive metadata; the cover
+    // and page count still resolve from the container itself
+    expect(resolved.metadata).toEqual({
+      cover: {
+        uri: `page_001.jpg`,
+        mediaType: `image/jpeg`,
+        confidence: `assumed`,
+      },
+      numberOfPages: 2,
+    })
     expect(resolved.readingOrder).toHaveLength(2)
   })
 })
@@ -380,5 +401,110 @@ describe(`Given a folder comic`, () => {
         contents: [],
       },
     ])
+  })
+})
+
+describe(`Given the cover in metadata`, () => {
+  const epubWithCover = () =>
+    archiveWith(
+      [
+        textRecord(
+          `OEBPS/content.opf`,
+          `<?xml version="1.0"?><package xmlns="http://www.idpf.org/2007/opf" version="3.0">` +
+            `<metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:title>x</dc:title></metadata>` +
+            `<manifest>` +
+            `<item id="c" href="cover.jpg" media-type="image/jpeg" properties="cover-image"/>` +
+            `<item id="p1" href="p1.xhtml" media-type="application/xhtml+xml"/>` +
+            `</manifest><spine><itemref idref="p1"/></spine></package>`,
+        ),
+        textRecord(`OEBPS/p1.xhtml`, xhtml(false)),
+        textRecord(`OEBPS/cover.jpg`, ``, { encodingFormat: `image/jpeg` }),
+      ],
+      `book.epub`,
+    )
+
+  it(`rides along with metadata in the default projection`, async () => {
+    const resolved = await resolveArchive(epubWithCover())
+
+    expect(resolved.metadata.cover).toEqual({
+      uri: `OEBPS/cover.jpg`,
+      mediaType: `image/jpeg`,
+      confidence: `derived`,
+    })
+  })
+
+  it(`marks an OPF-declared cover as derived, for a metadata-only projection`, async () => {
+    const resolved = await resolveArchive(epubWithCover(), {
+      include: [`metadata`],
+    })
+
+    expect(resolved.metadata.cover).toEqual({
+      uri: `OEBPS/cover.jpg`,
+      mediaType: `image/jpeg`,
+      confidence: `derived`,
+    })
+  })
+
+  it(`falls back to the first page (assumed) for a package-less container`, async () => {
+    const archive = archiveWith(
+      [
+        textRecord(`ComicInfo.xml`, `<?xml version="1.0"?><ComicInfo/>`),
+        textRecord(`page_001.jpg`, ``, { encodingFormat: `image/jpeg` }),
+        textRecord(`page_002.jpg`, ``, { encodingFormat: `image/jpeg` }),
+      ],
+      `comic.cbz`,
+    )
+
+    // metadata-only, no readingOrder token: the fallback still resolves
+    // because metadata derives the cover from the container itself
+    const resolved = await resolveArchive(archive, { include: [`metadata`] })
+
+    expect(resolved.metadata.cover).toEqual({
+      uri: `page_001.jpg`,
+      mediaType: `image/jpeg`,
+      confidence: `assumed`,
+    })
+  })
+})
+
+describe(`Given the numberOfPages in metadata`, () => {
+  const comic = (records: ReturnType<typeof textRecord>[]) =>
+    archiveWith(records, `comic.cbz`)
+
+  it(`counts the pre-paginated pages of a package-less container`, async () => {
+    const resolved = await resolveArchive(
+      comic([
+        textRecord(`page_001.jpg`, ``, { encodingFormat: `image/jpeg` }),
+        textRecord(`page_002.jpg`, ``, { encodingFormat: `image/jpeg` }),
+        textRecord(`page_003.jpg`, ``, { encodingFormat: `image/jpeg` }),
+      ]),
+      { include: [`metadata`] },
+    )
+
+    expect(resolved.metadata.numberOfPages).toBe(3)
+  })
+
+  it(`prefers a declared ComicInfo PageCount over the counted pages`, async () => {
+    const resolved = await resolveArchive(
+      comic([
+        textRecord(
+          `ComicInfo.xml`,
+          `<?xml version="1.0"?><ComicInfo><PageCount>48</PageCount></ComicInfo>`,
+        ),
+        textRecord(`page_001.jpg`, ``, { encodingFormat: `image/jpeg` }),
+        textRecord(`page_002.jpg`, ``, { encodingFormat: `image/jpeg` }),
+      ]),
+      { include: [`metadata`] },
+    )
+
+    expect(resolved.metadata.numberOfPages).toBe(48)
+  })
+
+  it(`leaves it absent for a reflowable EPUB`, async () => {
+    const resolved = await resolveArchive(epubArchive(), {
+      include: [`metadata`],
+    })
+
+    expect(resolved.metadata.numberOfPages).toBeUndefined()
   })
 })

--- a/packages/archive-reader/src/resolveArchive.test.ts
+++ b/packages/archive-reader/src/resolveArchive.test.ts
@@ -505,4 +505,35 @@ describe(`Given the numberOfPages in metadata`, () => {
 
     expect(resolved.metadata.numberOfPages).toBeUndefined()
   })
+
+  it(`does not count audio/video tracks as pages`, async () => {
+    const resolved = await resolveArchive(
+      archiveWith(
+        [
+          textRecord(`track01.mp3`, ``, { encodingFormat: `audio/mpeg` }),
+          textRecord(`track02.mp3`, ``, { encodingFormat: `audio/mpeg` }),
+        ],
+        `audiobook.zip`,
+      ),
+      { include: [`metadata`] },
+    )
+
+    expect(resolved.metadata.numberOfPages).toBeUndefined()
+  })
+
+  it(`counts only the page-like items in a mixed archive`, async () => {
+    const resolved = await resolveArchive(
+      archiveWith(
+        [
+          textRecord(`narration.mp3`, ``, { encodingFormat: `audio/mpeg` }),
+          textRecord(`page_001.jpg`, ``, { encodingFormat: `image/jpeg` }),
+          textRecord(`page_002.jpg`, ``, { encodingFormat: `image/jpeg` }),
+        ],
+        `mixed.zip`,
+      ),
+      { include: [`metadata`] },
+    )
+
+    expect(resolved.metadata.numberOfPages).toBe(2)
+  })
 })

--- a/packages/archive-reader/src/resolveArchive.test.ts
+++ b/packages/archive-reader/src/resolveArchive.test.ts
@@ -199,12 +199,10 @@ describe(`Given an EPUB with a malformed OPF`, () => {
   it(`should swallow the parse error and keep resolving`, async () => {
     const resolved = await resolveArchive(malformedOpfArchive())
 
-    // the malformed OPF contributes no descriptive metadata; with no package
-    // document the cover degrades (assumed) to the first file-listing entry,
-    // same as the reading order below. No pre-paginated pages → no page count.
-    expect(resolved.metadata).toEqual({
-      cover: { uri: `OEBPS/content.opf`, confidence: `assumed` },
-    })
+    // the malformed OPF contributes no descriptive metadata, and the file
+    // listing holds no image (only the .opf and .xhtml docs), so no cover is
+    // assumed and there are no pre-paginated pages to count
+    expect(resolved.metadata).toEqual({})
     // reading order degrades to the file listing rather than failing the
     // resolve — the whole point of the lenient per-source policy
     expect(resolved.readingOrder.map((item) => item.uri)).toEqual([

--- a/packages/archive-reader/src/resolveArchive.ts
+++ b/packages/archive-reader/src/resolveArchive.ts
@@ -3,6 +3,7 @@ import { readArchiveApple } from "./apple/readArchiveApple"
 import type { Archive } from "./archives/types"
 import type { ComicInfo } from "./comicInfo/parse"
 import { readArchiveComicInfo } from "./comicInfo/readArchiveComicInfo"
+import { resolveArchiveCover } from "./cover/resolveArchiveCover"
 import type { KoboMetadata } from "./kobo/parse"
 import { readArchiveKobo } from "./kobo/readArchiveKobo"
 import { readingOrderDocumentsAllHaveViewport } from "./layout/scanReadingOrderDocumentsViewport"
@@ -51,7 +52,11 @@ export type ResolvedArchive = {
    * bump it.
    */
   readonly version: number
-  /** Cross-format normalized metadata (see {@link ResolvedMetadata}). */
+  /**
+   * Cross-format normalized metadata (see {@link ResolvedMetadata}),
+   * including the resolved `cover` — metadata is resolved for the whole
+   * container, not just its descriptive sidecars.
+   */
   readonly metadata: ResolvedMetadata
   readonly readingOrder: ArchiveReadingOrderItem[]
   /**
@@ -67,14 +72,18 @@ export type ResolvedArchive = {
  * Projection tokens are simply the keys of the result. Cost classes:
  *
  * - `metadata`, `sources`: sidecar XML reads (OPF, ComicInfo.xml,
- *   Apple/Kobo display options) — cheap.
+ *   Apple/Kobo display options) — cheap. `metadata` also derives the cover:
+ *   free for an OPF cover, and for a package-less container it computes the
+ *   reading-order listing (an in-memory records scan) for the first-page
+ *   fallback.
  * - `readingOrder`: the OPF read at most — cheap.
  * - `toc`: one nav or NCX document read+parse on top — medium.
  * - `version`: free, and always present regardless of projection.
  *
  * The default (`metadata`, `readingOrder`, `toc`) costs O(sidecar files) +
  * one navigation document: anything that reads the whole book is opt-in
- * (see `layoutScan`).
+ * (see `layoutScan`). `sources` is opt-in too — it rides for free on the
+ * reads its neighbors already do.
  */
 export type ResolveArchiveToken = keyof ResolvedArchive
 
@@ -118,6 +127,22 @@ const safeRead = async <T>(
   }
 }
 
+/**
+ * The counted page count: one page per pre-paginated reading-order item
+ * (comics, image archives, fixed layout). Reflowable documents are not
+ * pre-paginated, so a reflowable publication counts zero here and its page
+ * count stays absent — a document count is not a page count.
+ */
+const countPrePaginatedPages = (
+  readingOrder: ArchiveReadingOrderItem[],
+): number | undefined => {
+  const count = readingOrder.filter(
+    (item) => item.renditionLayout === "pre-paginated",
+  ).length
+
+  return count > 0 ? count : undefined
+}
+
 const RESOLVED_ARCHIVE_VERSION = 1
 
 /**
@@ -131,8 +156,16 @@ const RESOLVED_ARCHIVE_VERSION = 1
  * ```ts
  * const { metadata, readingOrder, toc } = await resolveArchive(archive)
  *
- * // library-shelf scan: metadata only, skip the toc read
+ * // library-shelf scan: metadata (incl. cover) only, skip the toc read
  * const { metadata } = await resolveArchive(archive, { include: ["metadata"] })
+ * renderShelfItem({ title: metadata.title, cover: metadata.cover?.uri })
+ *
+ * // your own per-source precedence via the raw sources escape hatch
+ * // (resolveArchiveMetadata normalizes a single source at a time)
+ * const { sources } = await resolveArchive(archive, { include: ["sources"] })
+ * const opf = sources.opf && resolveArchiveMetadata(sources.opf.opf)
+ * const comicInfo = sources.comicInfo && resolveArchiveMetadata(sources.comicInfo)
+ * const isbn = comicInfo?.isbn ?? opf?.isbn // ComicInfo wins, your call
  *
  * // full fidelity, including the O(book) layout refinement
  * const resolved = await resolveArchive(archive, {
@@ -204,6 +237,24 @@ export const resolveArchive = async <
       ...item,
       renditionLayout: "pre-paginated" as const,
     }))
+  }
+
+  // cover and the counted page count are part of the resolved metadata but
+  // are container-level derivations (basePath join, first-page fallback, page
+  // counting), so they are resolved here where the archive is available and
+  // folded into `metadata`. After the scan so both ride the finalized reading
+  // order (its layout drives the page count, and the scan can promote it).
+  if (wantsMetadata && metadata !== undefined) {
+    const order =
+      readingOrder ?? (await resolveArchiveReadingOrder(archive, { opf }))
+    const cover = await resolveArchiveCover(archive, {
+      opf,
+      readingOrder: order,
+    })
+    const numberOfPages =
+      metadata.numberOfPages ?? countPrePaginatedPages(order)
+
+    metadata = omitUndefined({ ...metadata, cover, numberOfPages })
   }
 
   const toc = wantsToc

--- a/packages/archive-reader/src/resolveArchive.ts
+++ b/packages/archive-reader/src/resolveArchive.ts
@@ -128,16 +128,24 @@ const safeRead = async <T>(
 }
 
 /**
- * The counted page count: one page per pre-paginated reading-order item
- * (comics, image archives, fixed layout). Reflowable documents are not
- * pre-paginated, so a reflowable publication counts zero here and its page
- * count stays absent — a document count is not a page count.
+ * The counted page count: one page per pre-paginated *page-like* reading-order
+ * item — an image or a fixed-layout document (comics, image archives, fixed
+ * layout). Reflowable documents are not pre-paginated, so they never count.
+ * Audio and video are pre-paginated discrete media too, but a track or clip is
+ * not a page, so they are excluded — an audiobook or video archive has no page
+ * count. Absent when nothing page-like is present.
  */
-const countPrePaginatedPages = (
+const countPages = (
   readingOrder: ArchiveReadingOrderItem[],
 ): number | undefined => {
+  const isAudioOrVideo = (mediaType: string | undefined): boolean =>
+    mediaType?.startsWith("audio/") === true ||
+    mediaType?.startsWith("video/") === true
+
   const count = readingOrder.filter(
-    (item) => item.renditionLayout === "pre-paginated",
+    (item) =>
+      item.renditionLayout === "pre-paginated" &&
+      !isAudioOrVideo(item.mediaType),
   ).length
 
   return count > 0 ? count : undefined
@@ -251,8 +259,7 @@ export const resolveArchive = async <
       opf,
       readingOrder: order,
     })
-    const numberOfPages =
-      metadata.numberOfPages ?? countPrePaginatedPages(order)
+    const numberOfPages = metadata.numberOfPages ?? countPages(order)
 
     metadata = omitUndefined({ ...metadata, cover, numberOfPages })
   }

--- a/packages/archive-reader/src/types/resolvedMetadata.ts
+++ b/packages/archive-reader/src/types/resolvedMetadata.ts
@@ -156,11 +156,57 @@ export type ResolvedKoboMetadata = {
 }
 
 /**
+ * How sure the resolver is about a value it produced:
+ *
+ * - `derived` — the container states it outright *or* it is computed from the
+ *   container's actual content (e.g. an OPF-declared cover, a page count read
+ *   from ComicInfo or counted from the pages). A value we know.
+ * - `assumed` — the container does not state it and it cannot be computed, so
+ *   the resolver applies a sensible convention. A best-effort opinion the
+ *   consumer may want to flag, or let the user confirm.
+ *
+ * Only carried on fields that actually have an `assumed` path; fields that are
+ * always `derived` (or always absent when unknown) do not carry it.
+ */
+export type ResolvedConfidence = "derived" | "assumed"
+
+/**
+ * The publication's cover image, addressed in the container's coordinate
+ * space (a record `uri` — rebase into your own serving space, like reading
+ * order uris). Determining it needs the container, not just the descriptive
+ * sidecars, so it is only populated by `resolveArchive`.
+ */
+export type ResolvedCover = {
+  readonly uri: string
+  /**
+   * Best-effort media type of the cover resource, from the archive record's
+   * encoding format when known, else detected from the filename. Absent when
+   * neither yields one.
+   */
+  readonly mediaType?: string
+  /**
+   * `derived` when the OPF references this image as the cover; `assumed` when
+   * the archive declares none and this is the package-less first-page
+   * convention. See {@link ResolvedConfidence}.
+   */
+  readonly confidence: ResolvedConfidence
+}
+
+/**
  * @see module doc above for design rules.
  */
 export type ResolvedMetadata = {
   /** Human-readable title of the work. OPF `dc:title`, ComicInfo `Title`. */
   readonly title?: string
+  /**
+   * The publication's cover image: the OPF-declared cover (EPUB 3
+   * `cover-image` property, the EPUB 2 `<meta name="cover">` convention, or a
+   * `cover`-ish image id), else the first page of a package-less container
+   * (CBZ, folder of images). Resolved against the container, so it is
+   * populated by `resolveArchive` and left absent by the source-level
+   * resolvers, which never see the file listing. See {@link ResolvedCover}.
+   */
+  readonly cover?: ResolvedCover
   /** OPF `dc:description`, ComicInfo `Summary`. */
   readonly description?: string
   /** OPF first non-empty `dc:publisher`, ComicInfo `Publisher`. */
@@ -207,7 +253,14 @@ export type ResolvedMetadata = {
     | "auto"
   /** OPF `rendition:spread` meta, validated values only (no defaulting here). */
   readonly renditionSpread?: "none" | "landscape" | "portrait" | "both" | "auto"
-  /** ComicInfo `PageCount`, when numeric (schema.org `numberOfPages`). */
+  /**
+   * Number of pages (schema.org `numberOfPages`). ComicInfo `PageCount` when
+   * declared, else — for a pre-paginated publication (comics, image
+   * archives, fixed layout) — the count of pre-paginated pages in the
+   * reading order. Absent for reflowable publications, where a document
+   * count is not a page count. Counting needs the container, so the counted
+   * value is only populated by `resolveArchive`.
+   */
   readonly numberOfPages?: number
   /** Digits-only GTIN when a source identifier matches a GS1 length (8/12/13/14). */
   readonly gtin?: string
@@ -244,8 +297,9 @@ export type ResolvedMetadata = {
  * Where a parsed source field lands: a {@link ResolvedMetadata} field
  * (dotted paths address the scoped corners), or a sibling part of the
  * resolved archive entity for structural fields (`readingOrder`, `toc`).
- * `cover` and `guide` are reserved homes for entity parts that only exist
- * as raw `sources` today — tracked, not yet promoted.
+ * `guide` is a reserved home for an entity part that only exists as raw
+ * `sources` today — tracked, not yet promoted. (`cover` used to be reserved
+ * here too; it is now the {@link ResolvedMetadata.cover} field.)
  *
  * Used by the per-format mapping tables (`opfMetadataHomes`,
  * `comicInfoMetadataHomes`, …) that compile-enforce the losslessness rule:
@@ -259,5 +313,4 @@ export type ResolvedMetadataHome =
   | `belongsTo.${"series" | "collection"}`
   | "readingOrder"
   | "toc"
-  | "cover"
   | "guide"

--- a/packages/archive-reader/src/types/resolvedMetadata.ts
+++ b/packages/archive-reader/src/types/resolvedMetadata.ts
@@ -255,11 +255,12 @@ export type ResolvedMetadata = {
   readonly renditionSpread?: "none" | "landscape" | "portrait" | "both" | "auto"
   /**
    * Number of pages (schema.org `numberOfPages`). ComicInfo `PageCount` when
-   * declared, else — for a pre-paginated publication (comics, image
-   * archives, fixed layout) — the count of pre-paginated pages in the
-   * reading order. Absent for reflowable publications, where a document
-   * count is not a page count. Counting needs the container, so the counted
-   * value is only populated by `resolveArchive`.
+   * declared, else the count of page-like reading-order items — images and
+   * fixed-layout documents (comics, image archives, fixed layout). Reflowable
+   * documents are not pages, and audio/video tracks are not pages either, so
+   * both are excluded; a reflowable book or an audiobook has no page count.
+   * Counting needs the container, so the counted value is only populated by
+   * `resolveArchive`.
    */
   readonly numberOfPages?: number
   /** Digits-only GTIN when a source identifier matches a GS1 length (8/12/13/14). */

--- a/packages/archive-reader/src/utils/toContainerUri.ts
+++ b/packages/archive-reader/src/utils/toContainerUri.ts
@@ -1,0 +1,12 @@
+/**
+ * Rebases an OPF manifest-relative `href` (spine item, cover image…) onto the
+ * package document's `basePath` to produce a container-relative uri — the
+ * coordinate space every resolved archive part addresses. Absolute http(s)
+ * urls (the URL-list pseudo-archives author these) are their own record uri
+ * and pass through untouched.
+ */
+export const toContainerUri = (href: string, basePath: string): string => {
+  if (/^https?:\/\//.test(href)) return href
+
+  return basePath ? `${basePath}/${href}` : href
+}

--- a/packages/archive-reader/src/utils/toContainerUri.ts
+++ b/packages/archive-reader/src/utils/toContainerUri.ts
@@ -1,12 +1,37 @@
 /**
+ * Resolves the `.`/`..` segments of a container path (RFC 3986 §5.2.4
+ * "remove dot segments"), so a manifest href authored relative to a nested
+ * package document lands on the real record uri. Operates on the raw path
+ * (no percent-decoding) so the result still matches the archive's record uris
+ * verbatim. A `..` past the root is clamped, matching URL resolution.
+ */
+const removeDotSegments = (path: string): string => {
+  const out: string[] = []
+
+  for (const segment of path.split("/")) {
+    if (segment === ".") continue
+    if (segment === "..") {
+      out.pop()
+      continue
+    }
+    out.push(segment)
+  }
+
+  return out.join("/")
+}
+
+/**
  * Rebases an OPF manifest-relative `href` (spine item, cover image…) onto the
  * package document's `basePath` to produce a container-relative uri — the
- * coordinate space every resolved archive part addresses. Absolute http(s)
- * urls (the URL-list pseudo-archives author these) are their own record uri
- * and pass through untouched.
+ * coordinate space every resolved archive part addresses. The href is a
+ * relative reference resolved against the package document's directory, so
+ * dot segments are collapsed (`OEBPS/Text` + `../Images/cover.jpg` →
+ * `OEBPS/Images/cover.jpg`), not concatenated verbatim. Absolute http(s) urls
+ * (the URL-list pseudo-archives author these) are their own record uri and
+ * pass through untouched.
  */
 export const toContainerUri = (href: string, basePath: string): string => {
   if (/^https?:\/\//.test(href)) return href
 
-  return basePath ? `${basePath}/${href}` : href
+  return removeDotSegments(basePath ? `${basePath}/${href}` : href)
 }


### PR DESCRIPTION
## What

Makes `resolveArchive` the single call that yields everything needed to present a book, so consumers don't re-parse or re-compose the archive. Two things that could only be reconstructed by hand before are now resolved for the whole container and folded into `metadata`:

- **`ResolvedMetadata.cover`** (`ResolvedCover = { uri, mediaType?, confidence }`) — the OPF-declared cover rebased onto the package base path, else the first page of a package-less container (CBZ / folder of images), else absent. Container-relative, like reading-order uris. A standalone `resolveArchiveCover(archive, { opf?, readingOrder? })` is exported too.
- **`ResolvedMetadata.numberOfPages`** — previously only the declared ComicInfo `<PageCount>`; now falls back to the count of pre-paginated reading-order pages (comics, image archives, fixed layout), and stays absent for reflowable publications where a document count is not a page count.

Supporting changes:

- **`ResolvedConfidence`** (`"derived" | "assumed"`) — flags whether a resolved value is known (declared or computed) or a best-effort convention. Carried on `cover` today (`derived` = OPF-declared, `assumed` = first-page fallback); `numberOfPages` is always `derived`, so it carries no flag. The vocabulary is shared and ready for a future field with an `assumed` path.
- Extracted `toContainerUri` (OPF href → container uri, absolute-url passthrough), now shared by the reading-order and cover resolvers.

`cover` was already a reserved-but-unpromoted home in `ResolvedMetadataHome`; this promotes it to a real field. Everything is additive — no existing field's shape or meaning changes incompatibly, so the `ResolvedArchive` version is unchanged.

## Design notes

- Cover and page count live **in `metadata`**, not as separate projection tokens: "resolve metadata" means resolve it *for the archive*, and cover/page-count are descriptive, display-facing facts about the book. They ride in the default projection.
- They're populated by `resolveArchive` (which sees the container), not by the source-level `resolveMetadata` / `resolveArchiveMetadata` (which only see parsed sidecars) — a genuine information boundary, not an implementation limit.

## Test plan

- `npx vitest run` — 218 passing (added cover-resolver, `numberOfPages`, and `resolveArchive` projection tests; updated the CBZ / malformed-source cases that now carry a resolved cover + page count).
- `npx tsc --noEmit` — clean.
- `biome check` — clean.
- `npm run build` — succeeds; generated `dist` types expose `ResolvedCover`, `ResolvedConfidence`, `resolveArchiveCover`, and `ResolvedMetadata.cover` / `numberOfPages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)