### PR TITLE
feat(archive-reader): report declared-but-unreadable sources on resolveArchive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,23 @@ export NVM_DIR="${NVM_DIR:-/opt/nvm}" && . "$NVM_DIR/nvm.sh" && nvm install && n
 
 `nvm install`/`nvm use` read `.nvmrc` from the repo root, so this always follows whatever version is pinned there — no version numbers to keep in sync. Regenerate `package-lock.json` only with the npm that ships with that pinned Node: a mismatched npm rewrites native-binary metadata (e.g. dropping `libc`, mismarking optional platform binaries as `dev`) and produces spurious lockfile churn.
 
+# API design: breaking changes are not a constraint
+
+Cleanliness of the design wins. **"I did not do that because it would be a breaking change" is never a valid reason** — do not weigh backward compatibility when choosing a shape, and do not present it as a trade-off. If the cleanest design changes a public type, renames an export, removes an option or reshapes a returned entity, do that.
+
+Concretely, never do these unless explicitly asked:
+
+- keep a deprecated export, alias or overload alive "for compatibility"
+- add an opt-in flag or option whose only purpose is preserving the old behavior
+- pick a weaker shape (a sibling field, an optional add-on, a widened union) because the better one would break consumers
+- write a migration shim, adapter or compatibility layer
+
+What is still expected of you:
+
+- update every in-repo consumer (all packages, examples, tests) in the same change — a break you introduce is a break you fix repo-wide, and the repo must typecheck and pass tests
+- update `gitbook/` for the new surface, per the Documentation section — not the old one, and no "previously this was…" notes
+- state the break plainly in your summary, including when it needs a semver major, so the release can be handled
+
 # Performances
 
 This library needs to be very careful with everything that impact performances (eg: reflow, heavy dom computation). Whenever possible we should use

--- a/gitbook/archive-reader/README.md
+++ b/gitbook/archive-reader/README.md
@@ -167,6 +167,7 @@ const resolved = await resolveArchive(archive)
 //   metadata: { title, cover?, numberOfPages?, contributors, renditionLayout, belongsTo, … },
 //   readingOrder: [{ uri, id?, mediaType?, size?, renditionLayout?, progressionWeight, … }],
 //   toc: [{ title, path, containerHref, contents }],
