### PR TITLE
fix(archive-reader): resolve ncx toc entries against the ncx file directory

### DIFF
--- a/packages/archive-reader/src/toc/ncx.ts
+++ b/packages/archive-reader/src/toc/ncx.ts
@@ -1,4 +1,4 @@
-import { urlJoin } from "@prose-reader/shared"
+import { getUriBasePath, urlJoin } from "@prose-reader/shared"
 import { XmlDocument, type XmlElement } from "xmldoc"
 import { readRecordAsText } from "../archives/readRecordAsText"
 import type { Archive } from "../archives/types"
@@ -7,10 +7,10 @@ import type { ArchiveTocItem } from "./types"
 
 const mapNcxChapter = (
   point: XmlElement,
-  { opfBasePath, prefix }: { opfBasePath: string; prefix: string },
+  { basePath, prefix }: { basePath: string; prefix: string },
 ) => {
   const src = point?.childNamed(`${prefix}content`)?.attr.src || ``
-  const path = urlJoin(opfBasePath, src)
+  const path = urlJoin(basePath, src)
 
   const out: ArchiveTocItem = {
     title:
@@ -21,9 +21,7 @@ const mapNcxChapter = (
   }
   const children = point.childrenNamed(`${prefix}navPoint`)
   if (children && children.length > 0) {
-    out.contents = children.map((pt) =>
-      mapNcxChapter(pt, { opfBasePath, prefix }),
-    )
+    out.contents = children.map((pt) => mapNcxChapter(pt, { basePath, prefix }))
   }
 
   return out
@@ -31,7 +29,7 @@ const mapNcxChapter = (
 
 const buildTocFromNcxDocument = (
   ncxData: XmlDocument,
-  { opfBasePath }: { opfBasePath: string },
+  { basePath }: { basePath: string },
 ) => {
   const toc: ArchiveTocItem[] = []
 
@@ -45,7 +43,7 @@ const buildTocFromNcxDocument = (
     .childNamed(`${prefix}navMap`)
     ?.childrenNamed(`${prefix}navPoint`)
     .forEach((point) => {
-      toc.push(mapNcxChapter(point, { opfBasePath, prefix }))
+      toc.push(mapNcxChapter(point, { basePath, prefix }))
     })
 
   return toc
@@ -73,7 +71,13 @@ export const resolveTocFromNcx = async ({
       if (file && !file.dir) {
         const ncxData = new XmlDocument(await readRecordAsText(file))
 
-        return buildTocFromNcxDocument(ncxData, { opfBasePath })
+        /**
+         * content src inside the ncx are relative to the ncx file,
+         * not the opf file
+         */
+        return buildTocFromNcxDocument(ncxData, {
+          basePath: getUriBasePath(file.uri),
+        })
       }
     }
   }

--- a/packages/archive-reader/src/toc/resolveArchiveToc.test.ts
+++ b/packages/archive-reader/src/toc/resolveArchiveToc.test.ts
@@ -43,6 +43,39 @@ describe(`Given ncx toc with prefix`, () => {
   })
 })
 
+describe(`Given an ncx located in a different directory than the opf`, () => {
+  it(`should resolve content src relative to the ncx file, not the opf`, async () => {
+    const opf = `<?xml version="1.0"?><package xmlns="http://www.idpf.org/2007/opf" version="2.0"><manifest><item id="ncx" href="OEBPS/toc.ncx" media-type="application/x-dtbncx+xml"/><item id="ch1" href="OEBPS/chapter1.xhtml" media-type="application/xhtml+xml"/></manifest><spine toc="ncx"><itemref idref="ch1"/></spine></package>`
+    const ncx = `<?xml version="1.0" encoding="UTF-8"?><ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1"><navMap><navPoint id="np1" playOrder="1"><navLabel><text>Chapter 1</text></navLabel><content src="chapter1.xhtml"/><navPoint id="np2" playOrder="2"><navLabel><text>Section 1.1</text></navLabel><content src="chapter1.xhtml#s1"/></navPoint></navPoint></navMap></ncx>`
+
+    const archive = createArchive({
+      filename: `archive`,
+      records: [
+        textRecord(`content.opf`, opf),
+        textRecord(`OEBPS/toc.ncx`, ncx),
+        textRecord(`OEBPS/chapter1.xhtml`),
+      ],
+      close: () => Promise.resolve(),
+    })
+
+    expect(await resolveArchiveToc(archive)).toEqual([
+      {
+        title: `Chapter 1`,
+        path: `OEBPS/chapter1.xhtml`,
+        containerHref: `OEBPS/chapter1.xhtml`,
+        contents: [
+          {
+            title: `Section 1.1`,
+            path: `OEBPS/chapter1.xhtml#s1`,
+            containerHref: `OEBPS/chapter1.xhtml#s1`,
+            contents: [],
+          },
+        ],
+      },
+    ])
+  })
+})
+
 describe(`Given an epub without nav document nor ncx`, () => {
   it(`should resolve an explicit empty toc instead of guessing from folders`, async () => {
     const archive = createArchive({


### PR DESCRIPTION
## The bug

`resolveArchiveToc` (public API of `@prose-reader/archive-reader`, documented in `gitbook/archive-reader/README.md` as producing a container-relative TOC) resolves NCX `content@src` against the **OPF directory** instead of the **NCX file's own directory**. Per the NCX/OPF spec, `content@src` is a relative URI resolved against the NCX document that contains it.

Observable on current master — an EPUB with the OPF at the container root and the NCX at `OEBPS/toc.ncx` whose entry is `<content src="chapter1.xhtml"/>`:

```ts
await resolveArchiveToc(archive)
// → path: "chapter1.xhtml"        (no such record — broken TOC link)
// expected: "OEBPS/chapter1.xhtml"
```

Every TOC entry of such a book points at a non-existent resource, so TOC navigation is silently broken whenever the NCX does not sit in the same directory as the OPF.

## Root cause

In `packages/archive-reader/src/toc/ncx.ts`, `mapNcxChapter` joined `content@src` with `opfBasePath`. The sibling nav-document strategy (`toc/nav.ts`) already does this correctly — it resolves against `getUriBasePath(tocFile.uri)` with an explicit comment that TOC links are relative to the TOC document, not the OPF. The NCX strategy was never given the same treatment; the bug is invisible in the common layout where NCX and OPF share a directory, which is why the existing fixture test never caught it.

## The fix

`resolveTocFromNcx` now derives the base path from the located NCX record's own uri (`getUriBasePath(file.uri)`) and threads it through `buildTocFromNcxDocument` / `mapNcxChapter`, exactly mirroring `nav.ts`. `opfBasePath` is still used for what it is actually for: locating the NCX file from its manifest href.

## Verification

- New regression test in `packages/archive-reader/src/toc/resolveArchiveToc.test.ts` (OPF at root, NCX under `OEBPS/`, nested navPoints): **fails before the fix** (`chapter1.xhtml`) and passes after (`OEBPS/chapter1.xhtml`).
- The pre-existing `tocWithPrefix` fixture test still passes — there the NCX sits next to the OPF, so both resolutions coincide, confirming the common layout is unchanged.
- Gates on the pinned Node 25 (matching CI): `@prose-reader/archive-reader` suite 230/230 (baseline 229/229 before the change), `lerna run test` green for all 12 packages, `lerna run build` green, `npm run tsc` green, `biome format` + `lint` clean. Playwright e2e not run in this environment (macOS screenshot baselines); the change is a pure resolution function fully covered by the unit suite.
- Docs checked: `gitbook/archive-reader/README.md` documents the TOC strategy order and the container-relative contract, which this change restores rather than alters — no doc update needed.

## Other findings (not addressed in this PR)

Carried over from PR #236's findings list, re-verified as still present on master:

1. **`generate()` emits an even CFI step for text nodes preceded by an element** — `packages/cfi/src/generate.ts` computes the text-node step as raw `childNodes` index + 1, colliding with element steps; `resolve()` then maps the CFI back to the wrong node. Fixing requires touching generate and resolve together and changes the meaning of previously stored CFIs.
2. **Streamer manifest hrefs don't escape `#`/`?` in resource paths** — `packages/streamer/src/generators/manifest/createManifestResourceHref.ts` uses bare `encodeURI`; a CBZ entry named `page#1.jpg` produces an href whose fragment breaks resource resolution. Left alone also because open PR #251 is consolidating streamer resource hooks nearby.
3. **Percent-encoded OPF hrefs never match archive records** — `packages/archive-reader/src/readingOrder/resolveArchiveReadingOrder.ts` and `opf/getSpineItemFilesFromArchive.ts` look up records by exact string match, but OPF hrefs are percent-encoded per spec while zip record URIs are raw (`chapter%201.xhtml` vs `chapter 1.xhtml`). The NCX/nav record lookups in `toc/ncx.ts` / `toc/nav.ts` share the same limitation.
4. **Video pause/autoplay on intersection is dead code for HTML-parsed content** — `packages/core/src/enhancers/media/media.ts:55` gates on `entry.target.tagName === "video"`, but `tagName` is uppercase in HTML documents, so off-screen videos are never paused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WssMWsyJnPVX9be1qiDpG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01WssMWsyJnPVX9be1qiDpG5)_