### PR TITLE
feat(archive-reader): image-record detection + fuller image formats

### DIFF
--- a/gitbook/archive-reader/README.md
+++ b/gitbook/archive-reader/README.md
@@ -51,6 +51,7 @@ A few rules of thumb:
 - **Bytes** come from `record.blob()` or `record.arrayBuffer()`.
 - **Text** is read with `readRecordAsText(record)` (it decodes `arrayBuffer()` as UTF‑8). There is intentionally no `string()` accessor, so decoding a binary record is always a deliberate act at the call site.
 - **Lookups** should go through `getArchiveFileRecordByUri(archive, uri)` (backed by `recordsByUri`) rather than scanning `archive.records`, since resource resolution is a per-fetch hot path.
+- **Images** are identified with `isImageRecord(record)` (an `image/*` media type, by encoding format or filename) and listed with `getArchiveImageRecords(archive)` — the page listing of a comic or image container.
 - Always build archives with `createArchive` (directly or via a creator) so `recordsByUri` is populated.
 
 {% hint style="info" %}

--- a/packages/archive-reader/src/archives/images.test.ts
+++ b/packages/archive-reader/src/archives/images.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest"
+import { createArchive } from "./createArchive"
+import { blobFileAccessors } from "./fileAccessors"
+import { getArchiveImageRecords, isImageRecord } from "./images"
+import type { ArchiveRecord } from "./types"
+
+const fileRecord = (
+  uri: string,
+  { encodingFormat }: { encodingFormat?: string } = {},
+): ArchiveRecord => ({
+  dir: false,
+  basename: uri.split(`/`).pop() ?? uri,
+  uri,
+  size: 0,
+  ...(encodingFormat !== undefined ? { encodingFormat } : {}),
+  ...blobFileAccessors(() => Promise.resolve(new Blob([]))),
+})
+
+const dirRecord = (uri: string): ArchiveRecord => ({
+  dir: true,
+  basename: uri.split(`/`).pop() ?? uri,
+  uri,
+})
+
+describe(`isImageRecord`, () => {
+  it(`detects an image by encoding format`, () => {
+    expect(
+      isImageRecord(fileRecord(`p1`, { encodingFormat: `image/avif` })),
+    ).toBe(true)
+  })
+
+  it(`detects an image by filename when the encoding format is absent`, () => {
+    // covers the raster formats detectMimeTypeFromName recognizes, including
+    // the ones it gained (gif/avif/bmp/tiff)
+    expect(isImageRecord(fileRecord(`page.gif`))).toBe(true)
+    expect(isImageRecord(fileRecord(`page.tiff`))).toBe(true)
+    expect(isImageRecord(fileRecord(`COVER.JPG`))).toBe(true)
+  })
+
+  it(`is false for non-image files and directories`, () => {
+    expect(isImageRecord(fileRecord(`chapter.xhtml`))).toBe(false)
+    expect(isImageRecord(fileRecord(`track.mp3`))).toBe(false)
+    expect(isImageRecord(fileRecord(`content.opf`))).toBe(false)
+    expect(isImageRecord(dirRecord(`Images`))).toBe(false)
+  })
+})
+
+describe(`getArchiveImageRecords`, () => {
+  it(`returns the image file records in record order, skipping the rest`, () => {
+    const archive = createArchive({
+      filename: `comic.cbz`,
+      records: [
+        dirRecord(`Images`),
+        fileRecord(`ComicInfo.xml`, { encodingFormat: `application/xml` }),
+        fileRecord(`Images/001.jpg`, { encodingFormat: `image/jpeg` }),
+        fileRecord(`Images/notes.txt`),
+        fileRecord(`Images/002.avif`),
+      ],
+      close: () => Promise.resolve(),
+    })
+
+    expect(getArchiveImageRecords(archive).map((record) => record.uri)).toEqual(
+      [`Images/001.jpg`, `Images/002.avif`],
+    )
+  })
+})