+//   unreadableSources: [],
 // }
 ```
 
@@ -182,7 +183,7 @@ Everything is **container-relative** (reading-order `uri`s, toc `containerHref`s
 | `readingOrder` | the OPF read at most — cheap |
 | `toc` | one nav or NCX document read+parse on top — medium |
 | `sources` | same reads as `metadata` — the verbatim parser outputs, for provenance and single-format needs |
-| `version` | free, always present |
+| `version`, `unreadableSources` | free, always present |
 
 The default is `["metadata", "readingOrder", "toc"]`: **the default costs O(sidecar files); anything that reads the whole book is opt-in.** `sources` is deliberately not in the default set — it roughly doubles the persisted entity.
 
@@ -203,6 +204,21 @@ const resolved = await resolveArchive(archive, {
 ### Metadata, sources & error policy
 
 `metadata` is the cross-format union vocabulary — see [Resolved metadata](resolved-metadata.md) for the vocabulary, the per-format mapping tables and the precedence rules. `sources` carries the verbatim parser outputs (`opf` with its `basePath`, `comicInfo`, `apple`, `kobo`); everything in `sources` is also represented, normalized, in `metadata`. Per-source parse failures are swallowed (logged via the debug `Report`): a malformed source — a sidecar or the package document (OPF) itself — never fails the resolve. A book whose OPF won't parse still resolves: it simply doesn't contribute to `metadata`/`toc`, and the reading order degrades to the archive's file listing (see [Resolving the reading order](#resolving-the-reading-order)).
+
+`unreadableSources` is the trace those swallowed failures leave — the sources the container **carries** but that yielded no parsed value:
+
+```typescript
+const { metadata, unreadableSources } = await resolveArchive(archive)
+
+// declared yet broken: refuse the publication rather than present an empty book
+if (unreadableSources.includes("opf")) {
+  throw new Error("Archive carries an OPF package document it cannot parse")
+}
+```
+
+It is always present (empty when every carried source parsed) whatever the projection, so rejecting a corrupt publication costs neither the `sources` payload nor a container-format probe of your own: `sources.opf === undefined` cannot tell a broken package document from a container that has none (a CBZ), and testing the archive records yourself (`isArchiveEpub`) re-derives what the resolver already knows. Its entries are the `sources` keys (`ResolvedArchiveSourceKind`), but the two fields stay separate on purpose: `sources` holds what parsed, `unreadableSources` holds what didn't.
+
+A source counts as unreadable when its document is there and reading or parsing it produced nothing — for the package document, that includes any `.opf` record the OPF discovery never reaches. A projection that reads nothing from the book (`include: ["version"]`) reports nothing.
 
 ## Reading embedded metadata
 

--- a/packages/archive-reader/src/index.ts
+++ b/packages/archive-reader/src/index.ts
@@ -89,6 +89,7 @@ export type {
   ResolveArchiveOptions,
   ResolveArchiveToken,
   ResolvedArchive,
+  ResolvedArchiveSourceKind,
   ResolvedArchiveSources,
 } from "./resolveArchive"
 export { resolveArchive } from "./resolveArchive"

--- a/packages/archive-reader/src/resolveArchive.test.ts
+++ b/packages/archive-reader/src/resolveArchive.test.ts
@@ -77,6 +77,7 @@ describe(`Given an EPUB`, () => {
 
     expect(resolved).toEqual({
       version: 1,
+      unreadableSources: [],
       metadata: {
         title: `My Book`,
         contributors: [{ name: `Jane Author`, roles: [`author`] }],
@@ -110,7 +111,7 @@ describe(`Given an EPUB`, () => {
     })
 
     expectTypeOf(resolved).toEqualTypeOf<
-      Pick<ResolvedArchive, `sources` | `version`>
+      Pick<ResolvedArchive, `sources` | `version` | `unreadableSources`>
     >()
 
     expect(resolved.version).toBe(1)
@@ -155,7 +156,8 @@ describe(`Given a projection that needs nothing read from the book`, () => {
       include: [`version`],
     })
 
-    expect(resolved).toEqual({ version: 1 })
+    // nothing was read, so nothing can be reported broken
+    expect(resolved).toEqual({ version: 1, unreadableSources: [] })
     expect(reads()).toBe(0)
   })
 
@@ -210,6 +212,39 @@ describe(`Given an EPUB with a malformed OPF`, () => {
       `OEBPS/page1.xhtml`,
       `OEBPS/page2.xhtml`,
     ])
+  })
+
+  it(`should report the package document as unreadable`, async () => {
+    const resolved = await resolveArchive(malformedOpfArchive())
+
+    // `sources.opf === undefined` cannot say this: a comic archive with no
+    // package document at all looks exactly the same there
+    expect(resolved.unreadableSources).toEqual([`opf`])
+  })
+
+  it(`should report it for a projection that never asks for sources`, async () => {
+    const resolved = await resolveArchive(malformedOpfArchive(), {
+      include: [`metadata`],
+    })
+
+    expect(resolved.unreadableSources).toEqual([`opf`])
+  })
+
+  it(`should report an OPF record the package discovery cannot reach`, async () => {
+    // carried, well-formed, yet never parsed: OPF discovery matches the
+    // lowercase extension only, so nothing reaches the parser and no read
+    // throws — the container still declares a package document we cannot use
+    const resolved = await resolveArchive(
+      archiveWith(
+        [
+          textRecord(`OEBPS/CONTENT.OPF`, `<package/>`),
+          textRecord(`OEBPS/page1.xhtml`, xhtml(false), { size: 100 }),
+        ],
+        `book.epub`,
+      ),
+    )
+
+    expect(resolved.unreadableSources).toEqual([`opf`])
   })
 })
 
@@ -331,10 +366,14 @@ describe(`Given a CBZ with a ComicInfo sidecar`, () => {
     ])
     // flat container: no toc derivable, key absent
     expect(`toc` in resolved).toBe(false)
+    // a container carrying no package document at all is not a broken EPUB
+    expect(resolved.unreadableSources).toEqual([])
   })
 
   it(`should swallow a malformed sidecar and keep resolving`, async () => {
     const resolved = await resolveArchive(comicArchive(`not xml`))
+
+    expect(resolved.unreadableSources).toEqual([`comicInfo`])
 
     // the malformed sidecar contributes no descriptive metadata; the cover
     // and page count still resolve from the container itself

--- a/packages/archive-reader/src/resolveArchive.ts
+++ b/packages/archive-reader/src/resolveArchive.ts
@@ -7,6 +7,7 @@ import { resolveArchiveCover } from "./cover/resolveArchiveCover"
 import type { KoboMetadata } from "./kobo/parse"
 import { readArchiveKobo } from "./kobo/readArchiveKobo"
 import { readingOrderDocumentsAllHaveViewport } from "./layout/scanReadingOrderDocumentsViewport"
+import { isArchiveEpub } from "./opf/isArchiveEpub"
 import type { ArchiveOpfParsed } from "./opf/readArchiveOpf"
 import { readArchiveOpf } from "./opf/readArchiveOpf"
 import type { ArchiveReadingOrderItem } from "./readingOrder/resolveArchiveReadingOrder"
@@ -33,6 +34,8 @@ export type ResolvedArchiveSources = {
   readonly apple?: AppleMetadata
   readonly kobo?: KoboMetadata
 }
+
+export type ResolvedArchiveSourceKind = keyof ResolvedArchiveSources
 
 /**
  * The fully resolved, plain-JSON view of a book container: everything a
@@ -66,6 +69,31 @@ export type ResolvedArchive = {
    */
   readonly toc?: ArchiveTocItem[]
   readonly sources: ResolvedArchiveSources
+  /**
+   * Sources the container carries but that yielded no parsed value: declared
+   * yet broken, which `sources` alone cannot express — an absent source and an
+   * unreadable one both read as `undefined` there.
+   *
+   * Always present (empty when every carried source parsed), whatever the
+   * projection: a consumer refusing to accept a corrupt publication should not
+   * have to ask for `sources`, nor re-derive the container format from the
+   * archive records to tell the two cases apart.
+   *
+   * ```ts
+   * const { metadata, unreadableSources } = await resolveArchive(archive)
+   *
+   * if (unreadableSources.includes("opf")) {
+   *   throw new Error("Archive carries an OPF package document it cannot parse")
+   * }
+   * ```
+   *
+   * A source counts as unreadable when its document (or, for the package
+   * document, any `.opf` record in the container) is there and reading or
+   * parsing it did not produce a value — the resolve itself never fails, so
+   * this is the only trace left. A projection that reads nothing from the book
+   * reports nothing.
+   */
+  readonly unreadableSources: ResolvedArchiveSourceKind[]
 }
 
 /**
@@ -78,7 +106,8 @@ export type ResolvedArchive = {
  *   fallback.
  * - `readingOrder`: the OPF read at most — cheap.
  * - `toc`: one nav or NCX document read+parse on top — medium.
- * - `version`: free, and always present regardless of projection.
+ * - `version`, `unreadableSources`: free, and always present regardless of
+ *   projection.
  *
  * The default (`metadata`, `readingOrder`, `toc`) costs O(sidecar files) +
  * one navigation document: anything that reads the whole book is opt-in
@@ -112,18 +141,25 @@ export type ResolveArchiveOptions<
   layoutScan?: boolean
 }
 
+/**
+ * `failed` separates "the read threw" from "the read found nothing", which
+ * `value === undefined` conflates — the distinction `unreadableSources`
+ * reports.
+ */
+type SafeRead<T> = { value: T | undefined; failed: boolean }
+
 const safeRead = async <T>(
   read: () => Promise<T>,
   source: string,
-): Promise<T | undefined> => {
+): Promise<SafeRead<T>> => {
   try {
-    return await read()
+    return { value: await read(), failed: false }
   } catch (e) {
     // books in the wild are dirty: a malformed source never fails the
     // resolve, it just doesn't contribute
     Report.error(`resolveArchive: unable to read ${source}`, e)
 
-    return undefined
+    return { value: undefined, failed: true }
   }
 }
 
@@ -151,6 +187,40 @@ const countPages = (
   return count > 0 ? count : undefined
 }
 
+/**
+ * A sidecar reader returns `undefined` only when the container does not carry
+ * the document at all, so a throw is the whole broken signal. The package
+ * document has one more broken shape: a container carrying an `.opf` record
+ * whose package document never reaches the parser (a name the OPF discovery
+ * does not match, a directory record). `isArchiveEpub` is the carrier test
+ * there, which is exactly what consumers had to reach for themselves.
+ */
+const collectUnreadableSources = ({
+  archive,
+  opf,
+  comicInfo,
+  apple,
+  kobo,
+}: {
+  archive: Archive
+  opf: SafeRead<ArchiveOpfParsed | undefined> | undefined
+  comicInfo: SafeRead<ComicInfo | undefined> | undefined
+  apple: SafeRead<AppleMetadata | undefined> | undefined
+  kobo: SafeRead<KoboMetadata | undefined> | undefined
+}): ResolvedArchiveSourceKind[] => {
+  const unreadable: ResolvedArchiveSourceKind[] = []
+
+  if (opf !== undefined && opf.value === undefined) {
+    if (opf.failed || isArchiveEpub(archive)) unreadable.push("opf")
+  }
+
+  if (comicInfo?.failed) unreadable.push("comicInfo")
+  if (apple?.failed) unreadable.push("apple")
+  if (kobo?.failed) unreadable.push("kobo")
+
+  return unreadable
+}
+
 const RESOLVED_ARCHIVE_VERSION = 1
 
 /**
@@ -175,6 +245,10 @@ const RESOLVED_ARCHIVE_VERSION = 1
  * const comicInfo = sources.comicInfo && resolveArchiveMetadata(sources.comicInfo)
  * const isbn = comicInfo?.isbn ?? opf?.isbn // ComicInfo wins, your call
  *
+ * // reject a publication whose package document is there but broken
+ * const { unreadableSources } = await resolveArchive(archive)
+ * if (unreadableSources.includes("opf")) throw new Error("broken OPF")
+ *
  * // full fidelity, including the O(book) layout refinement
  * const resolved = await resolveArchive(archive, {
  *   include: ["metadata", "readingOrder", "toc", "sources"],
@@ -187,7 +261,9 @@ export const resolveArchive = async <
 >(
   archive: Archive,
   options: ResolveArchiveOptions<T> = {},
-): Promise<Pick<ResolvedArchive, T[number] | "version">> => {
+): Promise<
+  Pick<ResolvedArchive, T[number] | "version" | "unreadableSources">
+> => {
   const tokens = new Set<ResolveArchiveToken>(
     options.include ?? DEFAULT_INCLUDE,
   )
@@ -207,20 +283,24 @@ export const resolveArchive = async <
   // (runLayoutScan implies metadata or readingOrder, so it is covered)
   const wantsOpf =
     wantsMetadata || wantsSources || wantsReadingOrder || wantsToc
-  const opf = wantsOpf
+  const opfRead = wantsOpf
     ? await safeRead(() => readArchiveOpf(archive), "opf")
     : undefined
+  const opf = opfRead?.value
 
   const wantsSidecars = wantsMetadata || wantsSources || runLayoutScan
-  const comicInfo = wantsSidecars
+  const comicInfoRead = wantsSidecars
     ? await safeRead(() => readArchiveComicInfo(archive), "comicInfo")
     : undefined
-  const apple = wantsSidecars
+  const comicInfo = comicInfoRead?.value
+  const appleRead = wantsSidecars
     ? await safeRead(() => readArchiveApple(archive), "apple")
     : undefined
-  const kobo = wantsSidecars
+  const apple = appleRead?.value
+  const koboRead = wantsSidecars
     ? await safeRead(() => readArchiveKobo(archive), "kobo")
     : undefined
+  const kobo = koboRead?.value
 
   let metadata =
     wantsMetadata || runLayoutScan
@@ -265,13 +345,20 @@ export const resolveArchive = async <
   }
 
   const toc = wantsToc
-    ? await safeRead(() => resolveArchiveToc(archive, { opf }), "toc")
+    ? (await safeRead(() => resolveArchiveToc(archive, { opf }), "toc")).value
     : undefined
 
   const result: {
     -readonly [K in keyof ResolvedArchive]?: ResolvedArchive[K]
-  } & { version: number } = {
+  } & Pick<ResolvedArchive, "version" | "unreadableSources"> = {
     version: RESOLVED_ARCHIVE_VERSION,
+    unreadableSources: collectUnreadableSources({
+      archive,
+      opf: opfRead,
+      comicInfo: comicInfoRead,
+      apple: appleRead,
+      kobo: koboRead,
+    }),
   }
 
   if (wantsMetadata && metadata !== undefined) result.metadata = metadata
@@ -284,5 +371,8 @@ export const resolveArchive = async <
   // `as`: the runtime projection above mirrors the type-level Pick over the
   // same token set; TypeScript cannot connect Set membership checks to the
   // computed Pick keys.
-  return result as Pick<ResolvedArchive, T[number] | "version">
+  return result as Pick<
+    ResolvedArchive,
+    T[number] | "version" | "unreadableSources"
+  >
 }


### PR DESCRIPTION
## Problem

`sources.opf === undefined` conflates two different books: a container with no package document at all (a CBZ) and an EPUB whose OPF is there but won't parse. A consumer wanting to reject the second had to pair the resolved entity with its own archive probe:

```ts
if (sources.opf === undefined && isArchiveEpub(archive)) {
  throw new Error("Archive carries an OPF package document it cannot parse")
}
```

That forces the consumer to hold on to the archive handle and re-derive the container format the resolver already knew.

## Change

`ResolvedArchive` now carries `unreadableSources` — the sources the container **carries** but that yielded no parsed value:

```ts
const { metadata, unreadableSources } = await resolveArchive(archive)

