### PR TITLE
chore: remove strict dead code

### DIFF
--- a/packages/cfi/src/utils.ts
+++ b/packages/cfi/src/utils.ts
@@ -57,15 +57,6 @@ export function cfiEscape(str: string): string {
 export const isCFI = /^epubcfi\((.*)\)$/
 
 /**
- * Wrap a CFI string in the epubcfi() function
- * @param cfi The CFI string to wrap
- * @returns The wrapped CFI string
- */
-export function wrapCfi(cfi: string): string {
-  return isCFI.test(cfi) ? cfi : `epubcfi(${cfi})`
-}
-
-/**
  * @important Make it non browser runtime specific
  */
 export const isElement = (node: Node): node is Element =>

--- a/packages/core/src/enhancers/pagination/chapters/shared.ts
+++ b/packages/core/src/enhancers/pagination/chapters/shared.ts
@@ -164,10 +164,6 @@ const hrefMatchesWithoutAnchor = (
   )
 }
 
-export const hrefMatches = (a: string, b: string) => {
-  return hrefMatchesWithoutAnchor(stripAnchor(a), stripAnchor(b))
-}
-
 export const isPossibleTocItemCandidateForHref = (
   hrefWithoutAnchor: string,
   tocItemHrefWithoutAnchor: string,

--- a/packages/core/src/spine/SpineLayout.ts
+++ b/packages/core/src/spine/SpineLayout.ts
@@ -21,16 +21,6 @@ import type { SpineItemsManager } from "./SpineItemsManager"
 import type { SpineItemsObserver } from "./SpineItemsObserver"
 import { SpineItemSpineLayout } from "./types"
 
-export type PageLayoutInformation = {
-  absolutePageIndex: number
-  itemIndex: number
-  absolutePosition: SpineItemSpineLayout
-}
-
-export type LayoutInfo = {
-  pages: PageLayoutInformation[]
-}
-
 export type SpineLayoutOptions = {
   immediate?: boolean
 }

--- a/packages/react-reader/src/audio/wave/constants.ts
+++ b/packages/react-reader/src/audio/wave/constants.ts
@@ -1,5 +1,3 @@
-import type { AudioVisualizerState } from "@prose-reader/enhancer-audio"
-
 export const FALLBACK_TOP_COLOR = `#93c5fd`
 export const FALLBACK_BOTTOM_COLOR = `#3b82f6`
 export const MIN_BAR_HEIGHT = 1
@@ -14,9 +12,3 @@ export const DEFAULT_STATE_HILL_SPREAD = 0.52
 export const DEFAULT_STATE_MAX_BAR_HEIGHT_RATIO = 0.16
 export const DEFAULT_STATE_OPACITY = 0.5
 export const DEFAULT_STATE_TEXTURE_AMOUNT = 0.34
-
-export const DEFAULT_VISUALIZER_STATE: AudioVisualizerState = {
-  levels: [],
-  isActive: false,
-  trackId: undefined,
-}


### PR DESCRIPTION
Automated dead-code sweep. Removes internal exports that are **never imported or referenced anywhere** in the repo and are **not part of any package's public API** (i.e. not re-exported by the package's `src/index.ts` barrel, so external consumers cannot reach them either).

Candidates were surfaced with `knip` and then each was verified by hand — most of knip's "unused exports" turned out to be used *within their own file* (knip only tracks cross-module imports) and were **left in place**. Only symbols with zero references beyond their own definition survived verification.

### Removed (evidence)

- **`wrapCfi`** — `packages/cfi/src/utils.ts`
  Repo-wide `grep -w wrapCfi` returns only the definition. `packages/cfi/src/index.ts` re-exports only `isIndirectionOnly, isParsedCfiRange` from `utils` (no `export *`), so it is not public API.

- **`hrefMatches`** — `packages/core/src/enhancers/pagination/chapters/shared.ts`
  Uncalled wrapper: `grep -w hrefMatches` finds only the definition and one comment. The internal helper it delegated to (`hrefMatchesWithoutAnchor`, still used at line 132) is kept. Not re-exported by `packages/core/src/index.ts`.

- **`LayoutInfo`** + **`PageLayoutInformation`** — `packages/core/src/spine/SpineLayout.ts`
  `LayoutInfo` has no consumers (the only other `LayoutInfo` is a distinct local type inside `clampRectInSpine.test.ts`); `PageLayoutInformation` was referenced only inside `LayoutInfo`, so both die together. Neither is re-exported by `packages/core/src/index.ts`.

- **`DEFAULT_VISUALIZER_STATE`** — `packages/react-reader/src/audio/wave/constants.ts`
  `grep -w DEFAULT_VISUALIZER_STATE` returns only the definition. Also drops the now-unused `AudioVisualizerState` import (its only user). Not re-exported by `packages/react-reader/src/index.ts`.

### Left in place on purpose (verified, not dead)

- `NOTIFICATION_KEYS` (react-reader) — referenced only inside a commented-out, `TODO`-gated block; disabled-feature code, kept.
- `apps/demo/src/types.ts` — ambient `declare global` for `__PROSE_READER_DEBUG` (used in `serviceWorker/debug.ts`); wired by tsconfig inclusion, not imports.
- `archive-reader` `createArchiveFrom*` files and their deps, `react-native` `src/{native,web,shared}` files — these are the packages' public subpath-export entry points (knip false positives).
- `apps/tests/tests/**/index.tsx`, `prose-react-native-demo/**` — Playwright route fixtures and a CI-checked Expo app, loaded by convention.
- Chakra `components/ui/*` snippets — generated design-system surface.
- Flagged dependencies (`stream-browserify`, `@chakra-ui/styled-system`, `@babel/core`, …) — build-tooling / peer-dependency gray areas; left in per "when in doubt, leave it".

### Gates

Run with the repo-pinned Node (`.nvmrc` → v25). `npm run format`, `npm run lint`, `npm run build`, and `npm run tsc` all pass; unit tests (`vitest`) pass for the three touched packages (`@prose-reader/cfi`, `@prose-reader/core`, `@prose-reader/react-reader`). No public API or documented surface (`gitbook/`) is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BLESCwKU2dqWHL4bE3KYv

---
_Generated by [Claude Code](https://claude.ai/code/session_015BLESCwKU2dqWHL4bE3KYv)_