--- a/packages/archive-reader/src/archives/images.test.ts
+++ b/packages/archive-reader/src/archives/images.test.ts
@@ -30,10 +30,11 @@ describe(`isImageRecord`, () => {
   })
 
   it(`detects an image by filename when the encoding format is absent`, () => {
-    // covers the raster formats detectMimeTypeFromName recognizes, including
-    // the ones it gained (gif/avif/bmp/tiff)
+    // covers the formats detectMimeTypeFromName recognizes, including the ones
+    // it gained (gif/avif/bmp/tiff) and svg (image/svg+xml)
     expect(isImageRecord(fileRecord(`page.gif`))).toBe(true)
     expect(isImageRecord(fileRecord(`page.tiff`))).toBe(true)
+    expect(isImageRecord(fileRecord(`cover.svg`))).toBe(true)
     expect(isImageRecord(fileRecord(`COVER.JPG`))).toBe(true)
   })
 

--- a/packages/archive-reader/src/archives/images.ts
+++ b/packages/archive-reader/src/archives/images.ts
@@ -1,0 +1,28 @@
+import { detectMimeTypeFromName, parseContentType } from "@prose-reader/shared"
+import type { Archive, ArchiveRecord, FileRecord } from "./types"
+import { isFileRecord } from "./types"
+
+/**
+ * Best-effort media type of a file record: the archive's own encoding format
+ * when known, else detected from the filename. Same derivation the reading
+ * order and cover use.
+ */
+const mediaTypeForRecord = (record: FileRecord): string | undefined =>
+  parseContentType(record.encodingFormat ?? "") ||
+  detectMimeTypeFromName(record.basename)
+
+/**
+ * Whether a record is an image resource — an `image/*` media type by encoding
+ * format or filename (the raster formats real CBZ/CBR/EPUB producers use).
+ * Directories are never images.
+ */
+export const isImageRecord = (record: ArchiveRecord): boolean =>
+  isFileRecord(record) &&
+  mediaTypeForRecord(record)?.startsWith("image/") === true
+
+/**
+ * Every image file record of the archive, in record order. The page listing
+ * of a comic or image container, and the raster asset inventory of any book.
+ */
+export const getArchiveImageRecords = (archive: Archive): FileRecord[] =>
+  archive.records.filter(isFileRecord).filter(isImageRecord)

--- a/packages/archive-reader/src/archives/images.ts
+++ b/packages/archive-reader/src/archives/images.ts
@@ -13,7 +13,7 @@ const mediaTypeForRecord = (record: FileRecord): string | undefined =>
 
 /**
  * Whether a record is an image resource — an `image/*` media type by encoding
- * format or filename (the raster formats real CBZ/CBR/EPUB producers use).
+ * format or filename (the image formats real CBZ/CBR/EPUB producers use).
  * Directories are never images.
  */
 export const isImageRecord = (record: ArchiveRecord): boolean =>

--- a/packages/archive-reader/src/index.ts
+++ b/packages/archive-reader/src/index.ts
@@ -32,6 +32,10 @@ export {
   arrayBufferFileAccessors,
   blobFileAccessors,
 } from "./archives/fileAccessors"