if (unreadableSources.includes("opf")) throw new Error("broken OPF")
```

It is always present (empty when everything carried parsed) whatever the projection, so rejecting a corrupt publication costs neither the opt-in `sources` payload nor a records scan.

### Why a sibling of `sources` and not a field inside it

- `sources` is verbatim parser output — "what the book said". An unreadable source produced no output; it's a fact about the resolve.
- `sources` is deliberately outside the default projection (it roughly doubles the persisted entity), but a broken source poisons the *default* tokens `metadata` / `toc` / `readingOrder`. Learning your book is corrupt shouldn't require buying the provenance payload.
- Putting a failure marker in that bag would make every `sources.opf.opf` reader narrow past a non-value for a case it doesn't care about.

The two share one vocabulary — `ResolvedArchiveSourceKind = keyof ResolvedArchiveSources` — so the token sets can't drift.

### Detection

`safeRead` now returns `{ value, failed }`: a throw and an absent document both produced `undefined` before, which is exactly the distinction being reported. For the sidecars a throw is the whole broken signal, since their readers return `undefined` only when the file is genuinely absent.

The OPF has one extra broken shape, now covered: a container carrying an `.opf` record whose package document never reaches the parser — `getArchiveOpfInfo` matches `uri.endsWith(".opf")` lowercase only, while `isArchiveEpub` matches case-insensitively, so `OEBPS/CONTENT.OPF` resolved to nothing today *without* throwing. Tested.

Kobo is unchanged and remains the weak spot: `readArchiveKobo` swallows per-file parse errors internally as documented merge semantics, so a broken Kobo sidecar rarely surfaces as `failed`. Changing that is a separate behavioral call.

Scoped to the four metadata sources. A broken nav document / NCX is a similar class of problem but `toc` isn't a source, so it stays out rather than stretching the field's meaning.

## Compatibility

`ResolvedArchive` gains a **required** field, so anything constructing that type whole needs it — semver major. Reading the resolve result is purely additive.

## Also in this PR

An `AGENTS.md` section stating that breaking changes are not a design constraint in this repo: declining a cleaner shape to avoid one is never a valid reason, and neither are the hedges that substitute for it (deprecated aliases, compat flags, migration shims). Unrelated to the feature, but it came out of reviewing this design.

## Verification

- `resolveArchive.test.ts`: 26 passed, including 4 new cases (malformed OPF reported; reported on a `["metadata"]`-only projection; the unreachable `.OPF` record; a CBZ with no package document reports nothing).
- 339 tests passing across `archive-reader`, `streamer`, `cbz`; both packages `tsc --noEmit` clean; biome clean.
- `gitbook/archive-reader/README.md` updated: cost table, default-shape example, and the error-policy section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)