### PR TITLE
refactor(streamer): consolidate archive resource fix hooks

### DIFF
--- a/packages/streamer/src/generators/resources/hooks/calibreFixHook.ts
+++ b/packages/streamer/src/generators/resources/hooks/calibreFixHook.ts
@@ -1,10 +1,5 @@
-import {
-  type Archive,
-  getArchiveFileRecordByUri,
-  readRecordAsText,
-} from "@prose-reader/archive-reader"
 import { XmlDocument } from "xmldoc"
-import type { HookResource } from "./types"
+import { createTextResourceHook } from "./createTextResourceHook"
 
 const hasCalibreCoverMeta = (doc: XmlDocument) => {
   const metaElm = doc
@@ -26,38 +21,21 @@ const getBuggyCoverSvg = (doc: XmlDocument) => {
     )
 }
 
-const fixBuggyCover =
-  ({ archive, resourcePath }: { archive: Archive; resourcePath: string }) =>
-  async (resource: HookResource): Promise<HookResource> => {
-    const file = getArchiveFileRecordByUri(archive, resourcePath)
+export const calibreFixHook = createTextResourceHook(
+  ".xhtml",
+  (bodyToParse) => {
+    const opfXmlDoc = new XmlDocument(bodyToParse)
 
-    if (file?.basename.endsWith(`.xhtml`)) {
-      const bodyToParse =
-        typeof resource.body === `string`
-          ? resource.body
-          : await readRecordAsText(file)
-
-      const opfXmlDoc = new XmlDocument(bodyToParse)
-
-      if (hasCalibreCoverMeta(opfXmlDoc)) {
-        const buggySvg = getBuggyCoverSvg(opfXmlDoc)
-
-        if (buggySvg) {
-          delete buggySvg.attr.preserveAspectRatio
-        }
-
-        return {
-          ...resource,
-          body: opfXmlDoc?.toString(),
-        }
-      }
+    if (!hasCalibreCoverMeta(opfXmlDoc)) {
+      return undefined
     }
 
-    return resource
-  }
+    const buggySvg = getBuggyCoverSvg(opfXmlDoc)
 
-export const calibreFixHook =
-  ({ archive, resourcePath }: { archive: Archive; resourcePath: string }) =>
-  async (resource: HookResource): Promise<HookResource> => {
-    return fixBuggyCover({ archive, resourcePath })(resource)
-  }
+    if (buggySvg) {
+      delete buggySvg.attr.preserveAspectRatio
+    }
+
+    return opfXmlDoc.toString()
+  },
+)

--- a/packages/streamer/src/generators/resources/hooks/createTextResourceHook.ts
+++ b/packages/streamer/src/generators/resources/hooks/createTextResourceHook.ts
@@ -1,0 +1,53 @@
+import {
+  getArchiveFileRecordByUri,
+  readRecordAsText,
+} from "@prose-reader/archive-reader"
+import type {
+  StreamerResourceHook,
+  StreamerResourceHookContext,
+  StreamerResourceHookFactory,
+} from "../../../hooks"
+
+/**
+ * Shared scaffolding for resource hooks that rewrite the text body of a single
+ * archive file matching a given extension.
+ *
+ * Resolves the archive record for `resourcePath` and, when its basename ends
+ * with `extension`, reads the resource body as text (reusing an already-string
+ * body, otherwise reading the record) and passes it to `transform`. When
+ * `transform` returns a string the resource body is replaced; when it returns
+ * `undefined` the resource is returned untouched (so a non-string body is
+ * preserved as-is).
+ */
+export const createTextResourceHook =
+  (
+    extension: string,
+    transform: (
+      body: string,
+    ) => string | undefined | Promise<string | undefined>,
+  ): StreamerResourceHookFactory =>
+  ({
+    archive,
+    resourcePath,
+  }: StreamerResourceHookContext): StreamerResourceHook =>
+  async (resource) => {
+    const file = getArchiveFileRecordByUri(archive, resourcePath)
+
+    if (file?.basename.endsWith(extension)) {
+      const bodyToParse =
+        typeof resource.body === `string`
+          ? resource.body
+          : await readRecordAsText(file)
+
+      const newBody = await transform(bodyToParse)
+
+      if (newBody !== undefined) {
+        return {
+          ...resource,
+          body: newBody,
+        }
+      }
+    }
+
+    return resource
+  }

--- a/packages/streamer/src/generators/resources/hooks/cssFixHook.ts
+++ b/packages/streamer/src/generators/resources/hooks/cssFixHook.ts
@@ -1,35 +1,9 @@
-import {
-  type Archive,
-  getArchiveFileRecordByUri,
-  readRecordAsText,
-} from "@prose-reader/archive-reader"
-import type { HookResource } from "./types"
+import { createTextResourceHook } from "./createTextResourceHook"
 
-export const cssFixHook =
-  ({ archive, resourcePath }: { archive: Archive; resourcePath: string }) =>
-  async (resource: HookResource): Promise<HookResource> => {
-    const file = getArchiveFileRecordByUri(archive, resourcePath)
-
-    if (file?.basename.endsWith(`.css`)) {
-      const bodyToParse =
-        typeof resource.body === `string`
-          ? resource.body
-          : await readRecordAsText(file)
-
-      /**
-       * Fix the potentially invalid writing mode present on some vertical book.
-       * This has the benefit of making it compatible with firefox as well.
-       */
-      const newBody = bodyToParse.replaceAll(
-        `-webkit-writing-mode`,
-        `writing-mode`,
-      )
-
-      return {
-        ...resource,
-        body: newBody,
-      }
-    }
-
-    return resource
-  }
+export const cssFixHook = createTextResourceHook(".css", (body) =>
+  /**
+   * Fix the potentially invalid writing mode present on some vertical book.
+   * This has the benefit of making it compatible with firefox as well.
+   */
+  body.replaceAll(`-webkit-writing-mode`, `writing-mode`),
+)

--- a/packages/streamer/src/generators/resources/hooks/selfClosingTagsFixHook.ts
+++ b/packages/streamer/src/generators/resources/hooks/selfClosingTagsFixHook.ts
@@ -1,9 +1,4 @@
-import {
-  type Archive,
-  getArchiveFileRecordByUri,
-  readRecordAsText,
-} from "@prose-reader/archive-reader"
-import type { HookResource } from "./types"
+import { createTextResourceHook } from "./createTextResourceHook"
 
 const invalidSelfClosingTags = [
   "div",
@@ -65,43 +60,25 @@ const invalidSelfClosingTags = [
  * is a first lighter regex which check if any such tag exist in the first place before running
  * the full replace regex empty.
  */
-export const selfClosingTagsFixHook =
-  ({ archive, resourcePath }: { archive: Archive; resourcePath: string }) =>
-  async (resource: HookResource): Promise<HookResource> => {
-    const file = getArchiveFileRecordByUri(archive, resourcePath)
-
-    if (file?.basename.endsWith(`.xhtml`)) {
-      const bodyToParse =
-        typeof resource.body === `string`
-          ? resource.body
-          : await readRecordAsText(file)
-
-      const tagCheckPattern = new RegExp(
-        `<(${invalidSelfClosingTags.join("|")})[\\s/>]`,
-        "i",
-      )
-      if (!tagCheckPattern.test(bodyToParse)) {
-        return resource
-      }
-
-      const tagPattern = new RegExp(
-        `<(${invalidSelfClosingTags.join("|")})(\\s[^>]*)?\\s*/>`,
-        "gi",
-      )
-
-      const fixedBody = bodyToParse.replace(
-        tagPattern,
-        (_, tagName, attributes = "") => {
-          // Convert to an opening and closing tag
-          return `<${tagName} ${attributes.trim()}></${tagName}>`
-        },
-      )
-
-      return {
-        ...resource,
-        body: fixedBody,
-      }
+export const selfClosingTagsFixHook = createTextResourceHook(
+  ".xhtml",
+  (bodyToParse) => {
+    const tagCheckPattern = new RegExp(
+      `<(${invalidSelfClosingTags.join("|")})[\\s/>]`,
+      "i",
+    )
+    if (!tagCheckPattern.test(bodyToParse)) {
+      return undefined
     }
 
-    return resource
-  }
+    const tagPattern = new RegExp(
+      `<(${invalidSelfClosingTags.join("|")})(\\s[^>]*)?\\s*/>`,
+      "gi",
+    )
+
+    return bodyToParse.replace(tagPattern, (_, tagName, attributes = "") => {
+      // Convert to an opening and closing tag
+      return `<${tagName} ${attributes.trim()}></${tagName}>`
+    })
+  },
+)


### PR DESCRIPTION
## Summary

The streamer's resource "fix" hooks each re-implemented the same scaffolding around a small, hook-specific body transform. This PR extracts that shared scaffolding into a single factory so each hook is expressed as just *its extension + its transform*, removing the copy-pasted boilerplate.

Everything here is behavior-preserving — the public exports (`selfClosingTagsFixHook`, `cssFixHook`, `calibreFixHook`) keep the exact same factory signature `({ archive, resourcePath }) => async (resource) => …`, so their only call site (`generators/resources/index.ts`) is untouched, and the existing hook tests pass unchanged.

## Consolidation: archive text-resource fix hooks

**What was duplicated**

Three hooks each contained an identical block:

- `packages/streamer/src/generators/resources/hooks/cssFixHook.ts`
- `packages/streamer/src/generators/resources/hooks/selfClosingTagsFixHook.ts`
- `packages/streamer/src/generators/resources/hooks/calibreFixHook.ts` (inside its `fixBuggyCover` helper)

The repeated logic in every one:

```ts
const file = getArchiveFileRecordByUri(archive, resourcePath)
if (file?.basename.endsWith(EXT)) {
  const bodyToParse =
    typeof resource.body === `string`
      ? resource.body
      : await readRecordAsText(file)
  // …hook-specific transform…
  return { ...resource, body: newBody }
}
return resource
```

Only two things actually varied between them: the **extension** to match and the **body transform**.

**What it became**

A new `createTextResourceHook(extension, transform)` factory (`packages/streamer/src/generators/resources/hooks/createTextResourceHook.ts`) owns the scaffolding once and is typed against the existing `StreamerResourceHookFactory` contract. Each hook is now just:

- `cssFixHook` → `.css` + a `replaceAll` transform
- `selfClosingTagsFixHook` → `.xhtml` + the tag-fixing regex transform
- `calibreFixHook` → `.xhtml` + the cover-svg fix (dropping the now-redundant inner `fixBuggyCover` indirection)

The transform returns `string | undefined`. Returning `undefined` means "leave the resource untouched", which preserves the original behavior exactly — including keeping a non-string (`Blob`) body intact when a hook decides not to rewrite (calibre with no `calibre:cover` meta, self-closing with no matching tags).

**Why these are truly the same concept**

All three are "read one archive file's text body, maybe rewrite it, otherwise pass through" transforms differing only in extension + transform — no diverging modes or flags were introduced; the varying part is passed as data/callback, not conditionals inside a merged body.

**Net LOC:** −18 (97 insertions / 115 deletions across 4 files), and the shared scaffold now lives in one place instead of three.

## Validation

Run with the repo-pinned Node (`.nvmrc` → v25), scoped to the affected package:

- `npm run build --workspace @prose-reader/streamer` (runs `tsc && vite build`) — green
- `npm run tsc --workspace @prose-reader/streamer` — no errors
- `npm test --workspace @prose-reader/streamer` — 70/70 passing (identical to the pre-change baseline)
- `biome lint` / `biome format` on the touched files — clean

These hooks are internal to `generateResourceFromArchive` (not part of the package's public `index.ts` exports) and are not referenced in `gitbook/`, so no documentation changes are required.

## Other candidates considered (left out on purpose)

- `getNavigationForLeftOrTopPage` / `getNavigationForRightOrBottomPage` (and their single-page siblings) are near-identical but genuinely directional — merging would require a direction/sign parameter and RTL branch flips, i.e. mode flags for diverging behavior. Skipped per the "not a duplicate if unifying needs mode params" rule.
- `AnnotationsList` / `BookmarksList` differ by data hook + an `allowLeftIcon` prop and represent independently-evolving features. Skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1JF9BvMTU8mVF7YrD3TBH

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1JF9BvMTU8mVF7YrD3TBH)_