### PR TITLE
chore(demo): bump react-router from 7.18.1 to 8.3.0

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^19.0.0",
     "react-dropzone": "^15.0.0",
     "react-icons": "^5.4.0",
-    "react-router": "^7.1.1",
+    "react-router": "^8.3.0",
     "react-use": "^17.4.0",
     "reactjrx": "^1.97.0",
     "rxjs": "^7.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "react-dom": "^19.0.0",
         "react-dropzone": "^15.0.0",
         "react-icons": "^5.4.0",
-        "react-router": "^7.1.1",
+        "react-router": "^8.3.0",
         "react-use": "^17.4.0",
         "reactjrx": "^1.97.0",
         "rxjs": "^7.8.0",
@@ -9619,16 +9619,11 @@
       "version": "2.0.0",
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
@@ -16654,18 +16649,19 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -17885,10 +17881,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",


### PR DESCRIPTION
## The update

**react-router `7.18.1` → `8.3.0`** (major, security-motivated) in `apps/demo`.

- **Security**: [GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2) — high severity (CVSS 7.1), CSRF in unstable RSC code paths allowing action execution before the 400 response. Vulnerable range is `7.12.0 – 8.2.x`; the fix ships **only in 8.3.0**, so the major bump is the patch path. The demo doesn't use RSC APIs, so practical exposure was low, but this clears the `npm audit` high on a direct dependency.
- **Breaking changes in v8 and why no code changes were needed**:
  - `react-router-dom` removed (DOM APIs now in `react-router`/`react-router/dom`) — the demo already imports everything from `react-router`.
  - ESM-only package — the demo is `"type": "module"` built with Vite.
  - Minimum React 19.2.7 / Node 22.22 — repo is on React 19.2.7+ and Node 25 (`.nvmrc`).
  - v8 future flags became defaults — the demo declared none.
  - Declarative-mode APIs used by the demo (`BrowserRouter`, `Routes`, `Route`, `Link`, `Navigate`, `useNavigate`, `useParams`) are unchanged in v8.
- The `^7.1.1` caret range was raised to `^8.3.0`, keeping the author's range style. `npm audit` no longer reports react-router.
- Docs: internal to the demo app, no public library surface affected — checked `gitbook/`, no update needed.

**Gates** (baseline recorded on clean checkout first; identical results after the update — no new failures):
- `npm run format` / `npm run lint` ✅
- `npm run build` (17 projects, includes demo `tsc -b --noEmit` + vite build) ✅
- `npm run tsc` (6 projects) ✅
- Playwright chromium project: 30 passed / 9 failed — **exactly the same 9 environment-related failures as the pre-update baseline** on this Linux runner (CI runs macOS). The tests app does not use react-router.

## Pending queue (other outdated deps found this run)

Patch / minor (lowest risk, next in line):
| Package | Current → Latest | Level |
|---|---|---|
| @biomejs/biome | 2.5.4 → 2.5.5 | patch |
| @chakra-ui/react | 3.36.0 → 3.36.1 | patch |
| @tanstack/react-query | 5.101.2 → 5.101.4 | patch |
| @vitejs/plugin-react | 6.0.3 → 6.0.4 | patch |
| @zip.js/zip.js | 2.8.33 → 2.8.34 | patch |
| react / react-dom | 19.2.7 → 19.2.8 | patch |
| reactjrx | 1.141.2 → 1.141.5 | patch |
| @playwright/test | 1.61.1 → 1.62.0 | minor |
| happy-dom | 20.10.6 → 20.11.1 | minor |
| lint-staged | 17.0.8 → 17.2.0 | minor |
| typescript | 6.0.3 → 7.0.2 | major version, but range is `*` (lockfile-only move) |

Majors (still coming, one per PR):
| Package | Current → Latest |
|---|---|
| @babel/core | 7.29.7 → 8.0.1 |
| @types/node | 25.9.5 → 26.1.1 |
| expo-file-system | 56.0.8 → 57.0.1 |
| pdfjs-dist | 5.7.284 → 6.1.200 |
| react-dropzone | 15.0.0 → 19.1.1 |
| react-router (v8 for demo done here) | — |
| xmldoc | 2.0.3 → 3.0.0 |

## Needs manual attention

Remaining `npm audit` findings are all on **transitive** deps with no fix reachable by updating a direct dependency:
- **tar (critical)**, js-yaml, minimatch, brace-expansion — pulled in by `lerna` (9.0.7 is already latest; npm's only "fix" is a downgrade to lerna 6.6.2). Blocked upstream on a lerna release.
- **axios / brace-expansion (high)** — via `nx` (pinned by lerna). Blocked upstream.
- **ejs/jake/filelist chain (high)** — via `workbox-build` → `vite-plugin-pwa`. Blocked upstream.
- **uuid (moderate)** — via `expo` → `xcode`. Blocked upstream.
- **fast-uri (high)** — transitive; `npm audit fix` claims a compatible fix, candidate for a future lockfile-only run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJxQNeyybXPN9q8hwYpd4x

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJxQNeyybXPN9q8hwYpd4x)_