### PR TITLE
perf(core): reduce spine visibility work on the navigation hot path

### DIFF
--- a/packages/core/src/spine/locator/SpineLocator.ts
+++ b/packages/core/src/spine/locator/SpineLocator.ts
@@ -126,7 +126,34 @@ export const createSpineLocator = ({
     | undefined => {
     const numberOfPages = spineItem.numberOfPages
 
-    const pages = Array.from(Array(numberOfPages)).map((_, index) => {
+    /**
+     * The viewport slice and the item layout are constant across every page of
+     * the item, so they are computed once here instead of per page. Visibility
+     * is evaluated inline so we neither materialize a full per-page position
+     * array nor rebuild the accumulator with a spread on each visible page
+     * (which was O(pages^2)). This runs several times per pan frame.
+     */
+    const viewportInfo = useAbsoluteViewport
+      ? viewport.absoluteViewport
+      : viewport.relativeViewport
+
+    const relativeSpinePosition = translateSpinePositionToRelativeViewport(
+      position,
+      viewport.absoluteViewport,
+      viewportInfo,
+    )
+
+    const viewportPosition = ViewportSlicePosition.from(
+      relativeSpinePosition,
+      viewportInfo,
+    )
+
+    const itemLayout = spineLayout.getSpineItemSpineLayoutInfo(spineItem)
+
+    let beginPageIndex: number | undefined
+    let endPageIndex: number | undefined
+
+    for (let index = 0; index < numberOfPages; index += 1) {
       const spineItemPosition =
         spineItemLocator.getSpineItemPositionFromPageIndex({
           pageIndex: index,
@@ -135,12 +162,14 @@ export const createSpineLocator = ({
 
       const spinePosition = getSpinePositionFromSpineItemPosition({
         spineItemPosition,
-        itemLayout: spineLayout.getSpineItemSpineLayoutInfo(spineItem),
+        itemLayout,
       })
 
-      return {
-        index,
-        absolutePosition: {
+      const { visible } = getItemVisibilityForPosition({
+        viewportPosition,
+        restrictToScreen,
+        threshold,
+        itemPosition: {
           width: viewport.pageSize.width,
           height: viewport.pageSize.height,
           left: spinePosition.x,
@@ -148,44 +177,15 @@ export const createSpineLocator = ({
           bottom: spinePosition.y + viewport.pageSize.height,
           right: spinePosition.x + viewport.pageSize.width,
         },
-      }
-    })
+      })
 
-    const pagesVisible = pages.reduce<number[]>(
-      (acc, { absolutePosition, index }) => {
-        const viewportInfo = useAbsoluteViewport
-          ? viewport.absoluteViewport
-          : viewport.relativeViewport
-
-        const relativeSpinePosition = translateSpinePositionToRelativeViewport(
-          position,
-          viewport.absoluteViewport,
-          viewportInfo,
-        )
-
-        const viewportPosition = ViewportSlicePosition.from(
-          relativeSpinePosition,
-          viewportInfo,
-        )
-
-        const { visible } = getItemVisibilityForPosition({
-          viewportPosition,
-          restrictToScreen,
-          threshold,
-          itemPosition: absolutePosition,
-        })
-
-        if (visible) {
-          return [...acc, index]
+      if (visible) {
+        if (beginPageIndex === undefined) {
+          beginPageIndex = index
         }
-
-        return acc
-      },
-      [],
-    )
-
-    const beginPageIndex = pagesVisible[0]
-    const endPageIndex = pagesVisible[pagesVisible.length - 1] ?? beginPageIndex
+        endPageIndex = index
+      }
+    }
 
     if (beginPageIndex === undefined || endPageIndex === undefined)
       return undefined

--- a/packages/core/src/spine/locator/getVisibleSpineItemsFromPosition.ts
+++ b/packages/core/src/spine/locator/getVisibleSpineItemsFromPosition.ts
@@ -34,13 +34,6 @@ export const getVisibleSpineItemsFromPosition = ({
       endIndex: number
     }
   | undefined => {
-  const fallbackSpineItem =
-    getSpineItemFromPosition({
-      position,
-      spineItemsManager,
-      spineLayout,
-    }) || spineItemsManager.get(0)
-
   const viewportInfo = useAbsoluteViewport
     ? viewport.absoluteViewport
     : viewport.relativeViewport
@@ -70,7 +63,20 @@ export const getVisibleSpineItemsFromPosition = ({
     }
   }
 
-  const beginItem = spineItemsVisible[0] ?? fallbackSpineItem
+  /**
+   * The fallback is only needed when nothing is visible. Computing it eagerly
+   * would run a full-spine `getSpineItemFromPosition` scan on every call, even
+   * though it is discarded whenever at least one item is visible (the common
+   * case). Resolve it lazily to avoid that extra O(n) pass per call.
+   */
+  const getFallbackSpineItem = () =>
+    getSpineItemFromPosition({
+      position,
+      spineItemsManager,
+      spineLayout,
+    }) || spineItemsManager.get(0)
+
+  const beginItem = spineItemsVisible[0] ?? getFallbackSpineItem()
   const endItem = spineItemsVisible[spineItemsVisible.length - 1] ?? beginItem
 
   if (!beginItem || !endItem) return undefined


### PR DESCRIPTION
## Target

**Subsystem:** `packages/core` spine locator (`getVisibleSpineItemsFromPosition`, `getVisiblePagesFromViewportPosition`).

**User-visible symptom:** jank during finger drags. In `controlled` page-turn mode, `enhancer-gestures` calls `panNavigator.panMoveTo` on every `pointermove` (one per frame, no throttle), which pushes the position through the full navigation consolidation pipeline. The `withSpineItem` operator (`navigation/consolidation/withSpineItem.ts`) calls `getVisibleSpineItemsFromPosition` **twice** and `getVisiblePagesFromViewportPosition` **once** per frame — each over the full spine / all pages of an item. A large EPUB has hundreds of spine items and a long reflowable chapter has dozens of pages, so this work runs at frame rate against the biggest collections the engine holds.

All changes are **behaviour-invisible** — identical outputs, ordering and semantics; only speed/allocation change. Equivalence was asserted in the benchmark (below) before measuring.

## Changes

1. **Defer the fallback item in `getVisibleSpineItemsFromPosition`.**
   Mechanism: the fallback (`getSpineItemFromPosition`, itself a full-spine `.find`) was computed eagerly on every call but is only read when *no* item is visible — resolve it lazily so the common case skips one O(n) full-spine pass.
   Scale: `spineItemsManager.items` (hundreds), ×2 calls/frame → removes one full-spine scan per call in the visible case.

2. **Hoist loop-invariant work + collapse the loop in `getVisiblePagesFromViewportPosition`.**
   Mechanism: `viewportInfo`, `relativeSpinePosition`, `viewportPosition` and the item layout depend only on the position/viewport (constant across pages) yet were recomputed for every page; the function also materialized a full per-page position array and rebuilt the visible-index accumulator with a spread (`[...acc, index]`), which is O(pages²). Now: invariants computed once, visibility evaluated inline in a single loop that tracks the begin/end visible page — no intermediate array, no spread.
   Scale: pages in the current spine item (dozens for a long reflowable chapter), called once/frame.

## Measured impact

Micro-benchmark (vitest `bench`) exercising the real functions with duck-typed spine/viewport fakes at realistic scale (300 spine items, 60 pages/item). The benchmark asserts old and new produce identical output, then compares:

| Function | Scale | Result |
|---|---|---|
| `getVisibleSpineItemsFromPosition` | 300 items | **1.12× faster** (deferred fallback; removes one O(n) scan/call) |
| `getVisiblePagesFromViewportPosition` | 60 pages | **3.61× faster** (single loop, hoisted invariants, no O(k²) spread) |

The `getVisibleSpineItemsFromPosition` gain is modest per call but scales with spine length and compounds (2 calls/frame). The pages gain is the larger win. The benchmark was a throwaway and is not included in the diff.

## Gates

Run with the pinned Node (`.nvmrc` → 25). Baseline on a clean checkout was already green; after the change:
- `npm run build` (lerna, all packages) ✓
- `npm run tsc` ✓
- `npm run lint` / `npm run format` (biome) ✓
- core test suite: 186/186 passing (incl. `getVisibleSpineItemsFromPosition.test.ts`)

No public surface or documented behaviour changed (purely internal hot-path code), so no `gitbook/` update is needed — checked.

## Backlog (other perf opportunities found, not taken)

- **`getVisibleSpineItemsFromPosition` full-spine loop** — still O(n) per call; item layouts are monotonic in spine order, so the visible window could be found by binary search / incremental update from the previous frame. Higher impact but risks behaviour changes in RTL/spread edge cases, so left for a dedicated change.
- **`Pages` (`spine/Pages.ts`)** rebuilds the entire page array on every `layout$` emission, and `fromSpineItemPageIndex` / `fromAbsolutePageIndex` are O(total-pages) `.find`s per navigation — candidates for `Map`s keyed by `itemIndex:pageIndex` / `absolutePageIndex`.
- **`SpineItemsManager.get(id)`** is an O(n) `.find` by string id; the item list is immutable, so an `id → item` `Map` built once at construction would make it O(1).
- **`getPercentageEstimate` (`enhancers/pagination/progression.ts`)** does an O(n) prefix-sum (`slice().reduce`) over the manifest and an O(total-pages) `filter` per progression update — precompute cumulative weights and reuse `numberOfPagesPerItems`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvTMZKXAkMXQZ22HPJV2Na

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvTMZKXAkMXQZ22HPJV2Na)_