### PR TITLE
chore(archive-reader): bump @zip.js/zip.js from 2.8.31 to 2.8.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8162,7 +8162,9 @@
       "license": "MIT"
     },
     "node_modules/@zip.js/zip.js": {
-      "version": "2.8.31",
+      "version": "2.8.33",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.33.tgz",
+      "integrity": "sha512-Mc+s4DdDl9lmhFmkOmNDryC/b4rZm7y2/qBUQTCwPYGkQ8dkCeykILqEYBd+14ATuj93XWZJBrPe2x+cF9LcGA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -20745,7 +20747,7 @@
       },
       "devDependencies": {
         "@types/unzipper": "^0.10.11",
-        "@zip.js/zip.js": "^2.8.26",
+        "@zip.js/zip.js": "^2.8.33",
         "buffer": "^6.0.3",
         "jszip": "^3.10.0",
         "libarchive.js": "^2.0.2",
@@ -20753,7 +20755,7 @@
         "unzipper": "^0.12.3"
       },
       "peerDependencies": {
-        "@zip.js/zip.js": "^2.8.26",
+        "@zip.js/zip.js": "^2.8.33",
         "buffer": "^6.0.3",
         "jszip": "^3.10.0",
         "libarchive.js": "^2.0.2",

--- a/packages/archive-reader/package.json
+++ b/packages/archive-reader/package.json
@@ -57,7 +57,7 @@
     "xmldoc": "^2.0.0"
   },
   "peerDependencies": {
-    "@zip.js/zip.js": "^2.8.26",
+    "@zip.js/zip.js": "^2.8.33",
     "buffer": "^6.0.3",
     "jszip": "^3.10.0",
     "libarchive.js": "^2.0.2",
@@ -86,7 +86,7 @@
   },
   "devDependencies": {
     "@types/unzipper": "^0.10.11",
-    "@zip.js/zip.js": "^2.8.26",
+    "@zip.js/zip.js": "^2.8.33",
     "buffer": "^6.0.3",
     "jszip": "^3.10.0",
     "libarchive.js": "^2.0.2",


### PR DESCRIPTION
## The update

| | |
|---|---|
| **Package** | `@zip.js/zip.js` |
| **Where** | `@prose-reader/archive-reader` (optional peer dep + devDependency) |
| **Version** | `2.8.31` → `2.8.33` |
| **Type** | patch |
| **Constraint** | within the existing `^2.8.26` range (floor raised to `^2.8.33`, caret shape unchanged — not widened) |
| **Security** | none — this is a routine maintenance patch |

`@zip.js/zip.js` is the library backing the `createArchiveFromZipJs` creator. It stays an *optional* peer dependency, so this only affects consumers who opt into the zip.js archive path. `2.8.32`/`2.8.33` are upstream bug-fix patches (no API changes); the caret already permitted them, so the change is effectively a lockfile refresh plus an explicit floor bump for clarity.

### Why this one
The security advisories below are all transitive through the dev toolchain (`lerna` → `nx`, and `expo`), and npm only offers to fix the critical/high ones by **downgrading `lerna` v9 → v6** (a major, and a downgrade) — which violates the pinned `^9.0.7` constraint, so none are cleanly actionable in a single-dependency PR (see *Needs manual attention*). With direct-dep bumps already owned by open Dependabot PRs, the highest-priority remaining actionable item is the most-behind uncovered patch — `@zip.js/zip.js` (2 releases behind).

## Gates
Baseline recorded on a clean `origin/master` checkout (Node 25, npm 11.12.1), then re-run with the update applied. **No new failures.**

| Gate | Baseline | With update |
|---|---|---|
| `npm run format` (biome) | ✅ | ✅ |
| `npm run lint` (biome) | ✅ | ✅ |
| `npm run build` (lerna, 17 projects) | ✅ | ✅ |
| `npm run tsc` (6 projects) | ✅ | ✅ |
| `@prose-reader/archive-reader` tests | ✅ | ✅ |

## Pending queue (other outdated deps found this run)

Patch / minor (candidates for future runs of this routine):

| Package | Current → Latest | Type | Note |
|---|---|---|---|
| `@biomejs/biome` | 2.5.4 → 2.5.5 | patch (dev) | not covered by a PR |
| `@tanstack/react-query` | 5.101.2 → 5.101.3 | patch | not covered by a PR |
| `happy-dom` | 20.10.6 → 20.11.0 | minor (dev) | not covered by a PR |
| `@zip.js/zip.js` | — | — | **this PR** |
| `reactjrx` | 1.141.2 → 1.141.3 | patch | Dependabot #245 |
| `@chakra-ui/react` | 3.36.0 → 3.36.1 | patch | Dependabot #242 |
| `lint-staged` | 17.0.8 → 17.1.0 | minor (dev) | Dependabot #244 |

## Deferred majors (non-security — need a human to schedule)

Not applied per policy (never apply non-security majors). Most already have a Dependabot PR:

| Package | Current → Latest | Breaking-change summary | PR |
|---|---|---|---|
| `typescript` | 6.0.3 → 7.0.2 | Major TS release; new/stricter checks likely surface new type errors across all workspaces. | #246 |
| `@types/node` | 25.9.5 → 26.1.1 | Node 26 typings; removed/changed API signatures may break `tsc`. | #243 |
| `@babel/core` | 7.29.7 → 8.0.1 | Babel 8 drops legacy options/plugins and older Node support. | #241 |
| `pdfjs-dist` | 5.7.284 → 6.1.200 | Major pdf.js; API/worker surface changes affecting `enhancer-pdf`. | #247 |
| `react-router` | 7.18.1 → 8.2.0 | Router v8 routing/API changes (demo app). | #249 |
| `react-dropzone` | 15.0.0 → 19.1.1 | Multiple majors of hook/API changes (demo app). | #250 |
| `xmldoc` | 2.0.3 → 3.0.0 | Major XML parser API change; used by `archive-reader` + `streamer`. | #248 |
| `expo-file-system` | 56.0.8 → 57.0.1 | Expo SDK 57 file-system API rewrite (react-native app). | not covered |

## Needs manual attention (security — blocked by constraints)

`npm audit` reports **16 advisories (1 critical, 4 high, 11 moderate)**, all in the dev/build toolchain (`lerna` → `nx`, and the Expo react-native chain). None ship in the published library bundles. The critical/high fixes npm proposes require **downgrading `lerna` 9 → 6.6.2** (a semver-major downgrade that breaks the pinned `^9.0.7` toolchain), so they cannot be resolved by a respectful single-dependency bump and need a human decision (upstream `lerna`/`nx` update, or targeted `overrides`):

| Advisory | Severity | Path | Fix offered by npm |
|---|---|---|---|
| `tar` (GHSA-23hp-3jrh-7fpw + others) | **critical** | `lerna`/`nx` → `tar` | lerna → 6.6.2 (major downgrade) ❌ |
| `axios` (GHSA-gcfj-64vw-6mp9 + others) | high | `nx` → `axios` | in-range, but nested under nx |
| `brace-expansion` (GHSA-3jxr-9vmj-r5cp) | high | `nx` → `brace-expansion` | in-range, but nested under nx |
| `js-yaml` (GHSA-52cp-r559-cp3m) | high | `lerna` → `js-yaml` | lerna → 6.6.2 (major downgrade) ❌ |
| `nx` | high | depends on vulnerable `axios`/`brace-expansion` | in-range |
| `@expo/*`, `expo`, `uuid`, `xcode` | moderate | Expo react-native chain | `npm audit fix` (bumps a few `@expo/*` patches only) |

`npm audit fix` (non-forced) only bumps four `@expo/*` packages and does **not** clear any of the high/critical advisories, so it was intentionally not applied here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SxTn3LSH3MSPjGjnbTv83F)_