### PR TITLE
fix(streamer): escape #/? found in manifest resource paths

### DIFF
--- a/gitbook/learn/streamer/api-reference.md
+++ b/gitbook/learn/streamer/api-reference.md
@@ -66,7 +66,7 @@ createManifestResourceHref(params: {
 }): string
 ```
 
-Builds the `href` used for a manifest resource. An absolute `http(s)://` `resourcePath` is returned untouched (when no `baseUrl` is given); otherwise the path is prefixed with `baseUrl` (a trailing `/` is added when missing) or with `file://` when no `baseUrl` is provided. The result is always passed through `encodeURI`.
+Builds the `href` used for a manifest resource. An absolute `http(s)://` `resourcePath` is returned untouched (when no `baseUrl` is given); otherwise the path is prefixed with `baseUrl` (a trailing `/` is added when missing) or with `file://` when no `baseUrl` is provided. The result is always passed through `encodeURI`, and `#`/`?` characters appearing in the resource path itself are additionally escaped (`%23`/`%3F`) — in an archive filename they are data, not fragment/query delimiters.
 
 ```typescript
 import { createManifestResourceHref } from "@prose-reader/streamer"

--- a/packages/streamer/src/generators/manifest/createManifestResourceHref.test.ts
+++ b/packages/streamer/src/generators/manifest/createManifestResourceHref.test.ts
@@ -22,6 +22,21 @@ describe("createManifestResourceHref", () => {
     )
   })
 
+  it("should escape fragment/query delimiters found in resource paths", () => {
+    expect(
+      createManifestResourceHref({
+        baseUrl: "http://localhost:9000/streamer/book",
+        resourcePath: "page #1.jpg",
+      }),
+    ).toBe("http://localhost:9000/streamer/book/page%20%231.jpg")
+
+    expect(
+      createManifestResourceHref({
+        resourcePath: "who?.jpg",
+      }),
+    ).toBe("file://who%3F.jpg")
+  })
+
   it("should keep absolute resource paths absolute without a base URL", () => {
     expect(
       createManifestResourceHref({

--- a/packages/streamer/src/generators/manifest/createManifestResourceHref.ts
+++ b/packages/streamer/src/generators/manifest/createManifestResourceHref.ts
@@ -1,3 +1,10 @@
+// encodeURI leaves `#` and `?` untouched (reserved URI delimiters), but in
+// a raw archive filename they are data and would otherwise be parsed as
+// fragment/query by whatever fetches the href (a fragment never even reaches
+// the streamer). Same escaping as the archive-reader toc containerHref.
+const encodeResourcePath = (resourcePath: string) =>
+  encodeURI(resourcePath).replace(/#/g, `%23`).replace(/\?/g, `%3F`)
+
 export const createManifestResourceHref = ({
   baseUrl = ``,
   resourcePath,
@@ -13,5 +20,5 @@ export const createManifestResourceHref = ({
     ? `${baseUrl}${baseUrl.endsWith(`/`) ? `` : `/`}`
     : `file://`
 
-  return encodeURI(`${hrefBaseUrl}${resourcePath}`)
+  return `${encodeURI(hrefBaseUrl)}${encodeResourcePath(resourcePath)}`
 }


### PR DESCRIPTION
## The bug

`createManifestResourceHref` (public API of `@prose-reader/streamer`, documented in `gitbook/learn/streamer/api-reference.md`) builds manifest spine-item hrefs with bare `encodeURI`, which deliberately leaves `#` and `?` untouched — they are reserved URI delimiters. But in a raw archive filename they are **data**. Observable on current master, for a CBZ/zip containing an entry named `page #1.jpg`:

```ts
createManifestResourceHref({
  baseUrl: "http://localhost:9000/streamer/book",
  resourcePath: "page #1.jpg",
})
// → "http://localhost:9000/streamer/book/page%20#1.jpg"
```

Everything from `#` onward is a URL fragment. The browser strips a fragment before the request is made, so `ServiceWorkerStreamer.fetchEventListener` receives `…/streamer/book/page%20` and `fetchResource` looks up a record named `page ` — `generateResourceFromArchive` throws `no file found for resourcePath`, and the page never renders. A `?` in a filename similarly turns the tail into a query string.

The repo already fixed exactly this on the TOC side: `archive-reader/src/toc/folders.ts:97-103` escapes `#`/`?` in `containerHref` with an explanatory comment and an enforcing test. The manifest generator was left inconsistent, so the same file gets a working TOC href and a broken spine href.

## Root cause

`encodeURI` percent-encodes spaces, brackets, `%`, etc., but by design passes through the reserved delimiters `#` and `?`. The resource path portion of a manifest href is pure data (an archive record uri), so those two characters must be escaped there.

## The fix

`createManifestResourceHref` now runs the resource-path portion through `encodeURI` plus `%23`/`%3F` replacement, mirroring the `folders.ts` escaping. The base-url portion and the absolute-`http(s)` passthrough branch (remote resources authored as real URLs, where `?`/`#` may be genuine query/fragment) are unchanged. The decode side already round-trips: `Streamer.fetchResource` → `normalizeResourcePath` → `decodeURIComponent` turns `page%20%231.jpg` back into the record uri `page #1.jpg`.

## Verification

- New regression test in `packages/streamer/src/generators/manifest/createManifestResourceHref.test.ts`: **fails before the fix** (`page%20#1.jpg` — the `#` survives as a fragment delimiter) and passes after (`page%20%231.jpg`), covering both the base-url and `file://` forms and both `#` and `?`.
- `@prose-reader/streamer` suite: 71/71 (baseline 70/70 before the change).
- Gates on the pinned Node 25 (matching CI): `lerna run test` green for all 12 unit-test packages, `lerna run build` green (17 projects), `npm run tsc` green, biome clean (enforced by the lint-staged pre-commit hook). The Playwright e2e app is not runnable in this environment — all 195 failures are `browserType.launch: Executable doesn't exist` (pinned browser builds absent from the container), identical with or without the change.
- Docs: `gitbook/learn/streamer/api-reference.md` documented the old behavior ("the result is always passed through `encodeURI`") — updated in the same change to state the additional `#`/`?` escaping.

## Other findings (not addressed in this PR)

Carried over from #236/#255's findings lists, re-verified as still present on master, plus one new observation adjacent to this fix:

1. **`generate()` emits an even CFI step for text nodes preceded by an element** — `packages/cfi/src/generate.ts` computes the text-node step as raw `childNodes` index + 1, colliding with element steps; `resolve()` then maps the CFI back to the wrong node. Fixing requires touching generate and resolve together and changes the meaning of previously stored CFIs.
2. **Percent-encoded OPF hrefs never match archive records** — `packages/archive-reader/src/readingOrder/resolveArchiveReadingOrder.ts` and `opf/getSpineItemFilesFromArchive.ts` look up records by exact string match, but OPF hrefs are percent-encoded per spec while zip record URIs are raw (`chapter%201.xhtml` vs `chapter 1.xhtml`). `toContainerUri` deliberately skips decoding to keep verbatim matches, so a safe fix needs a decoded-fallback lookup.
3. **Video pause/autoplay on intersection is dead code for HTML-parsed content** — `packages/core/src/enhancers/media/media.ts:55` gates on `entry.target.tagName === "video"`, but `tagName` is uppercase (`"VIDEO"`) in HTML documents, so off-screen videos are never paused. Only `<video>` elements are observed, so the guard should be case-insensitive.
4. **New: the records-manifest `items` map shares the `#`/`?` limitation** — `packages/streamer/src/generators/manifest/manifestFromResolvedArchive.ts:152` builds `items` hrefs with bare `encodeURI(baseUrl + file.uri)`. Left out of this PR deliberately: those hrefs are consumed by fuzzy lowercase `endsWith` matching against **raw** document `src` values in `packages/core/src/enhancers/html/renderer/assets.ts:74/139` (which already mismatches any encoded character, e.g. spaces), so escaping there without fixing the matcher could change asset resolution rather than strictly fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GL8RejZttnD3K2aiyUmMS

---
_Generated by [Claude Code](https://claude.ai/code/session_011GL8RejZttnD3K2aiyUmMS)_