### PR TITLE
Use OPF identifiers for safer metadata matching

### DIFF
--- a/apps/metadata-fetcher-api/src/createApp.test.ts
+++ b/apps/metadata-fetcher-api/src/createApp.test.ts
@@ -126,9 +126,10 @@ const createEpub = async (): Promise<Uint8Array<ArrayBuffer>> => {
   await writer.add(
     "OPS/package.opf",
     new TextReader(`<?xml version="1.0" encoding="UTF-8"?>
-      <package version="3.0" unique-identifier="isbn" xmlns="http://www.idpf.org/2007/opf">
+      <package version="3.0" unique-identifier="bookid" xmlns="http://www.idpf.org/2007/opf">
         <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-          <dc:identifier id="isbn">9780441013593</dc:identifier>
+          <dc:identifier>9780441013593</dc:identifier>
+          <dc:identifier id="bookid">https://example.com/books/dune</dc:identifier>
           <dc:title>Dune</dc:title>
           <dc:creator>Frank Herbert</dc:creator>
           <dc:language>en</dc:language>
@@ -348,6 +349,14 @@ describe("metadata-fetcher-api playground", () => {
       expect(await response.json()).toMatchObject({
         title: "Dune",
         isbn: "9780441013593",
+        identifiers: [
+          { value: "9780441013593" },
+          {
+            value: "https://example.com/books/dune",
+            scheme: "URL",
+            unique: true,
+          },
+        ],
         contributors: [{ name: "Frank Herbert", roles: ["author"] }],
         languages: ["en"],
       })

--- a/gitbook/archive-reader/resolved-metadata.md
+++ b/gitbook/archive-reader/resolved-metadata.md
@@ -72,7 +72,7 @@ Roles use the Readium terms our sources can express — `author`, `translator`, 
 
 Every non-empty OPF `dc:identifier` is preserved in document order. The identifier selected by `package@unique-identifier` has `unique: true`. Parsed source data at `sources.opf.identifiers` also retains each element's XML `id`; normalized `metadata.identifiers` omits that internal anchor while keeping the semantic marker.
 
-Normalized identifiers retain an explicitly authored scheme. When none was authored, a syntactically valid absolute `http://` or `https://` value is classified as `scheme: "URL"`. The inference is deliberately narrow: malformed URLs and other prefixes such as `urn:`, `uuid:`, `calibre:`, or `url:` stay unclassified.
+Normalized identifiers retain an explicitly authored EPUB 2 `opf:scheme`, or the value of an EPUB 3 `meta property="identifier-type"` that refines the identifier. Types expressed through `scheme="onix:codelist5"` are normalized to their named identifier system (`06` → `DOI`, `15` → `ISBN`, and the other standard codes used by the resolver). The direct EPUB 2 attribute wins when a hybrid file states both. Only when neither type was authored is a syntactically valid absolute `http://` or `https://` value classified as `scheme: "URL"`. The inference is deliberately narrow: malformed URLs and other prefixes such as `urn:`, `uuid:`, `calibre:`, or `url:` stay unclassified.
 
 ## Precedence
 
@@ -144,7 +144,7 @@ These mirror the compile-enforced tables shipped next to each resolver — the l
 | `dc:subject` | `subjects` | all, document order |
 | `dc:creator`, `dc:contributor` | `contributors` | roles from `opf:role` and EPUB 3 `meta refines property="role"`, `file-as` → `sortAs` |
 | `dc:date` | `published` | parsed as W3CDTF |
-| `dc:identifier` | `identifiers` | all; authored scheme retained, otherwise valid absolute HTTP(S) → scheme `URL`; the `package@unique-identifier` target has `unique: true`; ISBN-scheme entries drive `isbn`/`gtin` |
+| `dc:identifier` | `identifiers` | all; EPUB 2 `opf:scheme` or EPUB 3 `identifier-type` refinement retained, otherwise valid absolute HTTP(S) → scheme `URL`; the `package@unique-identifier` target has `unique: true`; ISBN-scheme entries drive `isbn`/`gtin` |
 | spine `page-progression-direction` | `readingDirection` | validated |
 | `rendition:layout` meta | `renditionLayout` | validated |
 | `rendition:flow` meta | `renditionFlow` | validated |

--- a/gitbook/archive-reader/resolved-metadata.md
+++ b/gitbook/archive-reader/resolved-metadata.md
@@ -72,6 +72,8 @@ Roles use the Readium terms our sources can express — `author`, `translator`, 
 
 Every non-empty OPF `dc:identifier` is preserved in document order. The identifier selected by `package@unique-identifier` has `unique: true`. Parsed source data at `sources.opf.identifiers` also retains each element's XML `id`; normalized `metadata.identifiers` omits that internal anchor while keeping the semantic marker.
 
+Normalized identifiers retain an explicitly authored scheme. When none was authored, a syntactically valid absolute `http://` or `https://` value is classified as `scheme: "URL"`. The inference is deliberately narrow: malformed URLs and other prefixes such as `urn:`, `uuid:`, `calibre:`, or `url:` stay unclassified.
+
 ## Precedence
 
 When several sources are present, `resolveMetadata` merges field-wise:
@@ -142,7 +144,7 @@ These mirror the compile-enforced tables shipped next to each resolver — the l
 | `dc:subject` | `subjects` | all, document order |
 | `dc:creator`, `dc:contributor` | `contributors` | roles from `opf:role` and EPUB 3 `meta refines property="role"`, `file-as` → `sortAs` |
 | `dc:date` | `published` | parsed as W3CDTF |
-| `dc:identifier` | `identifiers` | all, with scheme; the `package@unique-identifier` target has `unique: true`; ISBN-scheme entries drive `isbn`/`gtin` |
+| `dc:identifier` | `identifiers` | all; authored scheme retained, otherwise valid absolute HTTP(S) → scheme `URL`; the `package@unique-identifier` target has `unique: true`; ISBN-scheme entries drive `isbn`/`gtin` |
 | spine `page-progression-direction` | `readingDirection` | validated |
 | `rendition:layout` meta | `renditionLayout` | validated |
 | `rendition:flow` meta | `renditionFlow` | validated |

--- a/gitbook/metadata-fetcher/README.md
+++ b/gitbook/metadata-fetcher/README.md
@@ -111,7 +111,7 @@ The rules:
   | `publisher`, `languages`, `numberOfPages` | 0.15 | edition details — they must never sink a convincing match alone |
 
 - **A stated identifier settles it.** An agreeing ISBN or GTIN pins the score to `1` whatever else disagrees; a *contradicting* one scores `0` at the heaviest weight, which is what sinks a plausible-looking wrong edition. ISBN-10 and ISBN-13 of the same book compare equal (`toIsbn13` is exported).
-- **Comparisons are fuzzy where the world is.** Titles compare on character bigrams with the subtitle asymmetry repaired (`Dune` ≡ `Dune: a novel`, but `Dune: Book One` ≠ `Dune: Messiah`); names compare on their token set (`Herbert, Frank` ≡ `Frank Herbert`); diacritics and punctuation are folded (`Les Misérables` ≡ `Les Miserables`); languages compare on their primary subtag (`en-US` ≡ `en`).
+- **Comparisons are fuzzy where the world is.** Titles compare on character bigrams with the subtitle asymmetry repaired (`Dune` ≡ `Dune: a novel`, but `Dune: Book One` ≠ `Dune: Messiah`); an explicit conflicting volume, part, or book number makes the title score `0` (`Vol. I` ≠ `vol. 2`). Names compare on their token set (`Herbert, Frank` ≡ `Frank Herbert`); diacritics and punctuation are folded (`Les Misérables` ≡ `Les Miserables`); languages compare on their primary subtag (`en-US` ≡ `en`).
 
 `minScore` (default `0.5`) decides which matches are `accepted` — which ones contribute to the merged `metadata`. Rejected matches are **kept and ranked**, not dropped: "the catalog found three books, none convincing" is an answer, and it is exactly what a "did you mean?" picker renders.
 
@@ -202,7 +202,7 @@ const provider = createOpenLibraryProvider({
 | `fetch` | the global one | for tests, a custom agent, or a caching layer |
 | `userAgent` | — | Open Library's API etiquette asks for an identifying one (app name + contact) and throttles anonymous traffic harder |
 
-**Lookup strategy**, at most two requests: an ISBN search when the book states one — the catalog then verifies the identity for us — falling back to a title (+ first author) search when the ISBN is unknown to it or absent. A query with neither an ISBN nor a title yields no candidates rather than a fishing expedition.
+**Lookup strategy**, at most three requests: an ISBN search when the book states one — the catalog then verifies the identity for us; an exact `id_project_gutenberg` search when an identifier is an official Project Gutenberg URL; then a title (+ first author) search when those identifiers are unknown to Open Library or absent. The Gutenberg URL interpretation is deliberately local to this provider because `id_project_gutenberg` is Open Library's catalog field, not a generic URL convention. A query with none of those terms yields no candidates rather than a fishing expedition.
 
 **Mapping** (`search.json` doc → `ResolvedMetadata`, exported as `openLibraryMetadataHomes`):
 
@@ -216,6 +216,7 @@ const provider = createOpenLibraryProvider({
 | `subject` | `subjects` | capped at the first 25 — a popular work carries hundreds, most of them long-tail noise |
 | `number_of_pages_median` | `numberOfPages` | |
 | `cover_i` | `cover` | absolute url on the cover service, `confidence: "derived"` |
+| `id_project_gutenberg` | `identifiers` | scheme `ProjectGutenberg`; an exact lookup also echoes the book's original Gutenberg URL so the shared scorer can recognize the agreement |
 | `key` | `identifiers` | scheme `OpenLibrary`, e.g. `/works/OL893415W`; also `id` and `url` on the match |
 
 `isbn` is set **only** when the search was an ISBN lookup, and then it is the queried one: the API answered "this work has that ISBN", which is a fact about the record. A title-search hit describes a *work*, whose editions each have their own ISBN, so picking one would be fabrication.

--- a/packages/archive-reader/src/opf/resolve.test.ts
+++ b/packages/archive-reader/src/opf/resolve.test.ts
@@ -155,6 +155,52 @@ describe("resolveOpf", () => {
     ])
   })
 
+  it("uses an EPUB 3 identifier-type refinement before inferring URL", () => {
+    expect(
+      resolveOpf({
+        ...emptyOpf(),
+        identifiers: [
+          {
+            id: "doi",
+            value: "https://doi.org/10.1016/j.iheduc.2008.03.001",
+          },
+          {
+            id: "legacy",
+            scheme: "URI",
+            value: "https://example.com/explicit",
+          },
+          { id: "unrefined", value: "https://example.com/inferred" },
+          {
+            id: "onix-doi",
+            value: "https://doi.org/10.1000/182",
+          },
+        ],
+        metas: [
+          { property: "identifier-type", refines: "#doi", value: " DOI " },
+          {
+            property: "identifier-type",
+            refines: "legacy",
+            value: "DOI",
+          },
+          {
+            property: "identifier-type",
+            refines: "#onix-doi",
+            scheme: "onix:codelist5",
+            value: "06",
+          },
+        ],
+      }).identifiers,
+    ).toEqual([
+      {
+        value: "https://doi.org/10.1016/j.iheduc.2008.03.001",
+        scheme: "DOI",
+      },
+      { value: "https://example.com/explicit", scheme: "URI" },
+      { value: "https://example.com/inferred", scheme: "URL" },
+      { value: "https://doi.org/10.1000/182", scheme: "DOI" },
+    ])
+  })
+
   it("falls back to first identifier value that normalizes as ISBN", () => {
     expect(
       resolveOpf({

--- a/packages/archive-reader/src/opf/resolve.test.ts
+++ b/packages/archive-reader/src/opf/resolve.test.ts
@@ -124,6 +124,37 @@ describe("resolveOpf", () => {
     ])
   })
 
+  it("infers URL only for valid absolute HTTP(S) identifiers without a scheme", () => {
+    expect(
+      resolveOpf({
+        ...emptyOpf(),
+        identifiers: [
+          {
+            id: "bookid",
+            unique: true,
+            value: "http://www.gutenberg.org/78139",
+          },
+          { value: "HTTPS://example.com/books/1" },
+          { value: "https://" },
+          { value: "urn:uuid:abc" },
+          { value: "url:http://example.com/books/1" },
+          { value: "https://example.com/explicit", scheme: "URI" },
+        ],
+      }).identifiers,
+    ).toEqual([
+      {
+        unique: true,
+        value: "http://www.gutenberg.org/78139",
+        scheme: "URL",
+      },
+      { value: "HTTPS://example.com/books/1", scheme: "URL" },
+      { value: "https://" },
+      { value: "urn:uuid:abc" },
+      { value: "url:http://example.com/books/1" },
+      { value: "https://example.com/explicit", scheme: "URI" },
+    ])
+  })
+
   it("falls back to first identifier value that normalizes as ISBN", () => {
     expect(
       resolveOpf({

--- a/packages/archive-reader/src/opf/resolve.ts
+++ b/packages/archive-reader/src/opf/resolve.ts
@@ -126,6 +126,53 @@ const contributorsFromOpf = (input: OpfMetadata): ResolvedContributor[] =>
 const metaRefinesId = (meta: OpfMetaEntry, id: string): boolean =>
   meta.refines !== undefined && meta.refines.replace(/^#/, "") === id
 
+const ONIX_CODE_LIST_5_IDENTIFIER_TYPES: Readonly<Record<string, string>> = {
+  "02": "ISBN",
+  "03": "GTIN",
+  "04": "UPC",
+  "05": "ISMN",
+  "06": "DOI",
+  "13": "LCCN",
+  "14": "GTIN",
+  "15": "ISBN",
+  "22": "URN",
+  "23": "OCLC",
+  "24": "ISBN",
+  "25": "ISMN",
+  "26": "DOI",
+  "34": "GTIN",
+  "35": "ARK",
+}
+
+const normalizedIdentifierType = (
+  meta: OpfMetaEntry | undefined,
+): string | undefined => {
+  const value = meta?.value?.trim()
+
+  if (value === undefined || value.length === 0) return undefined
+  if (meta?.scheme?.trim().toLowerCase() !== "onix:codelist5") return value
+
+  return ONIX_CODE_LIST_5_IDENTIFIER_TYPES[value] ?? value
+}
+
+const refinedIdentifierType = (
+  identifier: OpfIdentifier,
+  metas: ReadonlyArray<OpfMetaEntry>,
+): string | undefined => {
+  const id = identifier.id
+
+  if (id === undefined) return undefined
+
+  return normalizedIdentifierType(
+    metas.find(
+      (meta) =>
+        meta.property === "identifier-type" &&
+        metaRefinesId(meta, id) &&
+        meta.value !== undefined,
+    ),
+  )
+}
+
 const parseDecimal = (raw: string | undefined): number | undefined => {
   const trimmed = raw?.trim()
   if (trimmed === undefined || !/^\d+(\.\d+)?$/.test(trimmed)) return undefined
@@ -263,11 +310,14 @@ export const resolveOpf = (input: OpfMetadata): ResolvedMetadata => {
     isbn: normalizeIsbn(rawIsbn),
     identifiers:
       input.identifiers.length > 0
-        ? input.identifiers.map(({ value, scheme, unique }) =>
+        ? input.identifiers.map((identifier) =>
             omitUndefined({
-              value,
-              scheme: scheme ?? inferredIdentifierScheme(value),
-              unique,
+              value: identifier.value,
+              scheme:
+                identifier.scheme ??
+                refinedIdentifierType(identifier, input.metas) ??
+                inferredIdentifierScheme(identifier.value),
+              unique: identifier.unique,
             }),
           )
         : undefined,

--- a/packages/archive-reader/src/opf/resolve.ts
+++ b/packages/archive-reader/src/opf/resolve.ts
@@ -63,6 +63,23 @@ const rawIdentifierValueForIsbn = (
   return undefined
 }
 
+const inferredIdentifierScheme = (value: string): string | undefined => {
+  const trimmed = value.trim()
+
+  if (!/^https?:\/\//i.test(trimmed)) return undefined
+
+  try {
+    const url = new URL(trimmed)
+
+    return (url.protocol === "http:" || url.protocol === "https:") &&
+      url.hostname.length > 0
+      ? "URL"
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
 /**
  * Common MARC relator codes normalized into the Readium role vocabulary;
  * anything else passes through verbatim (losslessness beats guessing).
@@ -247,7 +264,11 @@ export const resolveOpf = (input: OpfMetadata): ResolvedMetadata => {
     identifiers:
       input.identifiers.length > 0
         ? input.identifiers.map(({ value, scheme, unique }) =>
-            omitUndefined({ value, scheme, unique }),
+            omitUndefined({
+              value,
+              scheme: scheme ?? inferredIdentifierScheme(value),
+              unique,
+            }),
           )
         : undefined,
     belongsTo,

--- a/packages/archive-reader/src/types/resolvedMetadata.ts
+++ b/packages/archive-reader/src/types/resolvedMetadata.ts
@@ -275,9 +275,10 @@ export type ResolvedMetadata = {
   readonly isbn?: string
   /**
    * Raw identifier values, trimmed. OPF contributes every `dc:identifier`,
-   * retaining its announced scheme or classifying a valid absolute HTTP(S)
-   * value as scheme `URL`; `unique` marks the package's selected identifier.
-   * ComicInfo contributes `GTIN` (scheme `GTIN`).
+   * retaining its announced EPUB 2 scheme or EPUB 3 `identifier-type`
+   * refinement, otherwise classifying a valid absolute HTTP(S) value as
+   * scheme `URL`; `unique` marks the package's selected identifier. ComicInfo
+   * contributes `GTIN` (scheme `GTIN`).
    */
   readonly identifiers?: ReadonlyArray<{
     readonly value: string

--- a/packages/archive-reader/src/types/resolvedMetadata.ts
+++ b/packages/archive-reader/src/types/resolvedMetadata.ts
@@ -274,9 +274,10 @@ export type ResolvedMetadata = {
   readonly gtin?: string
   readonly isbn?: string
   /**
-   * Raw identifiers, trimmed, with their announced scheme when present.
-   * OPF every `dc:identifier`; `unique` marks the one referenced by the
-   * package's `unique-identifier` attribute. ComicInfo `GTIN` (scheme `GTIN`).
+   * Raw identifier values, trimmed. OPF contributes every `dc:identifier`,
+   * retaining its announced scheme or classifying a valid absolute HTTP(S)
+   * value as scheme `URL`; `unique` marks the package's selected identifier.
+   * ComicInfo contributes `GTIN` (scheme `GTIN`).
    */
   readonly identifiers?: ReadonlyArray<{
     readonly value: string

--- a/packages/metadata-fetcher/src/match/scoreMetadataCandidate.test.ts
+++ b/packages/metadata-fetcher/src/match/scoreMetadataCandidate.test.ts
@@ -149,4 +149,40 @@ describe("scoreMetadataCandidate", () => {
     expect(result.score).toBeGreaterThan(0.8)
     expect(result.score).toBeLessThan(1)
   })
+
+  it("rejects a fuzzy catalog hit that names a different volume", () => {
+    const result = score(
+      {
+        title: "Wilhelm Meister's apprenticeship and travels, vol. 2 of 2",
+        contributors: [
+          { name: "Goethe, Johann Wolfgang von", roles: ["author"] },
+        ],
+        identifiers: [
+          {
+            value: "http://www.gutenberg.org/78139",
+            scheme: "URL",
+            unique: true,
+          },
+        ],
+        languages: ["en"],
+        published: { year: 2026 },
+        publisher: "Public domain in the USA.",
+      },
+      {
+        title: "Wilhelm Meister's Apprenticeship and Travels, Vol. I (of 2)",
+        contributors: [
+          { name: "Johann Wolfgang von Goethe", roles: ["author"] },
+        ],
+        identifiers: [{ value: "/works/OL40566043W", scheme: "OpenLibrary" }],
+        languages: ["en"],
+        published: { year: 2015 },
+        publisher: "CreateSpace Independent Publishing Platform",
+      },
+    )
+
+    expect(result.score).toBeLessThan(0.5)
+    expect(result.signals).toContainEqual(
+      expect.objectContaining({ field: "title", score: 0 }),
+    )
+  })
 })

--- a/packages/metadata-fetcher/src/match/similarity.test.ts
+++ b/packages/metadata-fetcher/src/match/similarity.test.ts
@@ -53,7 +53,29 @@ describe("titleSimilarity", () => {
     expect(titleSimilarity("Dune: Book One", "Dune: Messiah")).toBeLessThan(0.8)
   })
 
-  it("never scores below the plain comparison", () => {
+  it("rejects contradictory volume, part, and book numbers", () => {
+    expect(
+      titleSimilarity(
+        "Wilhelm Meister's apprenticeship and travels, vol. 2 of 2",
+        "Wilhelm Meister's Apprenticeship and Travels, Vol. I (of 2)",
+      ),
+    ).toBe(0)
+    expect(titleSimilarity("The Story, Part Two", "The Story, Part III")).toBe(
+      0,
+    )
+    expect(
+      titleSimilarity("Chronicles: Book 4", "Chronicles: Book Fourth"),
+    ).toBeGreaterThan(0)
+  })
+
+  it("does not invent a contradiction when only one title states a division", () => {
+    expect(titleSimilarity("Dune", "Dune: Book One")).toBeGreaterThan(0)
+    expect(
+      titleSimilarity("Collected Works, Volume II", "Collected Works, vol. 2"),
+    ).toBeGreaterThan(0.8)
+  })
+
+  it("keeps exact full titles exact", () => {
     expect(titleSimilarity("Dune", "Dune")).toBe(1)
     expect(titleSimilarity("Dune: Messiah", "Dune: Messiah")).toBe(1)
   })

--- a/packages/metadata-fetcher/src/match/similarity.ts
+++ b/packages/metadata-fetcher/src/match/similarity.ts
@@ -64,14 +64,136 @@ const splitTitle = (value: string): { main: string; hasSubtitle: boolean } => {
 /** Below an exact match: the omitted half could have been a volume title. */
 const SUBTITLE_REPAIR_CEILING = 0.9
 
+type TitleDivision = "volume" | "part" | "book"
+const TITLE_DIVISIONS: ReadonlyArray<TitleDivision> = ["volume", "part", "book"]
+
+const TITLE_DIVISION_PATTERN =
+  /\b(volumes?|vols?|parts?|books?)\s+([\p{L}\p{N}]+)\b/gu
+
+const TITLE_NUMBER_WORDS: Readonly<Record<string, number>> = {
+  one: 1,
+  first: 1,
+  two: 2,
+  second: 2,
+  three: 3,
+  third: 3,
+  four: 4,
+  fourth: 4,
+  five: 5,
+  fifth: 5,
+  six: 6,
+  sixth: 6,
+  seven: 7,
+  seventh: 7,
+  eight: 8,
+  eighth: 8,
+  nine: 9,
+  ninth: 9,
+  ten: 10,
+  tenth: 10,
+  eleven: 11,
+  eleventh: 11,
+  twelve: 12,
+  twelfth: 12,
+}
+
+const ROMAN_DIGIT_VALUES: Readonly<Record<string, number>> = {
+  i: 1,
+  v: 5,
+  x: 10,
+  l: 50,
+  c: 100,
+  d: 500,
+  m: 1000,
+}
+
+const parseRomanNumeral = (value: string): number | undefined => {
+  if (!/^m{0,3}(cm|cd|d?c{0,3})(xc|xl|l?x{0,3})(ix|iv|v?i{0,3})$/i.test(value))
+    return undefined
+
+  let total = 0
+  let previous = 0
+
+  for (const symbol of [...value.toLowerCase()].reverse()) {
+    const current = ROMAN_DIGIT_VALUES[symbol]
+
+    if (current === undefined) return undefined
+
+    if (current < previous) total -= current
+    else {
+      total += current
+      previous = current
+    }
+  }
+
+  return total > 0 ? total : undefined
+}
+
+const parseTitleDivisionNumber = (value: string): number | undefined => {
+  if (/^\d+$/.test(value)) return Number.parseInt(value, 10)
+
+  return TITLE_NUMBER_WORDS[value] ?? parseRomanNumeral(value)
+}
+
+const titleDivision = (value: string): TitleDivision | undefined => {
+  if (value.startsWith("vol")) return "volume"
+  if (value.startsWith("part")) return "part"
+  if (value.startsWith("book")) return "book"
+
+  return undefined
+}
+
+const explicitTitleDivisions = (
+  value: string,
+): ReadonlyMap<TitleDivision, ReadonlySet<number>> => {
+  const divisions = new Map<TitleDivision, Set<number>>()
+
+  for (const match of normalizeForComparison(value).matchAll(
+    TITLE_DIVISION_PATTERN,
+  )) {
+    const division =
+      match[1] !== undefined ? titleDivision(match[1]) : undefined
+    const number =
+      match[2] !== undefined ? parseTitleDivisionNumber(match[2]) : undefined
+
+    if (division === undefined || number === undefined) continue
+
+    const numbers = divisions.get(division) ?? new Set<number>()
+    numbers.add(number)
+    divisions.set(division, numbers)
+  }
+
+  return divisions
+}
+
+const titleDivisionsContradict = (a: string, b: string): boolean => {
+  const left = explicitTitleDivisions(a)
+  const right = explicitTitleDivisions(b)
+
+  for (const division of TITLE_DIVISIONS) {
+    const leftNumbers = left.get(division)
+    const rightNumbers = right.get(division)
+
+    if (leftNumbers === undefined || rightNumbers === undefined) continue
+    if ([...leftNumbers].every((number) => !rightNumbers.has(number)))
+      return true
+  }
+
+  return false
+}
+
 /**
  * {@link textSimilarity}, with `Dune` matched against `Dune: a novel`.
  *
  * Only when **one** side states a subtitle: that asymmetry is the same title
  * catalogued at a different depth. When both state one, both catalogers meant
  * it — `Dune: Book One` and `Dune: Messiah` are two books.
+ * Explicit volume, part, or book numbers are semantic identity: when both
+ * sides state different ones, the title score is `0` however similar the rest.
  */
 export const titleSimilarity = (a: string, b: string): number => {
+  if (titleDivisionsContradict(a, b)) return 0
+
   const full = textSimilarity(a, b)
   const left = splitTitle(a)
   const right = splitTitle(b)

--- a/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.test.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.test.ts
@@ -82,6 +82,59 @@ describe("createOpenLibraryProvider", () => {
     expect(candidates[0]?.metadata.isbn).toBeUndefined()
   })
 
+  it("looks an official Project Gutenberg URL up by Open Library's external id", async () => {
+    const identifierValue = "http://www.gutenberg.org/1342"
+    const fetchMock = fetchReturning({
+      docs: [
+        {
+          ...DUNE_DOC,
+          id_project_gutenberg: ["1342", "42671"],
+        },
+      ],
+    })
+    const provider = createOpenLibraryProvider({ fetch: fetchMock })
+
+    const candidates = await provider.search(
+      {
+        identifiers: [{ value: identifierValue, scheme: "URL", unique: true }],
+      },
+      context,
+    )
+    const url = requestedUrl(fetchMock, 0)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(url.searchParams.get("q")).toBe("id_project_gutenberg:1342")
+    expect(url.searchParams.get("title")).toBeNull()
+    expect(url.searchParams.get("fields")).toContain("id_project_gutenberg")
+    expect(candidates[0]?.metadata.identifiers).toEqual([
+      { value: identifierValue, scheme: "URL" },
+      { value: "1342", scheme: "ProjectGutenberg" },
+      { value: "42671", scheme: "ProjectGutenberg" },
+      { value: DUNE_DOC.key, scheme: "OpenLibrary" },
+    ])
+  })
+
+  it("falls back to title when Open Library has no Gutenberg cross-reference", async () => {
+    const fetchMock = fetchReturning({ docs: [] }, { docs: [DUNE_DOC] })
+    const provider = createOpenLibraryProvider({ fetch: fetchMock })
+
+    await provider.search(
+      {
+        title: "Dune",
+        identifiers: [
+          { value: "https://www.gutenberg.org/ebooks/999999", scheme: "URL" },
+        ],
+      },
+      context,
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(requestedUrl(fetchMock, 0).searchParams.get("q")).toBe(
+      "id_project_gutenberg:999999",
+    )
+    expect(requestedUrl(fetchMock, 1).searchParams.get("title")).toBe("Dune")
+  })
+
   it("returns nothing, without asking, when the query has neither ISBN nor title", async () => {
     const fetchMock = fetchReturning()
     const provider = createOpenLibraryProvider({ fetch: fetchMock })

--- a/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.ts
@@ -7,6 +7,10 @@ import type {
 import { metadataAuthors } from "../../utils/metadataAuthors.ts"
 import { MetadataProviderResponseError } from "../responseError.ts"
 import { type OpenLibraryDoc, parseOpenLibrarySearchResponse } from "./parse.ts"
+import {
+  type OpenLibraryProjectGutenbergLookup,
+  projectGutenbergLookupFromMetadata,
+} from "./projectGutenbergIdentifier.ts"
 import { resolveOpenLibraryDoc } from "./resolve.ts"
 
 export const OPEN_LIBRARY_PROVIDER_ID = "openLibrary"
@@ -30,6 +34,7 @@ const SEARCH_FIELDS = [
   "subject",
   "number_of_pages_median",
   "cover_i",
+  "id_project_gutenberg",
 ].join(",")
 
 export type OpenLibraryProviderOptions = {
@@ -71,11 +76,11 @@ const searchTerms = (
  * })
  * ```
  *
- * Lookup strategy, at most two requests: an **ISBN search** when the book
- * states one — the catalog then verifies the identity for us — falling back
- * to a **title (+ first author) search** when the ISBN is unknown to it or
- * absent. A query with neither an ISBN nor a title yields no candidates
- * rather than a fishing expedition.
+ * Lookup strategy, at most three requests: an **ISBN search** when the book
+ * states one; an exact **Project Gutenberg id search** when an identifier is
+ * an official Gutenberg URL; then a **title (+ first author) search**. A query
+ * with none of those terms yields no candidates rather than a fishing
+ * expedition.
  */
 export const createOpenLibraryProvider = (
   options: OpenLibraryProviderOptions = {},
@@ -120,10 +125,18 @@ export const createOpenLibraryProvider = (
 
   const toCandidates = (
     docs: ReadonlyArray<OpenLibraryDoc>,
-    isbn: string | undefined,
+    options: {
+      readonly isbn?: string
+      readonly confirmedProjectGutenberg?: OpenLibraryProjectGutenbergLookup
+    } = {},
   ): ReadonlyArray<MetadataCandidate> =>
     docs.map((doc) => ({
-      metadata: resolveOpenLibraryDoc(doc, { coversBaseUrl, isbn }),
+      metadata: resolveOpenLibraryDoc(doc, {
+        coversBaseUrl,
+        isbn: options.isbn,
+        matchedProjectGutenbergIdentifier:
+          options.confirmedProjectGutenberg?.identifier,
+      }),
       id: doc.key,
       url: doc.key !== undefined ? `${baseUrl}${doc.key}` : undefined,
       raw: doc,
@@ -134,18 +147,32 @@ export const createOpenLibraryProvider = (
     name: "Open Library",
     search: async (metadata, context) => {
       const isbn = metadata.isbn?.trim() || undefined
+      const projectGutenberg = projectGutenbergLookupFromMetadata(metadata)
 
       if (isbn !== undefined) {
         const docs = await searchDocs({ isbn }, context)
 
-        if (docs.length > 0) return toCandidates(docs, isbn)
+        if (docs.length > 0) return toCandidates(docs, { isbn })
+      }
+
+      if (projectGutenberg !== undefined) {
+        const docs = await searchDocs(
+          { q: `id_project_gutenberg:${projectGutenberg.id}` },
+          context,
+        )
+
+        if (docs.length > 0) {
+          return toCandidates(docs, {
+            confirmedProjectGutenberg: projectGutenberg,
+          })
+        }
       }
 
       const terms = searchTerms(metadata)
 
       if (terms === undefined) return []
 
-      return toCandidates(await searchDocs(terms, context), undefined)
+      return toCandidates(await searchDocs(terms, context))
     },
   }
 }

--- a/packages/metadata-fetcher/src/providers/openLibrary/parse.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/parse.ts
@@ -28,6 +28,8 @@ export type OpenLibraryDoc = {
   readonly number_of_pages_median?: number
   /** Cover id, addressing `covers.openlibrary.org`. */
   readonly cover_i?: number
+  /** Project Gutenberg ebook ids attached to the work's editions. */
+  readonly id_project_gutenberg?: ReadonlyArray<string>
 }
 
 const parseDoc = (record: Record<string, unknown>): OpenLibraryDoc => ({
@@ -41,6 +43,7 @@ const parseDoc = (record: Record<string, unknown>): OpenLibraryDoc => ({
   subject: readStringArray(record, "subject"),
   number_of_pages_median: readNumber(record, "number_of_pages_median"),
   cover_i: readNumber(record, "cover_i"),
+  id_project_gutenberg: readStringArray(record, "id_project_gutenberg"),
 })
 
 /**

--- a/packages/metadata-fetcher/src/providers/openLibrary/projectGutenbergIdentifier.test.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/projectGutenbergIdentifier.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { projectGutenbergLookupFromMetadata } from "./projectGutenbergIdentifier.ts"
+
+describe("projectGutenbergLookupFromMetadata", () => {
+  it.each([
+    "http://www.gutenberg.org/78139",
+    "https://www.gutenberg.org/ebooks/78139",
+    "https://www.gutenberg.org/ebooks/78139.epub3.images",
+    "https://www.gutenberg.org/files/78139/78139-h/78139-h.htm",
+    "https://gutenberg.org/cache/epub/78139/pg78139-images.html",
+  ])("extracts the id from an official Gutenberg URL: %s", (value) => {
+    expect(
+      projectGutenbergLookupFromMetadata({
+        identifiers: [{ value, scheme: "URL" }],
+      }),
+    ).toEqual({ id: "78139", identifier: { value, scheme: "URL" } })
+  })
+
+  it("does not reinterpret arbitrary URLs or authored identifier types", () => {
+    expect(
+      projectGutenbergLookupFromMetadata({
+        identifiers: [
+          { value: "https://example.com/78139", scheme: "URL" },
+          {
+            value: "https://www.gutenberg.org/78139",
+            scheme: "DOI",
+          },
+        ],
+      }),
+    ).toBeUndefined()
+  })
+})

--- a/packages/metadata-fetcher/src/providers/openLibrary/projectGutenbergIdentifier.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/projectGutenbergIdentifier.ts
@@ -1,0 +1,72 @@
+import type { ResolvedMetadata } from "@prose-reader/archive-reader"
+
+export type OpenLibraryProjectGutenbergLookup = {
+  readonly id: string
+  /** The book's exact identifier spelling, echoed only after OL confirms it. */
+  readonly identifier: {
+    readonly value: string
+    readonly scheme?: string
+  }
+}
+
+const GUTENBERG_HOSTS: ReadonlySet<string> = new Set([
+  "gutenberg.org",
+  "www.gutenberg.org",
+])
+
+const GUTENBERG_PATHS: ReadonlyArray<RegExp> = [
+  /^\/ebooks\/(\d+)(?:[./]|$)/i,
+  /^\/files\/(\d+)(?:\/|$)/i,
+  /^\/cache\/epub\/(\d+)(?:\/|$)/i,
+  /^\/(\d+)(?:\/|$)/,
+]
+
+const projectGutenbergIdFromUrl = (value: string): string | undefined => {
+  try {
+    const url = new URL(value.trim())
+
+    if (url.protocol !== "http:" && url.protocol !== "https:") return undefined
+    if (!GUTENBERG_HOSTS.has(url.hostname.toLowerCase())) return undefined
+
+    for (const pattern of GUTENBERG_PATHS) {
+      const id = pattern.exec(url.pathname)?.[1]
+
+      if (id !== undefined) return id
+    }
+  } catch {
+    return undefined
+  }
+
+  return undefined
+}
+
+/**
+ * Open Library-specific crosswalk: its `id_project_gutenberg` search field
+ * stores the numeric id encoded by official Gutenberg URLs. Other providers
+ * own their own identifier conventions; this is intentionally not generic.
+ */
+export const projectGutenbergLookupFromMetadata = (
+  metadata: ResolvedMetadata,
+): OpenLibraryProjectGutenbergLookup | undefined => {
+  for (const identifier of metadata.identifiers ?? []) {
+    const scheme = identifier.scheme?.trim().toLowerCase()
+
+    if (scheme !== undefined && scheme !== "url" && scheme !== "uri") continue
+
+    const id = projectGutenbergIdFromUrl(identifier.value)
+
+    if (id === undefined) continue
+
+    return {
+      id,
+      identifier: {
+        value: identifier.value,
+        ...(identifier.scheme !== undefined
+          ? { scheme: identifier.scheme }
+          : {}),
+      },
+    }
+  }
+
+  return undefined
+}

--- a/packages/metadata-fetcher/src/providers/openLibrary/resolve.test.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/resolve.test.ts
@@ -10,9 +10,21 @@ describe("parseOpenLibrarySearchResponse", () => {
     expect(
       parseOpenLibrarySearchResponse({
         numFound: 1,
-        docs: [{ key: "/works/OL1W", title: "Dune" }],
+        docs: [
+          {
+            key: "/works/OL1W",
+            title: "Dune",
+            id_project_gutenberg: ["1342"],
+          },
+        ],
       }),
-    ).toEqual([expect.objectContaining({ key: "/works/OL1W", title: "Dune" })])
+    ).toEqual([
+      expect.objectContaining({
+        key: "/works/OL1W",
+        title: "Dune",
+        id_project_gutenberg: ["1342"],
+      }),
+    ])
   })
 
   it("reads an unexpected payload as nothing found", () => {
@@ -29,6 +41,7 @@ describe("parseOpenLibrarySearchResponse", () => {
           author_name: ["Frank Herbert", null, "  "],
           first_publish_year: "1965",
           cover_i: 8188413,
+          id_project_gutenberg: ["1342", null, "  "],
         },
       ],
     })
@@ -36,6 +49,7 @@ describe("parseOpenLibrarySearchResponse", () => {
     expect(doc).toEqual({
       author_name: ["Frank Herbert"],
       cover_i: 8188413,
+      id_project_gutenberg: ["1342"],
     })
   })
 })
@@ -72,6 +86,7 @@ describe("resolveOpenLibraryDoc", () => {
           subject: ["Science fiction"],
           number_of_pages_median: 412,
           cover_i: 8188413,
+          id_project_gutenberg: ["1965"],
         },
         { coversBaseUrl },
       ),
@@ -88,7 +103,10 @@ describe("resolveOpenLibraryDoc", () => {
         mediaType: "image/jpeg",
         confidence: "derived",
       },
-      identifiers: [{ value: "/works/OL893415W", scheme: "OpenLibrary" }],
+      identifiers: [
+        { value: "1965", scheme: "ProjectGutenberg" },
+        { value: "/works/OL893415W", scheme: "OpenLibrary" },
+      ],
     })
   })
 
@@ -114,6 +132,24 @@ describe("resolveOpenLibraryDoc", () => {
       isbn: "9780441013593",
       identifiers: [{ value: "9780441013593", scheme: "ISBN" }],
     })
+  })
+
+  it("echoes a Gutenberg URL only after an exact external-id lookup", () => {
+    expect(
+      resolveOpenLibraryDoc(
+        { title: "Pride and Prejudice", id_project_gutenberg: ["1342"] },
+        {
+          coversBaseUrl,
+          matchedProjectGutenbergIdentifier: {
+            value: "http://www.gutenberg.org/1342",
+            scheme: "URL",
+          },
+        },
+      ).identifiers,
+    ).toEqual([
+      { value: "http://www.gutenberg.org/1342", scheme: "URL" },
+      { value: "1342", scheme: "ProjectGutenberg" },
+    ])
   })
 
   it("dedupes the languages the MARC variants collapse into", () => {

--- a/packages/metadata-fetcher/src/providers/openLibrary/resolve.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/resolve.ts
@@ -27,12 +27,14 @@ export const openLibraryMetadataHomes = {
   subject: "subjects",
   number_of_pages_median: "numberOfPages",
   cover_i: "cover",
+  id_project_gutenberg: "identifiers",
 } as const satisfies Record<
   keyof OpenLibraryDoc,
   keyof ResolvedMetadata | "identifiers"
 >
 
 export const OPEN_LIBRARY_IDENTIFIER_SCHEME = "OpenLibrary"
+const PROJECT_GUTENBERG_IDENTIFIER_SCHEME = "ProjectGutenberg"
 
 const emptyToUndefined = <T>(
   values: ReadonlyArray<T>,
@@ -56,6 +58,11 @@ export const resolveOpenLibraryDoc = (
     readonly coversBaseUrl: string
     /** The ISBN this record was looked up by, when it was. */
     readonly isbn?: string
+    /** The source identifier that an exact Gutenberg-id lookup confirmed. */
+    readonly matchedProjectGutenbergIdentifier?: {
+      readonly value: string
+      readonly scheme?: string
+    }
   },
 ): ResolvedMetadata => {
   const title =
@@ -75,6 +82,13 @@ export const resolveOpenLibraryDoc = (
     ...(options.isbn !== undefined
       ? [{ value: options.isbn, scheme: "ISBN" }]
       : []),
+    ...(options.matchedProjectGutenbergIdentifier !== undefined
+      ? [options.matchedProjectGutenbergIdentifier]
+      : []),
+    ...(doc.id_project_gutenberg ?? []).map((value) => ({
+      value,
+      scheme: PROJECT_GUTENBERG_IDENTIFIER_SCHEME,
+    })),
     ...(doc.key !== undefined
       ? [{ value: doc.key, scheme: OPEN_LIBRARY_IDENTIFIER_SCHEME }]
       : []),


### PR DESCRIPTION
## Summary

- classify valid absolute HTTP(S) OPF identifiers without an authored type as `URL`
- honor EPUB 2 `opf:scheme` and EPUB 3 `identifier-type` refinements before URL inference, including ONIX codelist 5 normalization
- let the Open Library provider recognize official Project Gutenberg URLs and query `id_project_gutenberg` before title/author fallback
- return Open Library's Gutenberg identifiers and echo an exact matched source URL for shared scoring
- score explicit conflicting volume, part, or book numbers as a title contradiction
- document the resolved identifier, provider lookup, and matching behavior

## Why

Some EPUBs use a Project Gutenberg URL as their package identifier without declaring an identifier type. Open Library has a searchable `id_project_gutenberg` field, so its provider can derive the numeric id from official Gutenberg URL forms and use the catalog cross-reference when one exists.

Open Library does not currently have a cross-reference for Gutenberg 78139. Its title/author fallback returns Volume I records for the uploaded Volume 2 EPUB. A fuzzy character comparison otherwise rates those titles too highly, so explicit division-number disagreements now make the title signal zero and keep the wrong volume below the acceptance threshold.

The URL fallback remains deliberately narrow and source-faithful: parsed OPF data is unchanged, explicit EPUB identifier types win, and arbitrary URLs are not interpreted as catalog identifiers.

## Validation

- `npm test --workspace @prose-reader/archive-reader` — 237 tests passed
- `npm test --workspace @prose-reader/metadata-fetcher` — 83 tests passed
- `npm test --workspace prose-reader-metadata-fetcher-api` — 36 tests passed
- `npm run tsc` — all 8 projects passed
- `npm run build --workspace @prose-reader/archive-reader`
- `npm run build --workspace @prose-reader/metadata-fetcher`
- Biome check on all changed TypeScript files
- live Open Library verification: Gutenberg 1342 resolves through `id_project_gutenberg`; Gutenberg 78139 currently returns no exact result