+export {
+  getArchiveImageRecords,
+  isImageRecord,
+} from "./archives/images"
 export { readRecordAsText } from "./archives/readRecordAsText"
 export type {
   Archive,

--- a/packages/shared/src/contentType.test.ts
+++ b/packages/shared/src/contentType.test.ts
@@ -55,6 +55,7 @@ describe("detectMimeTypeFromName", () => {
     ["page.bmp", "image/bmp"],
     ["page.tif", "image/tiff"],
     ["page.tiff", "image/tiff"],
+    ["cover.svg", "image/svg+xml"],
   ])("detects the image type of %s", (name, mimeType) => {
     expect(detectMimeTypeFromName(name)).toBe(mimeType)
   })

--- a/packages/shared/src/contentType.test.ts
+++ b/packages/shared/src/contentType.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { isMediaContentMimeType, parseContentType } from "./contentType"
+import {
+  detectMimeTypeFromName,
+  isMediaContentMimeType,
+  parseContentType,
+} from "./contentType"
 
 describe("parseContentType", () => {
   it("should keep mime type without parameters", () => {
@@ -39,4 +43,28 @@ describe("isMediaContentMimeType", () => {
       expect(isMediaContentMimeType(mimeType)).toBe(false)
     },
   )
+})
+
+describe("detectMimeTypeFromName", () => {
+  it.each([
+    ["page.png", "image/png"],
+    ["page.jpeg", "image/jpeg"],
+    ["page.gif", "image/gif"],
+    ["page.webp", "image/webp"],
+    ["page.avif", "image/avif"],
+    ["page.bmp", "image/bmp"],
+    ["page.tif", "image/tiff"],
+    ["page.tiff", "image/tiff"],
+  ])("detects the image type of %s", (name, mimeType) => {
+    expect(detectMimeTypeFromName(name)).toBe(mimeType)
+  })
+
+  it("is case-insensitive on the extension", () => {
+    expect(detectMimeTypeFromName("COVER.JPG")).toBe("image/jpg")
+    expect(detectMimeTypeFromName("Scan.TIFF")).toBe("image/tiff")
+  })
+
+  it("returns undefined for an unknown extension", () => {
+    expect(detectMimeTypeFromName("book.opf")).toBeUndefined()
+  })
 })

--- a/packages/shared/src/contentType.ts
+++ b/packages/shared/src/contentType.ts
@@ -22,6 +22,8 @@ export const detectMimeTypeFromName = (name: string) => {
     case `tif`:
     case `tiff`:
       return `image/tiff`
+    case `svg`:
+      return `image/svg+xml`
     case `txt`:
       return `text/plain`
     case `xhtml`:

--- a/packages/shared/src/contentType.ts
+++ b/packages/shared/src/contentType.ts
@@ -1,7 +1,8 @@
 import { getUrlExtension } from "./url"
 
 export const detectMimeTypeFromName = (name: string) => {
-  const extension = getUrlExtension(name)
+  // extensions are case-insensitive (`COVER.JPG` is a jpeg)
+  const extension = getUrlExtension(name).toLowerCase()
 
   switch (extension) {
     case `png`:
@@ -10,10 +11,19 @@ export const detectMimeTypeFromName = (name: string) => {
       return `image/jpg`
     case `jpeg`:
       return `image/jpeg`
-    case `txt`:
-      return `text/plain`
+    case `gif`:
+      return `image/gif`
     case `webp`:
       return `image/webp`
+    case `avif`:
+      return `image/avif`
+    case `bmp`:
+      return `image/bmp`
+    case `tif`:
+    case `tiff`:
+      return `image/tiff`
+    case `txt`:
+      return `text/plain`
     case `xhtml`:
       return `application/xhtml+xml`
     case `mp3`:


### PR DESCRIPTION
## What

Moves oboku's generic "what is an image in an archive?" logic into `@prose-reader/archive-reader`, and closes the media-type gap that the cover/page-count work (#237) hinged on.

- **`@prose-reader/shared`** — `detectMimeTypeFromName` now recognizes `gif`, `avif`, `bmp`, `tif`, `tiff` (the raster formats real CBZ/CBR/EPUB producers use beyond jpg/png/webp) and matches the extension **case-insensitively** (`COVER.JPG` is a jpeg). This directly benefits #237: the reading-order layout, cover fallback, and page count now recognize these formats even when a record carries no encoding format.
- **`@prose-reader/archive-reader`** — new primitives:
  - `isImageRecord(record)` — an `image/*` media type by encoding format or filename; directories are never images.
  - `getArchiveImageRecords(archive)` — the image page listing of a comic or image container.

These replace oboku's local `IMAGE_EXTENSIONS` / `isImagePath` / `listImageEntries`, so consumers stop reimplementing image detection.

## Notes

- `gitbook/archive-reader` updated for the new exports (AGENTS.md § Documentation).
- Scope deliberately excludes the metadata **writer** (ComicInfo/OPF write-back) — held for a separate change pending the read+write scope decision for prose.

## Test plan

- `@prose-reader/shared`: `vitest` green (added `detectMimeTypeFromName` cases incl. case-insensitivity).
- `@prose-reader/archive-reader`: `tsc` clean, `vitest` green — 229 (added `isImageRecord` / `getArchiveImageRecords` coverage).
- `biome check` clean; both packages build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)