### PR TITLE
Add Gutenberg provider and explicit publication events

### DIFF
--- a/apps/metadata-fetcher-api/README.md
+++ b/apps/metadata-fetcher-api/README.md
@@ -112,7 +112,7 @@ Both answer with the `FetchedMetadata` entity verbatim — merged `metadata`, ra
 | `METADATA_MIN_SCORE` | `0.5` | default `minScore` |
 | `REQUEST_TIMEOUT_MS` | `10000` | budget for one lookup across every provider |
 | `PROJECT_GUTENBERG_USER_AGENT` | — | optional identifying user agent for exact RDF lookups |
-| `PROJECT_GUTENBERG_BASE_URL` | `https://www.gutenberg.org` | override to point at a mirror or a stub |
+| `PROJECT_GUTENBERG_BASE_URL` | `https://www.gutenberg.org` | absolute HTTP(S) origin; override to point at a mirror or a stub |
 | `OPEN_LIBRARY_USER_AGENT` | — | **set this**: Open Library asks API clients to identify themselves (app name + contact) and throttles anonymous traffic harder |
 | `OPEN_LIBRARY_BASE_URL` | `https://openlibrary.org` | override to point at a mirror or a stub |
 | `OPEN_LIBRARY_COVERS_BASE_URL` | `https://covers.openlibrary.org` | |

--- a/apps/metadata-fetcher-api/README.md
+++ b/apps/metadata-fetcher-api/README.md
@@ -62,9 +62,10 @@ Human-friendly lookup, for curl and quick tries.
 | `title` | |
 | `author` | repeatable |
 | `isbn`, `gtin` | |
-| `publisher`, `series` | |
+| `series` | |
 | `language` | repeatable |
-| `year` | publication year |
+| `originalPublisher`, `editionPublisher` | publisher for the explicitly named publication event |
+| `originalPublicationYear`, `editionPublicationYear` | year for the explicitly named publication event |
 
 ```bash
 curl "http://localhost:3000/metadata?isbn=9780441013593"

--- a/apps/metadata-fetcher-api/README.md
+++ b/apps/metadata-fetcher-api/README.md
@@ -44,7 +44,13 @@ The condition is inert for anyone else: nothing applies it unless asked, and nor
 Liveness, plus the providers this deployment exposes.
 
 ```json
-{ "status": "ok", "providers": [{ "id": "openLibrary", "name": "Open Library" }] }
+{
+  "status": "ok",
+  "providers": [
+    { "id": "projectGutenberg", "name": "Project Gutenberg" },
+    { "id": "openLibrary", "name": "Open Library" }
+  ]
+}
 ```
 
 ### `GET /metadata`
@@ -105,6 +111,8 @@ Both answer with the `FetchedMetadata` entity verbatim — merged `metadata`, ra
 | `METADATA_LIMIT` | `5` | default `limit` |
 | `METADATA_MIN_SCORE` | `0.5` | default `minScore` |
 | `REQUEST_TIMEOUT_MS` | `10000` | budget for one lookup across every provider |
+| `PROJECT_GUTENBERG_USER_AGENT` | — | optional identifying user agent for exact RDF lookups |
+| `PROJECT_GUTENBERG_BASE_URL` | `https://www.gutenberg.org` | override to point at a mirror or a stub |
 | `OPEN_LIBRARY_USER_AGENT` | — | **set this**: Open Library asks API clients to identify themselves (app name + contact) and throttles anonymous traffic harder |
 | `OPEN_LIBRARY_BASE_URL` | `https://openlibrary.org` | override to point at a mirror or a stub |
 | `OPEN_LIBRARY_COVERS_BASE_URL` | `https://covers.openlibrary.org` | |

--- a/apps/metadata-fetcher-api/docker-compose.yml
+++ b/apps/metadata-fetcher-api/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - "${METADATA_FETCHER_PORT:-3000}:3000"
     environment:
       PORT: 3000
+      PROJECT_GUTENBERG_USER_AGENT: ${PROJECT_GUTENBERG_USER_AGENT:-prose-reader-metadata-fetcher-api (development)}
       # Open Library asks clients to identify themselves (see the README)
       OPEN_LIBRARY_USER_AGENT: ${OPEN_LIBRARY_USER_AGENT:-prose-reader-metadata-fetcher-api (development)}
       METADATA_LIMIT: ${METADATA_LIMIT:-5}

--- a/apps/metadata-fetcher-api/src/config.test.ts
+++ b/apps/metadata-fetcher-api/src/config.test.ts
@@ -12,6 +12,7 @@ describe("configFromEnv", () => {
       requestTimeoutMs: 10_000,
     })
     expect(config.providers.map((provider) => provider.id)).toEqual([
+      "projectGutenberg",
       "openLibrary",
     ])
   })

--- a/apps/metadata-fetcher-api/src/config.test.ts
+++ b/apps/metadata-fetcher-api/src/config.test.ts
@@ -51,5 +51,11 @@ describe("configFromEnv", () => {
     expect(() => configFromEnv({ METADATA_MIN_SCORE: "2" })).toThrow(
       /METADATA_MIN_SCORE/,
     )
+    expect(() =>
+      configFromEnv({ PROJECT_GUTENBERG_BASE_URL: "not-a-url" }),
+    ).toThrow(/Invalid PROJECT_GUTENBERG_BASE_URL/)
+    expect(() =>
+      configFromEnv({ PROJECT_GUTENBERG_BASE_URL: "file:///tmp/catalog" }),
+    ).toThrow(/absolute HTTP\(S\) URL/)
   })
 })

--- a/apps/metadata-fetcher-api/src/config.ts
+++ b/apps/metadata-fetcher-api/src/config.ts
@@ -1,5 +1,6 @@
 import {
   createOpenLibraryProvider,
+  createProjectGutenbergProvider,
   type MetadataProvider,
 } from "@prose-reader/metadata-fetcher"
 
@@ -69,6 +70,10 @@ const readString = (
 const providersFromEnv = (
   env: NodeJS.ProcessEnv,
 ): ReadonlyArray<MetadataProvider> => [
+  createProjectGutenbergProvider({
+    userAgent: readString(env, "PROJECT_GUTENBERG_USER_AGENT"),
+    baseUrl: readString(env, "PROJECT_GUTENBERG_BASE_URL"),
+  }),
   createOpenLibraryProvider({
     userAgent: readString(env, "OPEN_LIBRARY_USER_AGENT"),
     baseUrl: readString(env, "OPEN_LIBRARY_BASE_URL"),

--- a/apps/metadata-fetcher-api/src/config.ts
+++ b/apps/metadata-fetcher-api/src/config.ts
@@ -67,12 +67,32 @@ const readString = (
   return raw !== undefined && raw.length > 0 ? raw : undefined
 }
 
+const readUrl = (env: NodeJS.ProcessEnv, key: string): string | undefined => {
+  const raw = readString(env, key)
+
+  if (raw === undefined) return undefined
+
+  let url: URL
+
+  try {
+    url = new URL(raw)
+  } catch {
+    throw invalid(key, raw, "an absolute HTTP(S) URL")
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw invalid(key, raw, "an absolute HTTP(S) URL")
+  }
+
+  return raw
+}
+
 const providersFromEnv = (
   env: NodeJS.ProcessEnv,
 ): ReadonlyArray<MetadataProvider> => [
   createProjectGutenbergProvider({
     userAgent: readString(env, "PROJECT_GUTENBERG_USER_AGENT"),
-    baseUrl: readString(env, "PROJECT_GUTENBERG_BASE_URL"),
+    baseUrl: readUrl(env, "PROJECT_GUTENBERG_BASE_URL"),
   }),
   createOpenLibraryProvider({
     userAgent: readString(env, "OPEN_LIBRARY_USER_AGENT"),

--- a/apps/metadata-fetcher-api/src/createApp.test.ts
+++ b/apps/metadata-fetcher-api/src/createApp.test.ts
@@ -41,7 +41,7 @@ const duneProvider: MetadataProvider = {
         raw: { note: "verbatim" },
         metadata: {
           title: "Dune",
-          publisher: "Chilton Books",
+          publication: { edition: { publisher: "Chilton Books" } },
           contributors: [{ name: "Frank Herbert", roles: ["author"] }],
         },
       },
@@ -203,7 +203,7 @@ describe("metadata-fetcher-api", () => {
 
   it("accepts a resolved archive posted verbatim", async () => {
     const response = await api.post("/metadata", {
-      version: 1,
+      version: 2,
       metadata: { title: "Dune", numberOfPages: 412 },
       readingOrder: [{ uri: "page-1.jpg" }],
       unreadableSources: [],
@@ -218,7 +218,7 @@ describe("metadata-fetcher-api", () => {
       title: 42,
       contributors: "nope",
       identifiers: [{ value: null }],
-      published: { year: "1965" },
+      publication: { original: { date: { year: "1965" } } },
     })
 
     // nothing survived as a search term — a 400, not a 500
@@ -263,10 +263,13 @@ describe("metadata-fetcher-api", () => {
     // the catalog's publisher disagrees, so the match is short of perfect —
     // which is exactly what `minScore=1` refuses
     const strict = await readFetched(
-      await api.get("/metadata?title=Dune&publisher=Ace&minScore=1"),
+      await api.get("/metadata?title=Dune&editionPublisher=Ace&minScore=1"),
     )
 
     expect(strict.matches[0]?.accepted).toBe(false)
+    expect(strict.matches[0]?.signals).toContainEqual(
+      expect.objectContaining({ field: "publication.edition.publisher" }),
+    )
     expect(strict.metadata).toEqual({})
 
     const raw = await readFetched(

--- a/apps/metadata-fetcher-api/src/createApp.ts
+++ b/apps/metadata-fetcher-api/src/createApp.ts
@@ -141,7 +141,32 @@ const metadataFromQuery = (query: Request["query"]): ResolvedMetadata => {
   const authors = queryValues(query.author)
   const languages = queryValues(query.language)
   const series = queryValue(query.series)
-  const year = Number(queryValue(query.year))
+  const originalPublisher = queryValue(query.originalPublisher)
+  const editionPublisher = queryValue(query.editionPublisher)
+  const originalYear = Number(queryValue(query.originalPublicationYear))
+  const editionYear = Number(queryValue(query.editionPublicationYear))
+  const original =
+    originalPublisher !== undefined || Number.isFinite(originalYear)
+      ? {
+          ...(originalPublisher !== undefined
+            ? { publisher: originalPublisher }
+            : {}),
+          ...(Number.isFinite(originalYear)
+            ? { date: { year: originalYear } }
+            : {}),
+        }
+      : undefined
+  const edition =
+    editionPublisher !== undefined || Number.isFinite(editionYear)
+      ? {
+          ...(editionPublisher !== undefined
+            ? { publisher: editionPublisher }
+            : {}),
+          ...(Number.isFinite(editionYear)
+            ? { date: { year: editionYear } }
+            : {}),
+        }
+      : undefined
 
   return {
     ...(queryValue(query.title) !== undefined
@@ -153,8 +178,13 @@ const metadataFromQuery = (query: Request["query"]): ResolvedMetadata => {
     ...(queryValue(query.gtin) !== undefined
       ? { gtin: queryValue(query.gtin) }
       : {}),
-    ...(queryValue(query.publisher) !== undefined
-      ? { publisher: queryValue(query.publisher) }
+    ...(original !== undefined || edition !== undefined
+      ? {
+          publication: {
+            ...(original !== undefined ? { original } : {}),
+            ...(edition !== undefined ? { edition } : {}),
+          },
+        }
       : {}),
     ...(authors.length > 0
       ? { contributors: authors.map((name) => ({ name, roles: ["author"] })) }
@@ -163,7 +193,6 @@ const metadataFromQuery = (query: Request["query"]): ResolvedMetadata => {
     ...(series !== undefined
       ? { belongsTo: { series: [{ name: series }] } }
       : {}),
-    ...(Number.isFinite(year) ? { published: { year } } : {}),
   }
 }
 

--- a/apps/metadata-fetcher-api/src/parseMetadataInput.test.ts
+++ b/apps/metadata-fetcher-api/src/parseMetadataInput.test.ts
@@ -18,7 +18,7 @@ describe("parseMetadataInput", () => {
   it("unwraps the resolved archive shape", () => {
     expect(
       parseMetadataInput({
-        version: 1,
+        version: 2,
         metadata: { title: "Dune" },
         unreadableSources: [],
       }),
@@ -29,7 +29,7 @@ describe("parseMetadataInput", () => {
     expect(
       parseMetadataInput({
         title: 42,
-        publisher: null,
+        publication: null,
         languages: "en",
         numberOfPages: "412",
         contributors: { name: "Frank Herbert" },
@@ -77,12 +77,24 @@ describe("parseMetadataInput", () => {
     ])
   })
 
-  it("reads a partial publication date", () => {
+  it("reads original and edition publication details", () => {
     expect(
-      parseMetadataInput({ published: { year: 1965 } })?.published,
-    ).toEqual({ year: 1965 })
-    expect(parseMetadataInput({ published: {} })?.published).toBeUndefined()
-    expect(parseMetadataInput({ published: "1965" })?.published).toBeUndefined()
+      parseMetadataInput({
+        publication: {
+          original: { date: { year: 1965 }, publisher: "Chilton Books" },
+          edition: { date: { year: 2005 }, imprint: "Ace" },
+        },
+      })?.publication,
+    ).toEqual({
+      original: { date: { year: 1965 }, publisher: "Chilton Books" },
+      edition: { date: { year: 2005 }, imprint: "Ace" },
+    })
+    expect(
+      parseMetadataInput({ publication: { original: {} } })?.publication,
+    ).toBeUndefined()
+    expect(
+      parseMetadataInput({ publication: "1965" })?.publication,
+    ).toBeUndefined()
   })
 
   it("reads series and collection membership", () => {

--- a/apps/metadata-fetcher-api/src/parseMetadataInput.ts
+++ b/apps/metadata-fetcher-api/src/parseMetadataInput.ts
@@ -1,4 +1,8 @@
-import type { ResolvedMetadata } from "@prose-reader/archive-reader"
+import type {
+  ResolvedDate,
+  ResolvedMetadata,
+  ResolvedPublication,
+} from "@prose-reader/archive-reader"
 
 /**
  * A request body is third-party data, and the fetcher trusts its input
@@ -118,16 +122,12 @@ const readCollections = (
   return collections.length > 0 ? collections : undefined
 }
 
-const readPublished = (
-  record: Record<string, unknown>,
-): ResolvedMetadata["published"] => {
-  const published = record.published
+const readDate = (value: unknown): ResolvedDate | undefined => {
+  if (!isRecord(value)) return undefined
 
-  if (!isRecord(published)) return undefined
-
-  const year = readNumber(published, "year")
-  const month = readNumber(published, "month")
-  const day = readNumber(published, "day")
+  const year = readNumber(value, "year")
+  const month = readNumber(value, "month")
+  const day = readNumber(value, "day")
 
   if (year === undefined && month === undefined && day === undefined) {
     return undefined
@@ -137,6 +137,42 @@ const readPublished = (
     ...(year !== undefined ? { year } : {}),
     ...(month !== undefined ? { month } : {}),
     ...(day !== undefined ? { day } : {}),
+  }
+}
+
+const readPublicationPart = (
+  value: unknown,
+): ResolvedPublication | undefined => {
+  if (!isRecord(value)) return undefined
+
+  const date = readDate(value.date)
+  const publisher = readString(value, "publisher")
+  const imprint = readString(value, "imprint")
+
+  if (date === undefined && publisher === undefined && imprint === undefined) {
+    return undefined
+  }
+
+  return {
+    ...(date !== undefined ? { date } : {}),
+    ...(publisher !== undefined ? { publisher } : {}),
+    ...(imprint !== undefined ? { imprint } : {}),
+  }
+}
+
+const readPublication = (
+  record: Record<string, unknown>,
+): ResolvedMetadata["publication"] => {
+  if (!isRecord(record.publication)) return undefined
+
+  const original = readPublicationPart(record.publication.original)
+  const edition = readPublicationPart(record.publication.edition)
+
+  if (original === undefined && edition === undefined) return undefined
+
+  return {
+    ...(original !== undefined ? { original } : {}),
+    ...(edition !== undefined ? { edition } : {}),
   }
 }
 
@@ -180,7 +216,6 @@ export const parseMetadataInput = (
 
   return omitUndefined({
     title: readString(record, "title"),
-    publisher: readString(record, "publisher"),
     isbn: readString(record, "isbn"),
     gtin: readString(record, "gtin"),
     languages: readStringArray(record, "languages"),
@@ -188,7 +223,7 @@ export const parseMetadataInput = (
     numberOfPages: readNumber(record, "numberOfPages"),
     contributors: readContributors(record),
     identifiers: readIdentifiers(record),
-    published: readPublished(record),
+    publication: readPublication(record),
     belongsTo: readBelongsTo(record),
   })
 }

--- a/apps/metadata-fetcher-api/src/playground/playground.js
+++ b/apps/metadata-fetcher-api/src/playground/playground.js
@@ -17,13 +17,34 @@ const el = (tag, className, text) => {
   return node
 }
 
+const describeDate = (date) => {
+  if (date?.year === undefined) return undefined
+
+  return [date.year, date.month, date.day]
+    .filter((part) => part !== undefined)
+    .map((part, index) =>
+      index === 0 ? String(part) : String(part).padStart(2, "0"),
+    )
+    .join("-")
+}
+
+const describePublication = (label, publication) => {
+  const details = [
+    describeDate(publication?.date),
+    publication?.publisher,
+    publication?.imprint,
+  ].filter(Boolean)
+
+  return details.length > 0 ? `${label}: ${details.join(", ")}` : undefined
+}
+
 const describe = (metadata) =>
   [
     (metadata.contributors ?? [])
       .map((contributor) => contributor.name)
       .join(", "),
-    metadata.published?.year,
-    metadata.publisher,
+    describePublication("original", metadata.publication?.original),
+    describePublication("edition", metadata.publication?.edition),
     metadata.numberOfPages && `${metadata.numberOfPages} pages`,
     metadata.languages?.join("/"),
   ]

--- a/gitbook/archive-reader/README.md
+++ b/gitbook/archive-reader/README.md
@@ -163,7 +163,7 @@ import { resolveArchive } from "@prose-reader/archive-reader"
 
 const resolved = await resolveArchive(archive)
 // {
-//   version: 1,
+//   version: 2,
 //   metadata: { title, cover?, numberOfPages?, contributors, renditionLayout, belongsTo, … },
 //   readingOrder: [{ uri, id?, mediaType?, size?, renditionLayout?, progressionWeight, … }],
 //   toc: [{ title, path, containerHref, contents }],

--- a/gitbook/archive-reader/resolved-metadata.md
+++ b/gitbook/archive-reader/resolved-metadata.md
@@ -5,7 +5,7 @@
 ## Design rules
 
 - **Union schema, not intersection.** The shape is rich enough to express what any supported format can say; each source populates the subset it knows. Results are sparse: an absent key means "no source had anything to say", and empty arrays/strings collapse to absent so `field !== undefined` is a reliable presence check.
-- **Vocabulary anchored on prior art.** Field names and semantics follow the [Readium Web Publication Manifest](https://readium.org/webpub-manifest/) where a term exists: `contributors` with role terms, `belongsTo.series`/`belongsTo.collection` with `position`, `numberOfPages`, `imprint`, `description`…
+- **Vocabulary anchored on prior art.** Field names and semantics follow the [Readium Web Publication Manifest](https://readium.org/webpub-manifest/) where a term exists: `contributors` with role terms, `belongsTo.series`/`belongsTo.collection` with `position`, `numberOfPages`, publication details, `description`…
 - **Normalization ≠ convergence.** Every field is typed/parsed/validated (`BlackAndWhite: "Yes"` → `boolean`, `Year`/`Month`/`Day` → a date shape), but concepts with no cross-format twin live in clearly format-scoped corners (`metadata.comic`, `metadata.apple`, `metadata.kobo`) rather than behind faked generic names.
 - **Losslessness: sources are never load-bearing.** Everything a parser captures has a declared home in the resolved entity. For the closed schemas (ComicInfo, Apple, Kobo) this is compile-enforced by the mapping tables below (exported as `comicInfoMetadataHomes`, `appleMetadataHomes`, `koboMetadataHomes`, `opfMetadataHomes`); for the open-ended OPF `meta` vocabulary, every entry is structurally copied into `metadata.properties`, lossless by construction.
 - **`metadata` versus `sources`.** `metadata` says what the resolver believes; `sources` (the verbatim parser outputs) say what the book said. The duplication is the contract: a wrong mapping opinion is revisable in a release because the raw value never left the entity.
@@ -28,13 +28,23 @@ type ResolvedMetadata = {
   /** the cover image; resolved against the container, so `resolveArchive` only */
   cover?: ResolvedCover
   description?: string
-  publisher?: string
-  imprint?: string
+  /** the work's first publication and this concrete edition are distinct facts */
+  publication?: {
+    original?: {
+      date?: { year?: number; month?: number; day?: number }
+      publisher?: string
+      imprint?: string
+    }
+    edition?: {
+      date?: { year?: number; month?: number; day?: number }
+      publisher?: string
+      imprint?: string
+    }
+  }
   rights?: string
   languages?: string[]
   subjects?: string[]
   contributors?: { name: string; roles: string[]; sortAs?: string }[]
-  published?: { year?: number; month?: number; day?: number }
   readingDirection?: "ltr" | "rtl"
   renditionLayout?: "reflowable" | "pre-paginated"
   renditionFlow?: "scrolled-continuous" | "scrolled-doc" | "paginated" | "auto"
@@ -64,6 +74,12 @@ Two fields are resolved for the whole **container**, not just its descriptive si
 - **`cover`** — the OPF-declared cover image (EPUB 3 `cover-image` property, the EPUB 2 `<meta name="cover">` convention, or a `cover`-ish image id), rebased onto a container-relative `uri` (`confidence: "derived"`); else the first image of the reading order for image-content containers — comics, image archives, synthetic image-spine OPFs such as `createArchiveFromUrls` lists (`confidence: "assumed"`). It stays absent when nothing image-like is a reading resource: an authored reflowable EPUB (text spine, so an interior illustration is never promoted) or an audiobook/video archive has no cover — a container with no cover of its own is exactly the case [metadata-fetcher](../metadata-fetcher/README.md) answers, with an absolute url into the catalog's cover service.
 - **`numberOfPages`** — the declared ComicInfo `PageCount`, else the count of page-like reading-order items (images and fixed-layout documents). Reflowable documents are not pages, and audio/video tracks are not pages, so both are excluded: a reflowable book or an audiobook has no page count.
 
+### Publication details
+
+`publication.original` describes the work's first known publication. `publication.edition` describes the concrete publication represented by the current file or catalog item. Keeping each event's `date`, `publisher`, and `imprint` together prevents an EPUB edition date, an original print date, and a catalog site's release from being treated as interchangeable.
+
+An EPUB package's `dc:date` is the publication date of that specific EPUB publication, so OPF and ComicInfo values populate `publication.edition`. Catalog providers can additionally populate `publication.original` when their source explicitly identifies the first publication.
+
 ### Contributor roles
 
 Roles use the Readium terms our sources can express — `author`, `translator`, `editor`, `artist`, `illustrator`, `letterer`, `penciler`, `colorist`, `inker`, `narrator`, `contributor` — plus the prose-reader extension `coverArtist` (ComicInfo `CoverArtist`; Readium has no cover-art term). Well-known MARC relator codes from OPF (`aut`, `trl`, `edt`, `art`, `ill`, `clr`, `nrt`, `ctb`) are normalized to those terms; unknown tokens pass through verbatim. A role-less `dc:creator` defaults to `author`, a role-less `dc:contributor` to `contributor`.
@@ -80,13 +96,14 @@ When several sources are present, `resolveMetadata` merges field-wise:
 
 | Field | Rule |
 | --- | --- |
-| descriptive fields (`title`, `description`, `publisher`, `languages`, `subjects`, `contributors`, `published`, `belongsTo`, `gtin`/`isbn`) | **OPF wins over ComicInfo** — the package document is the publication's own metadata; the sidecar fills gaps |
+| descriptive fields (`title`, `description`, `languages`, `subjects`, `contributors`, `belongsTo`, `gtin`/`isbn`) | **OPF wins over ComicInfo** — the package document is the publication's own metadata; the sidecar fills gaps |
+| `publication.edition` details (`date`, `publisher`, `imprint`) | merged field-wise, **OPF wins over ComicInfo** and the sidecar fills gaps |
 | `readingDirection` | **ComicInfo wins over OPF** (`Manga` beats `page-progression-direction`) — deliberate, preserving the historical pipeline behavior |
 | `renditionLayout` | **OPF explicit → Apple → Kobo**, first defined wins; the [`layoutScan`](README.md#resolving-a-publication) promotion applies on top, inside the resolver |
 | `identifiers` | concatenated, OPF first (identifier systems coexist) |
 | `cover` | OPF-declared cover, else the first-image fallback for image-content containers (`resolveArchive` only) |
 | `numberOfPages` | declared ComicInfo `PageCount`, else the counted page-like reading-order items (`resolveArchive` only) |
-| corners (`comic`, `apple`, `kobo`) and single-source fields (`rights`, `properties`, `imprint`) | from their only producer |
+| corners (`comic`, `apple`, `kobo`) and single-source fields (`rights`, `properties`) | from their only producer |
 
 ## Mapping tables
 
@@ -98,8 +115,8 @@ These mirror the compile-enforced tables shipped next to each resolver — the l
 | --- | --- | --- |
 | `Title` | `title` | trimmed |
 | `Summary` | `description` | |
-| `Publisher` | `publisher` | |
-| `Imprint` | `imprint` | |
+| `Publisher` | `publication.edition.publisher` | |
+| `Imprint` | `publication.edition.imprint` | |
 | `LanguageISO` | `languages` | single-entry array |
 | `Genre`, `Tags` | `subjects` | comma-split, Genre first |
 | `Writer` | `contributors` | role `author`, comma-split |
@@ -110,7 +127,7 @@ These mirror the compile-enforced tables shipped next to each resolver — the l
 | `CoverArtist` | `contributors` | role `coverArtist` |
 | `Editor` | `contributors` | role `editor` |
 | `Translator` | `contributors` | role `translator` |
-| `Year`, `Month`, `Day` | `published` | independent optional components |
+| `Year`, `Month`, `Day` | `publication.edition.date` | independent optional components |
 | `Manga` | `readingDirection` | `YesAndRightToLeft` → `rtl`; also `comic.manga` |
 | `PageCount` | `numberOfPages` | declared count; a page-like container without it is counted at the archive level |
 | `GTIN` | `identifiers` | scheme `GTIN`; also `gtin`/`isbn` normalization |
@@ -138,12 +155,12 @@ These mirror the compile-enforced tables shipped next to each resolver — the l
 | --- | --- | --- |
 | `dc:title` | `title` | first non-empty |
 | `dc:description` | `description` | |
-| `dc:publisher` | `publisher` | |
+| `dc:publisher` | `publication.edition.publisher` | |
 | `dc:rights` | `rights` | |
 | `dc:language` | `languages` | all, document order |
 | `dc:subject` | `subjects` | all, document order |
 | `dc:creator`, `dc:contributor` | `contributors` | roles from `opf:role` and EPUB 3 `meta refines property="role"`, `file-as` → `sortAs` |
-| `dc:date` | `published` | parsed as W3CDTF |
+| `dc:date` | `publication.edition.date` | the specific EPUB publication's date, parsed as W3CDTF |
 | `dc:identifier` | `identifiers` | all; EPUB 2 `opf:scheme` or EPUB 3 `identifier-type` refinement retained, otherwise valid absolute HTTP(S) → scheme `URL`; the `package@unique-identifier` target has `unique: true`; ISBN-scheme entries drive `isbn`/`gtin` |
 | spine `page-progression-direction` | `readingDirection` | validated |
 | `rendition:layout` meta | `renditionLayout` | validated |
@@ -167,4 +184,4 @@ These mirror the compile-enforced tables shipped next to each resolver — the l
 
 ## Error policy & versioning
 
-Per-source parse failures are swallowed and logged via the debug `Report` (books in the wild are dirty): a malformed `ComicInfo.xml` never fails a resolve, it just doesn't contribute. The `ResolvedArchive` entity carries a `version` field for consumers persisting it — bumped only when the shape or meaning of existing fields changes incompatibly; additive vocabulary growth does not bump it.
+Per-source parse failures are swallowed and logged via the debug `Report` (books in the wild are dirty): a malformed `ComicInfo.xml` never fails a resolve, it just doesn't contribute. The `ResolvedArchive` entity carries a `version` field for consumers persisting it — currently `2`, reflecting the explicit publication-event model. It is bumped only when the shape or meaning of existing fields changes incompatibly; additive vocabulary growth does not bump it.

--- a/gitbook/metadata-fetcher/README.md
+++ b/gitbook/metadata-fetcher/README.md
@@ -8,12 +8,16 @@ It takes a `ResolvedMetadata` — or anything carrying one, which is exactly the
 import { resolveArchive } from "@prose-reader/archive-reader"
 import {
   createOpenLibraryProvider,
+  createProjectGutenbergProvider,
   fetchMetadata,
 } from "@prose-reader/metadata-fetcher"
 
 const resolved = await resolveArchive(archive)
 const fetched = await fetchMetadata(resolved, {
-  providers: [createOpenLibraryProvider()],
+  providers: [
+    createProjectGutenbergProvider(),
+    createOpenLibraryProvider(),
+  ],
 })
 
 fetched.metadata.cover?.uri // what the catalogs found
@@ -110,7 +114,7 @@ The rules:
   | `published` | 0.2 | year proximity: reprints shift it |
   | `publisher`, `languages`, `numberOfPages` | 0.15 | edition details — they must never sink a convincing match alone |
 
-- **A stated identifier settles it.** An agreeing ISBN or GTIN pins the score to `1` whatever else disagrees; a *contradicting* one scores `0` at the heaviest weight, which is what sinks a plausible-looking wrong edition. ISBN-10 and ISBN-13 of the same book compare equal (`toIsbn13` is exported).
+- **Confirmed identity settles it.** An agreeing ISBN or GTIN pins the score to `1` whatever else disagrees, and a provider-confirmed shared identifier does the same. A *contradicting* ISBN or GTIN scores `0`, which sinks a plausible-looking wrong edition. Disjoint provider-specific identifier lists are not treated as contradictions: catalogs naturally use different id spaces. ISBN-10 and ISBN-13 of the same book compare equal (`toIsbn13` is exported).
 - **Comparisons are fuzzy where the world is.** Titles compare on character bigrams with the subtitle asymmetry repaired (`Dune` ≡ `Dune: a novel`, but `Dune: Book One` ≠ `Dune: Messiah`); an explicit conflicting volume, part, or book number makes the title score `0` (`Vol. I` ≠ `vol. 2`). Names compare on their token set (`Herbert, Frank` ≡ `Frank Herbert`); diacritics and punctuation are folded (`Les Misérables` ≡ `Les Miserables`); languages compare on their primary subtag (`en-US` ≡ `en`).
 
 `minScore` (default `0.5`) decides which matches are `accepted` — which ones contribute to the merged `metadata`. Rejected matches are **kept and ranked**, not dropped: "the catalog found three books, none convincing" is an answer, and it is exactly what a "did you mean?" picker renders.
@@ -125,7 +129,10 @@ if (fetched.metadata.title === undefined) {
 
 ```typescript
 const fetched = await fetchMetadata(resolved, {
-  providers: [createOpenLibraryProvider()],
+  providers: [
+    createProjectGutenbergProvider(),
+    createOpenLibraryProvider(),
+  ],
   limit: 5,
   minScore: 0.5,
   includeRaw: false,
@@ -183,7 +190,45 @@ A remote `cover.uri` is an **absolute url**, not a container-relative uri: a cat
 
 | Provider | Import | Catalog | Notes |
 | --- | --- | --- | --- |
+| `createProjectGutenbergProvider` | `@prose-reader/metadata-fetcher` | [Project Gutenberg](https://www.gutenberg.org) | official per-eBook RDF; exact Gutenberg identifiers only, no key |
 | `createOpenLibraryProvider` | `@prose-reader/metadata-fetcher` | [Open Library](https://openlibrary.org) | free, no key; books broadly, comics and manga much less so |
+
+### Project Gutenberg
+
+```typescript
+import { createProjectGutenbergProvider } from "@prose-reader/metadata-fetcher"
+
+const provider = createProjectGutenbergProvider({
+  userAgent: "MyReader/1.0 (contact@example.com)",
+})
+```
+
+| Option | Default | |
+| --- | --- | --- |
+| `baseUrl` | `https://www.gutenberg.org` | catalog origin; override for a mirror or stub |
+| `fetch` | the global one | for tests, a custom agent, or a caching layer |
+| `userAgent` | — | optional identifying user agent |
+
+**Lookup strategy**, exactly one request: the provider recognizes an official Gutenberg URL in `identifiers` (including `/ebooks/78139`, `/files/78139/…`, `/cache/epub/78139/…`, and the older `/78139` form), or a numeric identifier whose scheme is `ProjectGutenberg`. It then requests Gutenberg's official per-eBook RDF record at `/cache/epub/{id}/pg{id}.rdf`. A title or author alone never triggers the provider, so it neither crawls the website nor returns a fuzzy Gutenberg hit. Arbitrary URLs and identifiers with another authored scheme are ignored.
+
+The confirmed candidate echoes the book's exact input identifier and adds `{ value: "78139", scheme: "ProjectGutenberg" }`. That shared identifier makes the match decisive even when the catalog and embedded titles differ. A missing RDF record returns no candidate; a failing or malformed response is reported through `failedProviders` like any other provider failure.
+
+**Mapping** (per-eBook RDF → `ResolvedMetadata`, exported as `projectGutenbergMetadataHomes`):
+
+| Project Gutenberg RDF | Resolved | |
+| --- | --- | --- |
+| `pgterms:ebook@rdf:about` | `identifiers` | numeric scheme `ProjectGutenberg`; the exact matched input identifier is preserved too |
+| `dcterms:title` | `title` | |
+| `dcterms:creator`, `marcrel:*` | `contributors` | common MARC relators normalize to roles such as `author`, `translator`, `editor`, and `illustrator`; unknown codes remain verbatim |
+| `dcterms:issued` | `published` | Gutenberg release date, parsed through day precision when available |
+| `dcterms:publisher` | `publisher` | |
+| `dcterms:rights` | `rights` | |
+| `dcterms:language` | `languages` | RDF values are already BCP 47 |
+| LCSH `dcterms:subject`, `pgterms:bookshelf` | `subjects` | deduped and capped at 25; Library of Congress classification codes are excluded |
+| `pgterms:marc520`, then `dcterms:description` | `description` | catalog summary preferred over a general note |
+| medium/small cover in `dcterms:hasFormat` | `cover` | medium preferred; absolute HTTP(S) url, `confidence: "derived"` |
+
+The response is parsed and normalized in memory. The provider has no database, cache, file writes, or other persistence.
 
 ### Open Library
 
@@ -202,7 +247,7 @@ const provider = createOpenLibraryProvider({
 | `fetch` | the global one | for tests, a custom agent, or a caching layer |
 | `userAgent` | — | Open Library's API etiquette asks for an identifying one (app name + contact) and throttles anonymous traffic harder |
 
-**Lookup strategy**, at most three requests: an ISBN search when the book states one — the catalog then verifies the identity for us; an exact `id_project_gutenberg` search when an identifier is an official Project Gutenberg URL; then a title (+ first author) search when those identifiers are unknown to Open Library or absent. The Gutenberg URL interpretation is deliberately local to this provider because `id_project_gutenberg` is Open Library's catalog field, not a generic URL convention. A query with none of those terms yields no candidates rather than a fishing expedition.
+**Lookup strategy**, at most three requests: an ISBN search when the book states one — the catalog then verifies the identity for us; an exact `id_project_gutenberg` search when an identifier is an official Project Gutenberg URL or a numeric `ProjectGutenberg` identifier; then a title (+ first author) search when those identifiers are unknown to Open Library or absent. The Gutenberg crosswalk is applied explicitly by this provider because `id_project_gutenberg` is Open Library's catalog field, not a generic URL convention in the scorer. A query with none of those terms yields no candidates rather than a fishing expedition.
 
 **Mapping** (`search.json` doc → `ResolvedMetadata`, exported as `openLibraryMetadataHomes`):
 

--- a/gitbook/metadata-fetcher/README.md
+++ b/gitbook/metadata-fetcher/README.md
@@ -114,7 +114,7 @@ The rules:
   | `published` | 0.2 | year proximity: reprints shift it |
   | `publisher`, `languages`, `numberOfPages` | 0.15 | edition details — they must never sink a convincing match alone |
 
-- **Confirmed identity settles it.** An agreeing ISBN or GTIN pins the score to `1` whatever else disagrees, and a provider-confirmed shared identifier does the same. A *contradicting* ISBN or GTIN scores `0`, which sinks a plausible-looking wrong edition. Disjoint provider-specific identifier lists are not treated as contradictions: catalogs naturally use different id spaces. ISBN-10 and ISBN-13 of the same book compare equal (`toIsbn13` is exported).
+- **Confirmed identity settles it.** An agreeing ISBN or GTIN pins the score to `1` whatever else disagrees, and a provider-confirmed shared identifier does the same when both sides state the same scheme. A scheme-less raw value is not decisive because it could collide with another catalog's identifier. A *contradicting* ISBN or GTIN scores `0`, which sinks a plausible-looking wrong edition. Disjoint provider-specific identifier lists are not treated as contradictions: catalogs naturally use different id spaces. ISBN-10 and ISBN-13 of the same book compare equal (`toIsbn13` is exported).
 - **Comparisons are fuzzy where the world is.** Titles compare on character bigrams with the subtitle asymmetry repaired (`Dune` ≡ `Dune: a novel`, but `Dune: Book One` ≠ `Dune: Messiah`); an explicit conflicting volume, part, or book number makes the title score `0` (`Vol. I` ≠ `vol. 2`). Names compare on their token set (`Herbert, Frank` ≡ `Frank Herbert`); diacritics and punctuation are folded (`Les Misérables` ≡ `Les Miserables`); languages compare on their primary subtag (`en-US` ≡ `en`).
 
 `minScore` (default `0.5`) decides which matches are `accepted` — which ones contribute to the merged `metadata`. Rejected matches are **kept and ranked**, not dropped: "the catalog found three books, none convincing" is an answer, and it is exactly what a "did you mean?" picker renders.
@@ -211,7 +211,7 @@ const provider = createProjectGutenbergProvider({
 
 **Lookup strategy**, exactly one request: the provider recognizes an official Gutenberg URL in `identifiers` (including `/ebooks/78139`, `/files/78139/…`, `/cache/epub/78139/…`, and the older `/78139` form), or a numeric identifier whose scheme is `ProjectGutenberg`. It then requests Gutenberg's official per-eBook RDF record at `/cache/epub/{id}/pg{id}.rdf`. A title or author alone never triggers the provider, so it neither crawls the website nor returns a fuzzy Gutenberg hit. Arbitrary URLs and identifiers with another authored scheme are ignored.
 
-The confirmed candidate echoes the book's exact input identifier and adds `{ value: "78139", scheme: "ProjectGutenberg" }`. That shared identifier makes the match decisive even when the catalog and embedded titles differ. A missing RDF record returns no candidate; a failing or malformed response is reported through `failedProviders` like any other provider failure.
+The confirmed candidate echoes the book's exact input identifier and adds `{ value: "78139", scheme: "ProjectGutenberg" }`. A shared scheme-scoped identifier makes the match decisive even when the catalog and embedded titles differ. A missing RDF record returns no candidate; a failing or malformed response is reported through `failedProviders` like any other provider failure.
 
 **Mapping** (per-eBook RDF → `ResolvedMetadata`, exported as `projectGutenbergMetadataHomes`):
 

--- a/gitbook/metadata-fetcher/README.md
+++ b/gitbook/metadata-fetcher/README.md
@@ -56,6 +56,8 @@ type FetchedMetadata = {
 }
 ```
 
+`version` is currently `2`, matching the explicit `publication.original` / `publication.edition` vocabulary carried by every candidate.
+
 `metadata` is **only** the remote answer — the local metadata is deliberately not folded in, so you stay free to decide who wins (see [Merging with what the book said](#merging-with-what-the-book-said)).
 
 `sources` is the twin of `resolveArchive`'s `sources`: everything a provider contributed is also represented, merged, in `metadata`. The duplication is the contract — a wrong precedence opinion stays revisable because the per-provider values never left the entity. Unlike archive sources, the key space is open: providers are pluggable, so the keys are whatever providers you passed.
@@ -72,7 +74,9 @@ type MetadataMatch = {
   /** every field comparison behind the score */
   signals: {
     field: "isbn" | "gtin" | "identifiers" | "title" | "contributors" |
-           "series" | "publisher" | "published" | "languages" | "numberOfPages"
+           "series" | "publication.original.date" |
+           "publication.original.publisher" | "publication.edition.date" |
+           "publication.edition.publisher" | "languages" | "numberOfPages"
     score: number
     weight: number
     /** the two values compared, rendered for display */
@@ -88,14 +92,14 @@ type MetadataMatch = {
 }
 ```
 
-Scoring is done by the package, identically for every provider — a provider never grades its own homework, so scores stay comparable across catalogs and a match stays explainable to a user ("same title and author, different publisher"):
+Scoring is done by the package, identically for every provider — a provider never grades its own homework, so scores stay comparable across catalogs and a match stays explainable to a user ("same title and author, different edition publisher"):
 
 ```typescript
 fetched.matches[0]?.signals
 // [
 //   { field: "title", score: 1, weight: 0.8, query: "Dune", candidate: "Dune" },
 //   { field: "contributors", score: 1, weight: 0.5, query: "Frank Herbert", … },
-//   { field: "publisher", score: 0.2, weight: 0.15, query: "Ace", candidate: "Chilton Books" },
+//   { field: "publication.edition.publisher", score: 0.2, weight: 0.15, query: "Ace", candidate: "Chilton Books" },
 // ]
 ```
 
@@ -111,11 +115,12 @@ The rules:
   | `identifiers` | 0.6 | other identifier systems, scheme-aware |
   | `contributors` | 0.5 | authors, compared as people |
   | `series` | 0.3 | |
-  | `published` | 0.2 | year proximity: reprints shift it |
-  | `publisher`, `languages`, `numberOfPages` | 0.15 | edition details — they must never sink a convincing match alone |
+  | `publication.original.date`, `publication.edition.date` | 0.2 | year proximity within the same publication scope |
+  | `publication.original.publisher`, `publication.edition.publisher`, `languages`, `numberOfPages` | 0.15 | publication details — they must never sink a convincing match alone |
 
 - **Confirmed identity settles it.** An agreeing ISBN or GTIN pins the score to `1` whatever else disagrees, and a provider-confirmed shared identifier does the same when both sides state the same scheme. A scheme-less raw value is not decisive because it could collide with another catalog's identifier. A *contradicting* ISBN or GTIN scores `0`, which sinks a plausible-looking wrong edition. Disjoint provider-specific identifier lists are not treated as contradictions: catalogs naturally use different id spaces. ISBN-10 and ISBN-13 of the same book compare equal (`toIsbn13` is exported).
 - **Comparisons are fuzzy where the world is.** Titles compare on character bigrams with the subtitle asymmetry repaired (`Dune` ≡ `Dune: a novel`, but `Dune: Book One` ≠ `Dune: Messiah`); an explicit conflicting volume, part, or book number makes the title score `0` (`Vol. I` ≠ `vol. 2`). Names compare on their token set (`Herbert, Frank` ≡ `Frank Herbert`); diacritics and punctuation are folded (`Les Misérables` ≡ `Les Miserables`); languages compare on their primary subtag (`en-US` ≡ `en`).
+- **Publication scopes never cross.** An original publication date is compared only with another original publication date; an EPUB or catalog-edition date is compared only with another edition date. Equal years from different events do not create a signal.
 
 `minScore` (default `0.5`) decides which matches are `accepted` — which ones contribute to the merged `metadata`. Rejected matches are **kept and ranked**, not dropped: "the catalog found three books, none convincing" is an answer, and it is exactly what a "did you mean?" picker renders.
 
@@ -220,8 +225,9 @@ The confirmed candidate echoes the book's exact input identifier and adds `{ val
 | `pgterms:ebook@rdf:about` | `identifiers` | numeric scheme `ProjectGutenberg`; the exact matched input identifier is preserved too |
 | `dcterms:title` | `title` | |
 | `dcterms:creator`, `marcrel:*` | `contributors` | common MARC relators normalize to roles such as `author`, `translator`, `editor`, and `illustrator`; unknown codes remain verbatim |
-| `dcterms:issued` | `published` | Gutenberg release date, parsed through day precision when available |
-| `dcterms:publisher` | `publisher` | |
+| `dcterms:issued` | `publication.edition.date` | Gutenberg ebook release date, parsed through day precision when available; it is not the work's original publication date |
+| `dcterms:publisher` | `publication.edition.publisher` | the publisher of the Gutenberg edition |
+| `pgterms:marc260` | `publication.original.date`, `publication.original.publisher` | original print statement; only one unambiguous `$c` year and `$b` publisher are promoted |
 | `dcterms:rights` | `rights` | |
 | `dcterms:language` | `languages` | RDF values are already BCP 47 |
 | LCSH `dcterms:subject`, `pgterms:bookshelf` | `subjects` | deduped and capped at 25; Library of Congress classification codes are excluded |
@@ -255,8 +261,7 @@ const provider = createOpenLibraryProvider({
 | --- | --- | --- |
 | `title` + `subtitle` | `title` | joined (`Dune: a novel`) — `ResolvedMetadata` has one title field, and an OPF `dc:title` normally carries the subtitle too |
 | `author_name` | `contributors` | role `author` |
-| `first_publish_year` | `published.year` | |
-| `publisher` | `publisher` | first entry |
+| `first_publish_year` | `publication.original.date.year` | |
 | `language` | `languages` | MARC 21 → BCP 47 (`eng` → `en`); unknown codes pass through, `und`/`mul`/`zxx` are dropped |
 | `subject` | `subjects` | capped at the first 25 — a popular work carries hundreds, most of them long-tail noise |
 | `number_of_pages_median` | `numberOfPages` | |
@@ -345,8 +350,8 @@ import { hasSearchTerms, metadataAuthors } from "@prose-reader/metadata-fetcher"
 // often credits only a penciler
 metadataAuthors(metadata) // ["Frank Herbert"]
 
-// is there anything to go on at all? a publisher or a page count narrows a
-// search but cannot start one, so they don't count
+// is there anything to go on at all? publication details or a page count
+// narrow a search but cannot start one, so they don't count
 if (!hasSearchTerms(resolved.metadata)) return
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21476,7 +21476,8 @@
       "license": "MIT",
       "dependencies": {
         "@prose-reader/archive-reader": "^1.339.0",
-        "@prose-reader/shared": "^1.339.0"
+        "@prose-reader/shared": "^1.339.0",
+        "xmldoc": "^2.0.0"
       }
     },
     "packages/react-native": {

--- a/packages/archive-reader/src/comicInfo/resolve.test.ts
+++ b/packages/archive-reader/src/comicInfo/resolve.test.ts
@@ -74,7 +74,7 @@ describe("resolveComicInfo", () => {
 
     expect(resolveComicInfo(parsed)).toMatchObject({
       title: "Sample Story",
-      publisher: "Acme",
+      publication: { edition: { publisher: "Acme" } },
     })
   })
 
@@ -191,12 +191,12 @@ describe("resolveComicInfo", () => {
     ])
   })
 
-  it("assembles the published date from Year / Month / Day", () => {
+  it("assembles the edition publication date from Year / Month / Day", () => {
     const parsed = parseComicInfo(
       comicInfoWrap("<Year>2024</Year><Month>12</Month><Day>25</Day>"),
     )
 
-    expect(resolveComicInfo(parsed).published).toEqual({
+    expect(resolveComicInfo(parsed).publication?.edition?.date).toEqual({
       year: 2024,
       month: 12,
       day: 25,
@@ -206,13 +206,15 @@ describe("resolveComicInfo", () => {
   it("preserves a year-only date when Month / Day are absent", () => {
     const parsed = parseComicInfo(comicInfoWrap("<Year>2024</Year>"))
 
-    expect(resolveComicInfo(parsed).published).toEqual({ year: 2024 })
+    expect(resolveComicInfo(parsed).publication?.edition?.date).toEqual({
+      year: 2024,
+    })
   })
 
-  it("omits the published date when Year / Month / Day are all absent", () => {
+  it("omits the edition date when Year / Month / Day are all absent", () => {
     const parsed = parseComicInfo(comicInfoWrap("<Title>x</Title>"))
 
-    expect(resolveComicInfo(parsed).published).toBeUndefined()
+    expect(resolveComicInfo(parsed).publication).toBeUndefined()
   })
 
   it("ignores non-numeric date components", () => {
@@ -220,7 +222,9 @@ describe("resolveComicInfo", () => {
       comicInfoWrap("<Year>two thousand</Year><Month>12</Month>"),
     )
 
-    expect(resolveComicInfo(parsed).published).toEqual({ month: 12 })
+    expect(resolveComicInfo(parsed).publication?.edition?.date).toEqual({
+      month: 12,
+    })
   })
 
   it("does not surface a rights field (ComicInfo has none)", () => {
@@ -340,7 +344,7 @@ describe("resolveComicInfo", () => {
     expect(resolveComicInfo(parsed)).toMatchObject({
       numberOfPages: 32,
       description: "A short synopsis.",
-      imprint: "Vertigo",
+      publication: { edition: { imprint: "Vertigo" } },
     })
   })
 
@@ -373,9 +377,13 @@ describe("resolveComicInfo", () => {
         { name: "Alice", roles: ["author"] },
         { name: "Bob", roles: ["author"] },
       ],
-      publisher: "Acme",
+      publication: {
+        edition: {
+          publisher: "Acme",
+          date: { year: 2024, month: 5, day: 3 },
+        },
+      },
       languages: ["en"],
-      published: { year: 2024, month: 5, day: 3 },
       subjects: ["Action", "ninja"],
       belongsTo: { series: [{ name: "Sample Series", position: 1 }] },
       comic: { manga: true },

--- a/packages/archive-reader/src/comicInfo/resolve.ts
+++ b/packages/archive-reader/src/comicInfo/resolve.ts
@@ -2,6 +2,7 @@ import type {
   ResolvedCollection,
   ResolvedContributor,
   ResolvedContributorRole,
+  ResolvedDate,
   ResolvedMetadata,
   ResolvedMetadataHome,
 } from "../types/resolvedMetadata.ts"
@@ -28,24 +29,24 @@ export const comicInfoMetadataHomes = {
   CommunityRating: "comic.communityRating",
   Count: "belongsTo.series",
   CoverArtist: "contributors",
-  Day: "published",
+  Day: "publication.edition.date",
   Editor: "contributors",
   Format: "comic.format",
   Genre: "subjects",
   GTIN: "identifiers",
-  Imprint: "imprint",
+  Imprint: "publication.edition.imprint",
   Inker: "contributors",
   LanguageISO: "languages",
   Letterer: "contributors",
   Locations: "comic.locations",
   MainCharacterOrTeam: "comic.mainCharacterOrTeam",
   Manga: "readingDirection",
-  Month: "published",
+  Month: "publication.edition.date",
   Notes: "comic.notes",
   Number: "belongsTo.series",
   PageCount: "numberOfPages",
   Penciller: "contributors",
-  Publisher: "publisher",
+  Publisher: "publication.edition.publisher",
   Review: "comic.review",
   ScanInformation: "comic.scanInformation",
   Series: "belongsTo.series",
@@ -60,7 +61,7 @@ export const comicInfoMetadataHomes = {
   Volume: "comic.volume",
   Web: "comic.web",
   Writer: "contributors",
-  Year: "published",
+  Year: "publication.edition.date",
 } as const satisfies Record<ComicInfoKnownField, ResolvedMetadataHome>
 
 const readingDirection = (info: ComicInfo): "ltr" | "rtl" | undefined => {
@@ -133,9 +134,7 @@ const mangaFlag = (info: ComicInfo): boolean | undefined => {
   }
 }
 
-const dateFromYearMonthDay = (
-  info: ComicInfo,
-): ResolvedMetadata["published"] => {
+const dateFromYearMonthDay = (info: ComicInfo): ResolvedDate | undefined => {
   const year = parseNonNegativeInt(info.Year)
   const month = parseNonNegativeInt(info.Month)
   const day = parseNonNegativeInt(info.Day)
@@ -277,16 +276,24 @@ export const resolveComicInfo = (info: ComicInfo): ResolvedMetadata => {
   const gtinTrimmed = trimToUndefined(rawGtin)
   const languageIso = trimToUndefined(info.LanguageISO)
   const subjects = [...splitCommaList(info.Genre), ...splitCommaList(info.Tags)]
+  const edition = omitUndefined({
+    date: dateFromYearMonthDay(info),
+    publisher: trimToUndefined(info.Publisher),
+    imprint: trimToUndefined(info.Imprint),
+  })
 
   return omitUndefined({
     title: trimToUndefined(info.Title),
     description: trimToUndefined(info.Summary),
-    publisher: trimToUndefined(info.Publisher),
-    imprint: trimToUndefined(info.Imprint),
+    publication:
+      edition.date !== undefined ||
+      edition.publisher !== undefined ||
+      edition.imprint !== undefined
+        ? { edition }
+        : undefined,
     languages: languageIso !== undefined ? [languageIso] : undefined,
     subjects: emptyToUndefined(subjects),
     contributors: emptyToUndefined(contributorsFromComicInfo(info)),
-    published: dateFromYearMonthDay(info),
     readingDirection: readingDirection(info),
     numberOfPages: parseNonNegativeInt(info.PageCount),
     gtin: normalizeGtin(rawGtin),

--- a/packages/archive-reader/src/index.ts
+++ b/packages/archive-reader/src/index.ts
@@ -110,6 +110,8 @@ export type {
   ResolvedMetadata,
   ResolvedMetadataHome,
   ResolvedProperty,
+  ResolvedPublication,
+  ResolvedPublicationInfo,
 } from "./types/resolvedMetadata.ts"
 export { normalizeGtin } from "./utils/normalizeGtin.ts"
 export { normalizeIsbn } from "./utils/normalizeIsbn.ts"

--- a/packages/archive-reader/src/opf/resolve.test.ts
+++ b/packages/archive-reader/src/opf/resolve.test.ts
@@ -251,7 +251,7 @@ describe("resolveOpf", () => {
       }),
     ).toEqual({
       title: "Norwegian Wood",
-      publisher: "Vintage",
+      publication: { edition: { publisher: "Vintage" } },
       description: "A nostalgic story.",
       rights: "Copyright 2024",
       languages: ["en", "ja"],
@@ -343,19 +343,20 @@ describe("resolveOpf", () => {
 
   it("parses W3CDTF dc:date down to year / month / day", () => {
     expect(
-      resolveOpf({ ...emptyOpf(), date: "2024-12-25T12:00:00Z" }).published,
+      resolveOpf({ ...emptyOpf(), date: "2024-12-25T12:00:00Z" }).publication
+        ?.edition?.date,
     ).toEqual({ year: 2024, month: 12, day: 25 })
   })
 
   it("preserves a year-only dc:date", () => {
-    expect(resolveOpf({ ...emptyOpf(), date: "1997" }).published).toEqual({
-      year: 1997,
-    })
+    expect(
+      resolveOpf({ ...emptyOpf(), date: "1997" }).publication?.edition?.date,
+    ).toEqual({ year: 1997 })
   })
 
-  it("omits the published date when dc:date is unparseable", () => {
+  it("omits the edition date when dc:date is unparseable", () => {
     expect(
-      resolveOpf({ ...emptyOpf(), date: "sometime in 2024" }).published,
+      resolveOpf({ ...emptyOpf(), date: "sometime in 2024" }).publication,
     ).toBe(undefined)
   })
 

--- a/packages/archive-reader/src/opf/resolve.ts
+++ b/packages/archive-reader/src/opf/resolve.ts
@@ -29,12 +29,12 @@ export const opfMetadataHomes = {
   title: "title",
   creators: "contributors",
   contributors: "contributors",
-  publisher: "publisher",
+  publisher: "publication.edition.publisher",
   description: "description",
   rights: "rights",
   languages: "languages",
   subjects: "subjects",
-  date: "published",
+  date: "publication.edition.date",
   coverHref: "cover",
   renditionLayoutMeta: "renditionLayout",
   renditionFlowMeta: "renditionFlow",
@@ -292,16 +292,22 @@ export const resolveOpf = (input: OpfMetadata): ResolvedMetadata => {
           collection: collection.length > 0 ? collection : undefined,
         })
       : undefined
+  const edition = omitUndefined({
+    date: parseW3cDtfDate(input.date),
+    publisher: input.publisher,
+  })
 
   return omitUndefined({
     title: input.title,
     description: input.description,
-    publisher: input.publisher,
+    publication:
+      edition.date !== undefined || edition.publisher !== undefined
+        ? { edition }
+        : undefined,
     rights: input.rights,
     languages: input.languages.length > 0 ? [...input.languages] : undefined,
     subjects: input.subjects.length > 0 ? [...input.subjects] : undefined,
     contributors: contributors.length > 0 ? contributors : undefined,
-    published: parseW3cDtfDate(input.date),
     readingDirection,
     renditionLayout,
     renditionFlow: validatedRenditionFlow(input.renditionFlowMeta),

--- a/packages/archive-reader/src/resolveArchive.test.ts
+++ b/packages/archive-reader/src/resolveArchive.test.ts
@@ -76,7 +76,7 @@ describe(`Given an EPUB`, () => {
     const resolved = await resolveArchive(epubArchive())
 
     expect(resolved).toEqual({
-      version: 1,
+      version: 2,
       unreadableSources: [],
       metadata: {
         title: `My Book`,
@@ -114,7 +114,7 @@ describe(`Given an EPUB`, () => {
       Pick<ResolvedArchive, `sources` | `version` | `unreadableSources`>
     >()
 
-    expect(resolved.version).toBe(1)
+    expect(resolved.version).toBe(2)
     expect(resolved.sources.opf?.opf.title).toBe(`My Book`)
     expect(resolved.sources.opf?.basePath).toBe(`OEBPS`)
     expect(`metadata` in resolved).toBe(false)
@@ -157,7 +157,7 @@ describe(`Given a projection that needs nothing read from the book`, () => {
     })
 
     // nothing was read, so nothing can be reported broken
-    expect(resolved).toEqual({ version: 1, unreadableSources: [] })
+    expect(resolved).toEqual({ version: 2, unreadableSources: [] })
     expect(reads()).toBe(0)
   })
 

--- a/packages/archive-reader/src/resolveArchive.ts
+++ b/packages/archive-reader/src/resolveArchive.ts
@@ -221,7 +221,7 @@ const collectUnreadableSources = ({
   return unreadable
 }
 
-const RESOLVED_ARCHIVE_VERSION = 1
+const RESOLVED_ARCHIVE_VERSION = 2
 
 /**
  * Resolves a book container into a single enriched, plain-JSON entity:

--- a/packages/archive-reader/src/resolveMetadata.test.ts
+++ b/packages/archive-reader/src/resolveMetadata.test.ts
@@ -52,7 +52,7 @@ describe("resolveMetadata", () => {
     })
 
     expect(resolved.title).toBe("Package Title")
-    expect(resolved.publisher).toBe("Package Publisher")
+    expect(resolved.publication?.edition?.publisher).toBe("Package Publisher")
     expect(resolved.languages).toEqual(["en"])
     expect(resolved.contributors).toEqual([
       { name: "Package Author", roles: ["author"] },

--- a/packages/archive-reader/src/resolveMetadata.ts
+++ b/packages/archive-reader/src/resolveMetadata.ts
@@ -20,8 +20,8 @@ export type ResolveMetadataSources = {
  * Merges the per-source resolved metadata of every parsed source into one
  * {@link ResolvedMetadata}, with explicit precedence:
  *
- * - Descriptive fields (`title`, `description`, `publisher`, `languages`,
- *   `subjects`, `contributors`, `published`, `belongsTo`, `gtin`/`isbn`):
+ * - Descriptive fields (`title`, `description`, `publication`, `languages`,
+ *   `subjects`, `contributors`, `belongsTo`, `gtin`/`isbn`):
  *   **OPF wins over ComicInfo** — the package document is the publication's
  *   own metadata; a ComicInfo sidecar fills the gaps.
  * - `readingDirection`: **ComicInfo wins over OPF** (`Manga` beats
@@ -36,7 +36,7 @@ export type ResolveMetadataSources = {
  * - `identifiers` concatenates (OPF first) — different identifier systems
  *   coexist rather than compete.
  * - Format-scoped corners (`comic`, `apple`, `kobo`) and single-source
- *   fields (`rights`, `properties`, `imprint`, `numberOfPages`…) come from
+ *   fields (`rights`, `properties`, `numberOfPages`…) come from
  *   their only producer.
  */
 export const resolveMetadata = (
@@ -56,17 +56,30 @@ export const resolveMetadata = (
     ...(opf?.identifiers ?? []),
     ...(comicInfo?.identifiers ?? []),
   ]
+  const edition = omitUndefined({
+    date:
+      opf?.publication?.edition?.date ?? comicInfo?.publication?.edition?.date,
+    publisher:
+      opf?.publication?.edition?.publisher ??
+      comicInfo?.publication?.edition?.publisher,
+    imprint:
+      opf?.publication?.edition?.imprint ??
+      comicInfo?.publication?.edition?.imprint,
+  })
 
   return omitUndefined({
     title: opf?.title ?? comicInfo?.title,
     description: opf?.description ?? comicInfo?.description,
-    publisher: opf?.publisher ?? comicInfo?.publisher,
-    imprint: comicInfo?.imprint,
+    publication:
+      edition.date !== undefined ||
+      edition.publisher !== undefined ||
+      edition.imprint !== undefined
+        ? { edition }
+        : undefined,
     rights: opf?.rights,
     languages: opf?.languages ?? comicInfo?.languages,
     subjects: opf?.subjects ?? comicInfo?.subjects,
     contributors: opf?.contributors ?? comicInfo?.contributors,
-    published: opf?.published ?? comicInfo?.published,
     readingDirection: comicInfo?.readingDirection ?? opf?.readingDirection,
     renditionLayout:
       opf?.renditionLayout ?? apple?.renditionLayout ?? kobo?.renditionLayout,

--- a/packages/archive-reader/src/types/resolvedMetadata.ts
+++ b/packages/archive-reader/src/types/resolvedMetadata.ts
@@ -83,6 +83,23 @@ export type ResolvedDate = {
   readonly day?: number
 }
 
+/** Bibliographic details tied to one publication event. */
+export type ResolvedPublication = {
+  readonly date?: ResolvedDate
+  readonly publisher?: string
+  readonly imprint?: string
+}
+
+/**
+ * Separates the work's first publication from the concrete edition being
+ * described. An EPUB package and a ComicInfo sidecar describe `edition`;
+ * catalogs can additionally provide `original` when they explicitly know it.
+ */
+export type ResolvedPublicationInfo = {
+  readonly original?: ResolvedPublication
+  readonly edition?: ResolvedPublication
+}
+
 /**
  * One entry of the open-world property channel — structurally the OPF
  * `<meta>` shape (EPUB 3 `property`/`refines`/`value`, EPUB 2
@@ -216,10 +233,8 @@ export type ResolvedMetadata = {
   readonly cover?: ResolvedCover
   /** OPF `dc:description`, ComicInfo `Summary`. */
   readonly description?: string
-  /** OPF first non-empty `dc:publisher`, ComicInfo `Publisher`. */
-  readonly publisher?: string
-  /** ComicInfo `Imprint` (Readium term; OPF has no dedicated element). */
-  readonly imprint?: string
+  /** Original-versus-edition publication details. */
+  readonly publication?: ResolvedPublicationInfo
   /** Rights/copyright statement. OPF `dc:rights`; ComicInfo has none. */
   readonly rights?: string
   /**
@@ -240,8 +255,6 @@ export type ResolvedMetadata = {
    * roles merged when the same name appears in several fields).
    */
   readonly contributors?: ReadonlyArray<ResolvedContributor>
-  /** Publication date. OPF `dc:date` (W3CDTF); ComicInfo `Year`/`Month`/`Day`. */
-  readonly published?: ResolvedDate
   /**
    * OPF spine `page-progression-direction`, ComicInfo `Manga`
    * (`YesAndRightToLeft` → rtl). See `resolveMetadata` for precedence.
@@ -318,11 +331,16 @@ export type ResolvedMetadata = {
  * adding a parser field without declaring its home is a type error.
  */
 export type ResolvedMetadataHome =
-  | Exclude<keyof ResolvedMetadata, "comic" | "apple" | "kobo" | "belongsTo">
+  | Exclude<
+      keyof ResolvedMetadata,
+      "comic" | "apple" | "kobo" | "belongsTo" | "publication"
+    >
   | `comic.${keyof ResolvedComicMetadata}`
   | `apple.${keyof ResolvedAppleMetadata}`
   | `kobo.${keyof ResolvedKoboMetadata}`
   | `belongsTo.${"series" | "collection"}`
+  | `publication.${keyof ResolvedPublicationInfo}`
+  | `publication.${keyof ResolvedPublicationInfo}.${keyof ResolvedPublication}`
   | "readingOrder"
   | "toc"
   | "guide"

--- a/packages/metadata-fetcher/package.json
+++ b/packages/metadata-fetcher/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@prose-reader/archive-reader": "^1.339.0",
-    "@prose-reader/shared": "^1.339.0"
+    "@prose-reader/shared": "^1.339.0",
+    "xmldoc": "^2.0.0"
   }
 }

--- a/packages/metadata-fetcher/src/fetchMetadata.test.ts
+++ b/packages/metadata-fetcher/src/fetchMetadata.test.ts
@@ -31,18 +31,26 @@ describe("fetchMetadata", () => {
   it("accepts a resolved archive as well as bare metadata", async () => {
     const providers = [
       providerReturning("a", [
-        { metadata: { title: "Dune", publisher: "Ace" } },
+        {
+          metadata: {
+            title: "Dune",
+            publication: { edition: { publisher: "Ace" } },
+          },
+        },
       ]),
     ]
     const resolved: Pick<
       ResolvedArchive,
       "version" | "metadata" | "unreadableSources"
-    > = { version: 1, metadata: book, unreadableSources: [] }
+    > = { version: 2, metadata: book, unreadableSources: [] }
 
     const fromArchive = await fetchMetadata(resolved, { providers })
     const fromMetadata = await fetchMetadata(book, { providers })
 
-    expect(fromArchive.metadata).toEqual({ title: "Dune", publisher: "Ace" })
+    expect(fromArchive.metadata).toEqual({
+      title: "Dune",
+      publication: { edition: { publisher: "Ace" } },
+    })
     expect(fromMetadata.metadata).toEqual(fromArchive.metadata)
   })
 
@@ -93,7 +101,12 @@ describe("fetchMetadata", () => {
     const fetched = await fetchMetadata(book, {
       providers: [
         providerReturning("weak", [
-          { metadata: { title: "Something Else", publisher: "Wrong" } },
+          {
+            metadata: {
+              title: "Something Else",
+              publication: { edition: { publisher: "Wrong" } },
+            },
+          },
         ]),
         providerReturning("strong", [
           { metadata: { title: "Dune", numberOfPages: 412 } },
@@ -229,7 +242,7 @@ describe("fetchMetadata", () => {
 
   it("returns an empty, versioned entity when no provider is passed", async () => {
     expect(await fetchMetadata(book, { providers: [] })).toEqual({
-      version: 1,
+      version: 2,
       metadata: {},
       matches: [],
       sources: {},

--- a/packages/metadata-fetcher/src/fetchMetadata.ts
+++ b/packages/metadata-fetcher/src/fetchMetadata.ts
@@ -49,7 +49,7 @@ export type FetchMetadataOptions = {
 
 const DEFAULT_LIMIT = 5
 const DEFAULT_MIN_SCORE = 0.5
-const FETCHED_METADATA_VERSION = 1
+const FETCHED_METADATA_VERSION = 2
 
 const toMatch = ({
   candidate,

--- a/packages/metadata-fetcher/src/fetchMetadata.ts
+++ b/packages/metadata-fetcher/src/fetchMetadata.ts
@@ -87,13 +87,17 @@ const toMatch = ({
  * import { resolveArchive } from "@prose-reader/archive-reader"
  * import {
  *   createOpenLibraryProvider,
+ *   createProjectGutenbergProvider,
  *   fetchMetadata,
  *   mergeResolvedMetadata,
  * } from "@prose-reader/metadata-fetcher"
  *
  * const resolved = await resolveArchive(archive)
  * const fetched = await fetchMetadata(resolved, {
- *   providers: [createOpenLibraryProvider()],
+ *   providers: [
+ *     createProjectGutenbergProvider(),
+ *     createOpenLibraryProvider(),
+ *   ],
  * })
  *
  * // what the catalogs found, and why we believe it

--- a/packages/metadata-fetcher/src/index.ts
+++ b/packages/metadata-fetcher/src/index.ts
@@ -6,12 +6,16 @@
  * import { resolveArchive } from "@prose-reader/archive-reader"
  * import {
  *   createOpenLibraryProvider,
+ *   createProjectGutenbergProvider,
  *   fetchMetadata,
  * } from "@prose-reader/metadata-fetcher"
  *
  * const resolved = await resolveArchive(archive)
  * const fetched = await fetchMetadata(resolved, {
- *   providers: [createOpenLibraryProvider()],
+ *   providers: [
+ *     createProjectGutenbergProvider(),
+ *     createOpenLibraryProvider(),
+ *   ],
  * })
  * ```
  *
@@ -50,6 +54,26 @@ export {
   openLibraryMetadataHomes,
   resolveOpenLibraryDoc,
 } from "./providers/openLibrary/resolve.ts"
+export type { ProjectGutenbergProviderOptions } from "./providers/projectGutenberg/createProjectGutenbergProvider.ts"
+export {
+  createProjectGutenbergProvider,
+  PROJECT_GUTENBERG_PROVIDER_ID,
+} from "./providers/projectGutenberg/createProjectGutenbergProvider.ts"
+export {
+  PROJECT_GUTENBERG_IDENTIFIER_SCHEME,
+  projectGutenbergLookupFromMetadata,
+} from "./providers/projectGutenberg/identifier.ts"
+export type {
+  ProjectGutenbergContributor,
+  ProjectGutenbergCover,
+  ProjectGutenbergRecord,
+} from "./providers/projectGutenberg/parse.ts"
+export { parseProjectGutenbergRdf } from "./providers/projectGutenberg/parse.ts"
+export {
+  PROJECT_GUTENBERG_MAX_SUBJECTS,
+  projectGutenbergMetadataHomes,
+  resolveProjectGutenbergRecord,
+} from "./providers/projectGutenberg/resolve.ts"
 export {
   MetadataProviderResponseError,
   responseErrorStatus,

--- a/packages/metadata-fetcher/src/match/scoreMetadataCandidate.test.ts
+++ b/packages/metadata-fetcher/src/match/scoreMetadataCandidate.test.ts
@@ -153,6 +153,24 @@ describe("scoreMetadataCandidate", () => {
     )
   })
 
+  it("does not make a scheme-less identifier match decisive", () => {
+    const result = score(
+      {
+        title: "Dune",
+        identifiers: [{ value: "78139" }],
+      },
+      {
+        title: "Neuromancer",
+        identifiers: [{ value: "78139", scheme: "ProjectGutenberg" }],
+      },
+    )
+
+    expect(result.score).toBeLessThan(1)
+    expect(result.signals).toContainEqual(
+      expect.objectContaining({ field: "identifiers", score: 1 }),
+    )
+  })
+
   it("does not treat disjoint provider identifier spaces as decisive contradictions", () => {
     const result = score(
       {

--- a/packages/metadata-fetcher/src/match/scoreMetadataCandidate.test.ts
+++ b/packages/metadata-fetcher/src/match/scoreMetadataCandidate.test.ts
@@ -130,6 +130,44 @@ describe("scoreMetadataCandidate", () => {
     expect(clashing.score).toBe(0)
   })
 
+  it("makes a provider-confirmed shared identifier decisive", () => {
+    const result = score(
+      {
+        title: "A locally edited title",
+        identifiers: [
+          { value: "http://www.gutenberg.org/78139", scheme: "URL" },
+        ],
+      },
+      {
+        title: "The catalog title",
+        identifiers: [
+          { value: "http://www.gutenberg.org/78139", scheme: "URL" },
+          { value: "78139", scheme: "ProjectGutenberg" },
+        ],
+      },
+    )
+
+    expect(result.score).toBe(1)
+    expect(result.signals).toContainEqual(
+      expect.objectContaining({ field: "identifiers", score: 1 }),
+    )
+  })
+
+  it("does not treat disjoint provider identifier spaces as decisive contradictions", () => {
+    const result = score(
+      {
+        title: "Dune",
+        identifiers: [{ value: "one", scheme: "CatalogA" }],
+      },
+      {
+        title: "Dune",
+        identifiers: [{ value: "two", scheme: "CatalogB" }],
+      },
+    )
+
+    expect(result.score).toBeGreaterThan(0.5)
+  })
+
   it("compares languages on their primary subtag", () => {
     const { signals } = score({ languages: ["en-US"] }, { languages: ["en"] })
 

--- a/packages/metadata-fetcher/src/match/scoreMetadataCandidate.test.ts
+++ b/packages/metadata-fetcher/src/match/scoreMetadataCandidate.test.ts
@@ -7,7 +7,12 @@ const score = (query: ResolvedMetadata, candidate: ResolvedMetadata) =>
 
 describe("scoreMetadataCandidate", () => {
   it("scores 0 when the two sides have nothing comparable", () => {
-    expect(score({ title: "Dune" }, { publisher: "Ace" })).toEqual({
+    expect(
+      score(
+        { title: "Dune" },
+        { publication: { edition: { publisher: "Ace" } } },
+      ),
+    ).toEqual({
       score: 0,
       signals: [],
     })
@@ -15,7 +20,7 @@ describe("scoreMetadataCandidate", () => {
 
   it("only compares fields both sides state", () => {
     const { signals } = score(
-      { title: "Dune", publisher: "Ace" },
+      { title: "Dune", publication: { edition: { publisher: "Ace" } } },
       { title: "Dune", numberOfPages: 412 },
     )
 
@@ -24,8 +29,16 @@ describe("scoreMetadataCandidate", () => {
 
   it("pins the score to 1 on an agreeing ISBN, whatever else disagrees", () => {
     const result = score(
-      { isbn: "9780441013593", title: "Doon", publisher: "Somebody" },
-      { isbn: "9780441013593", title: "Dune", publisher: "Ace" },
+      {
+        isbn: "9780441013593",
+        title: "Doon",
+        publication: { edition: { publisher: "Somebody" } },
+      },
+      {
+        isbn: "9780441013593",
+        title: "Dune",
+        publication: { edition: { publisher: "Ace" } },
+      },
     )
 
     expect(result.score).toBe(1)
@@ -92,7 +105,10 @@ describe("scoreMetadataCandidate", () => {
   it("reports what it compared, for display", () => {
     const { signals } = score(
       { title: "Dune" },
-      { title: "Dune: Messiah", publisher: "Ace" },
+      {
+        title: "Dune: Messiah",
+        publication: { edition: { publisher: "Ace" } },
+      },
     )
 
     expect(signals[0]).toMatchObject({
@@ -104,12 +120,24 @@ describe("scoreMetadataCandidate", () => {
 
   it("tolerates a near publication year and a near page count", () => {
     const near = score(
-      { published: { year: 1965 }, numberOfPages: 412 },
-      { published: { year: 1966 }, numberOfPages: 400 },
+      {
+        publication: { original: { date: { year: 1965 } } },
+        numberOfPages: 412,
+      },
+      {
+        publication: { original: { date: { year: 1966 } } },
+        numberOfPages: 400,
+      },
     )
     const far = score(
-      { published: { year: 1965 }, numberOfPages: 412 },
-      { published: { year: 2011 }, numberOfPages: 90 },
+      {
+        publication: { original: { date: { year: 1965 } } },
+        numberOfPages: 412,
+      },
+      {
+        publication: { original: { date: { year: 2011 } } },
+        numberOfPages: 90,
+      },
     )
 
     expect(near.score).toBeGreaterThan(0.5)
@@ -196,14 +224,32 @@ describe("scoreMetadataCandidate", () => {
 
   it("weight-averages the comparable fields", () => {
     const result = score(
-      { title: "Dune", publisher: "Ace" },
-      { title: "Dune", publisher: "Chilton Books" },
+      { title: "Dune", publication: { edition: { publisher: "Ace" } } },
+      {
+        title: "Dune",
+        publication: { edition: { publisher: "Chilton Books" } },
+      },
     )
 
     // a perfect title (weight .8) barely dented by a different publisher
     // (weight .15) — an edition detail must not sink a convincing match
     expect(result.score).toBeGreaterThan(0.8)
     expect(result.score).toBeLessThan(1)
+  })
+
+  it("does not compare an original publication date with an edition date", () => {
+    const result = score(
+      {
+        title: "Dune",
+        publication: { original: { date: { year: 1965 } } },
+      },
+      {
+        title: "Dune",
+        publication: { edition: { date: { year: 1965 } } },
+      },
+    )
+
+    expect(result.signals.map((signal) => signal.field)).toEqual(["title"])
   })
 
   it("rejects a fuzzy catalog hit that names a different volume", () => {
@@ -221,8 +267,12 @@ describe("scoreMetadataCandidate", () => {
           },
         ],
         languages: ["en"],
-        published: { year: 2026 },
-        publisher: "Public domain in the USA.",
+        publication: {
+          edition: {
+            date: { year: 2026 },
+            publisher: "Project Gutenberg",
+          },
+        },
       },
       {
         title: "Wilhelm Meister's Apprenticeship and Travels, Vol. I (of 2)",
@@ -231,8 +281,13 @@ describe("scoreMetadataCandidate", () => {
         ],
         identifiers: [{ value: "/works/OL40566043W", scheme: "OpenLibrary" }],
         languages: ["en"],
-        published: { year: 2015 },
-        publisher: "CreateSpace Independent Publishing Platform",
+        publication: {
+          original: { date: { year: 1821 } },
+          edition: {
+            date: { year: 2015 },
+            publisher: "CreateSpace Independent Publishing Platform",
+          },
+        },
       },
     )
 

--- a/packages/metadata-fetcher/src/match/scoreMetadataCandidate.ts
+++ b/packages/metadata-fetcher/src/match/scoreMetadataCandidate.ts
@@ -21,8 +21,10 @@ export const METADATA_MATCH_WEIGHTS = {
   title: 0.8,
   contributors: 0.5,
   series: 0.3,
-  published: 0.2,
-  publisher: 0.15,
+  "publication.original.date": 0.2,
+  "publication.original.publisher": 0.15,
+  "publication.edition.date": 0.2,
+  "publication.edition.publisher": 0.15,
   languages: 0.15,
   numberOfPages: 0.15,
 } as const satisfies Record<MetadataMatchField, number>
@@ -94,7 +96,7 @@ const primaryLanguageSubtag = (language: string): string =>
   language.trim().toLowerCase().split("-")[0] ?? ""
 
 /** Reprints shift the year around, so a near one still corroborates. */
-const publishedYearScore = (
+const publicationYearScore = (
   queryYear: number,
   candidateYear: number,
 ): number => {
@@ -249,7 +251,16 @@ export const scoreMetadataCandidate = (
   }
 
   compareStrings("title", query.title, candidate.title, titleSimilarity)
-  compareStrings("publisher", query.publisher, candidate.publisher)
+  compareStrings(
+    "publication.original.publisher",
+    query.publication?.original?.publisher,
+    candidate.publication?.original?.publisher,
+  )
+  compareStrings(
+    "publication.edition.publisher",
+    query.publication?.edition?.publisher,
+    candidate.publication?.edition?.publisher,
+  )
   compareStrings(
     "series",
     query.belongsTo?.series?.[0]?.name,
@@ -271,16 +282,30 @@ export const scoreMetadataCandidate = (
     })
   }
 
-  const queryYear = query.published?.year
-  const candidateYear = candidate.published?.year
+  const comparePublicationYears = (
+    field: "publication.original.date" | "publication.edition.date",
+    queryYear: number | undefined,
+    candidateYear: number | undefined,
+  ) => {
+    if (queryYear === undefined || candidateYear === undefined) return
 
-  if (queryYear !== undefined && candidateYear !== undefined) {
-    addSignal("published", {
-      score: publishedYearScore(queryYear, candidateYear),
+    addSignal(field, {
+      score: publicationYearScore(queryYear, candidateYear),
       query: String(queryYear),
       candidate: String(candidateYear),
     })
   }
+
+  comparePublicationYears(
+    "publication.original.date",
+    query.publication?.original?.date?.year,
+    candidate.publication?.original?.date?.year,
+  )
+  comparePublicationYears(
+    "publication.edition.date",
+    query.publication?.edition?.date?.year,
+    candidate.publication?.edition?.date?.year,
+  )
 
   const queryLanguages = query.languages ?? []
   const candidateLanguages = candidate.languages ?? []

--- a/packages/metadata-fetcher/src/match/scoreMetadataCandidate.ts
+++ b/packages/metadata-fetcher/src/match/scoreMetadataCandidate.ts
@@ -32,20 +32,9 @@ export const METADATA_MATCH_WEIGHTS = {
  * directions. Catalogs and books disagree on titles and page counts
  * constantly; they do not agree or disagree on an ISBN by accident.
  */
-const DECISIVE_CONTRADICTION_FIELDS: ReadonlySet<MetadataMatchField> = new Set([
+const DECISIVE_FIELDS: ReadonlySet<MetadataMatchField> = new Set([
   "isbn",
   "gtin",
-])
-
-/**
- * Providers echo an identifier only after their catalog confirmed it. A
- * shared provider-confirmed identifier is decisive; disjoint identifier lists
- * are not contradictions because catalogs naturally use different id spaces.
- */
-const DECISIVE_AGREEMENT_FIELDS: ReadonlySet<MetadataMatchField> = new Set([
-  "isbn",
-  "gtin",
-  "identifiers",
 ])
 
 /** Blank is absent — the vocabulary says so, a hand-built query may not. */
@@ -55,8 +44,17 @@ const stated = (value: string | undefined): string | undefined => {
   return trimmed !== undefined && trimmed.length > 0 ? trimmed : undefined
 }
 
-const identifierKey = (identifier: MetadataIdentifier): string =>
-  identifier.value.trim().toLowerCase()
+const identifiersHaveSameValue = (
+  a: MetadataIdentifier,
+  b: MetadataIdentifier,
+): boolean => {
+  const aValue = stated(a.value)?.toLowerCase()
+
+  return aValue !== undefined && aValue === stated(b.value)?.toLowerCase()
+}
+
+const identifierScheme = (identifier: MetadataIdentifier): string | undefined =>
+  stated(identifier.scheme)?.toLowerCase()
 
 const identifierLabel = (identifier: MetadataIdentifier): string =>
   identifier.scheme !== undefined
@@ -71,10 +69,25 @@ const identifiersAgree = (
   a: MetadataIdentifier,
   b: MetadataIdentifier,
 ): boolean => {
-  if (identifierKey(a) !== identifierKey(b)) return false
-  if (a.scheme === undefined || b.scheme === undefined) return true
+  if (!identifiersHaveSameValue(a, b)) return false
+  const aScheme = identifierScheme(a)
+  const bScheme = identifierScheme(b)
 
-  return a.scheme.trim().toLowerCase() === b.scheme.trim().toLowerCase()
+  if (aScheme === undefined || bScheme === undefined) return true
+
+  return aScheme === bScheme
+}
+
+/** Only an authored scope makes a shared raw value unambiguous identity. */
+const identifiersAgreeDecisively = (
+  a: MetadataIdentifier,
+  b: MetadataIdentifier,
+): boolean => {
+  if (!identifiersHaveSameValue(a, b)) return false
+  const aScheme = identifierScheme(a)
+  const bScheme = identifierScheme(b)
+
+  return aScheme !== undefined && aScheme === bScheme
 }
 
 const primaryLanguageSubtag = (language: string): string =>
@@ -135,9 +148,10 @@ export type ScoredMetadataCandidate = {
  *   candidate, and nothing in common scores `0`.
  * - **The aggregate is a weighted average** ({@link METADATA_MATCH_WEIGHTS}),
  *   putting a rich query and a sparse one on the same scale.
- * - **Confirmed identity settles it** — an agreeing ISBN, GTIN, or identifier
- *   pins the score to `1`. A contradictory ISBN or GTIN pins it to `0`; two
- *   disjoint provider-specific identifier lists are merely unrelated.
+ * - **Confirmed identity settles it** — an agreeing ISBN, GTIN, or
+ *   scheme-scoped identifier pins the score to `1`. A contradictory ISBN or
+ *   GTIN pins it to `0`; two disjoint provider-specific identifier lists are
+ *   merely unrelated.
  */
 export const scoreMetadataCandidate = (
   query: ResolvedMetadata,
@@ -216,6 +230,11 @@ export const scoreMetadataCandidate = (
 
   const queryIdentifiers = query.identifiers ?? []
   const candidateIdentifiers = candidate.identifiers ?? []
+  const decisiveIdentifierAgreement = queryIdentifiers.some((identifier) =>
+    candidateIdentifiers.some((other) =>
+      identifiersAgreeDecisively(identifier, other),
+    ),
+  )
 
   if (queryIdentifiers.length > 0 && candidateIdentifiers.length > 0) {
     const shared = queryIdentifiers.some((identifier) =>
@@ -293,20 +312,18 @@ export const scoreMetadataCandidate = (
     })
   }
 
-  const decisiveContradictions = signals.filter((signal) =>
-    DECISIVE_CONTRADICTION_FIELDS.has(signal.field),
-  )
-  const decisiveAgreements = signals.filter((signal) =>
-    DECISIVE_AGREEMENT_FIELDS.has(signal.field),
-  )
+  const decisive = signals.filter((signal) => DECISIVE_FIELDS.has(signal.field))
 
   // Contradiction wins over agreement: refusing a publication whose stated
   // identity disagrees is the recoverable mistake. Without this the average is
   // merciful to exactly the wrong candidate — a different edition agreeing on
   // title and author scores (0.8 + 0.5) / 2.3 ≈ 0.57, accepted.
-  if (decisiveContradictions.some((signal) => signal.score === 0))
+  if (decisive.some((signal) => signal.score === 0))
     return { score: 0, signals }
-  if (decisiveAgreements.some((signal) => signal.score === 1))
+  if (
+    decisiveIdentifierAgreement ||
+    decisive.some((signal) => signal.score === 1)
+  )
     return { score: 1, signals }
 
   const totalWeight = signals.reduce(

--- a/packages/metadata-fetcher/src/match/scoreMetadataCandidate.ts
+++ b/packages/metadata-fetcher/src/match/scoreMetadataCandidate.ts
@@ -32,9 +32,20 @@ export const METADATA_MATCH_WEIGHTS = {
  * directions. Catalogs and books disagree on titles and page counts
  * constantly; they do not agree or disagree on an ISBN by accident.
  */
-const DECISIVE_FIELDS: ReadonlySet<MetadataMatchField> = new Set([
+const DECISIVE_CONTRADICTION_FIELDS: ReadonlySet<MetadataMatchField> = new Set([
   "isbn",
   "gtin",
+])
+
+/**
+ * Providers echo an identifier only after their catalog confirmed it. A
+ * shared provider-confirmed identifier is decisive; disjoint identifier lists
+ * are not contradictions because catalogs naturally use different id spaces.
+ */
+const DECISIVE_AGREEMENT_FIELDS: ReadonlySet<MetadataMatchField> = new Set([
+  "isbn",
+  "gtin",
+  "identifiers",
 ])
 
 /** Blank is absent — the vocabulary says so, a hand-built query may not. */
@@ -124,9 +135,9 @@ export type ScoredMetadataCandidate = {
  *   candidate, and nothing in common scores `0`.
  * - **The aggregate is a weighted average** ({@link METADATA_MATCH_WEIGHTS}),
  *   putting a rich query and a sparse one on the same scale.
- * - **A stated identifier settles it, both ways** — agreeing pins the score to
- *   `1`, contradicting to `0`. The latter is what sinks the wrong edition that
- *   agrees on everything a weighted average can see.
+ * - **Confirmed identity settles it** — an agreeing ISBN, GTIN, or identifier
+ *   pins the score to `1`. A contradictory ISBN or GTIN pins it to `0`; two
+ *   disjoint provider-specific identifier lists are merely unrelated.
  */
 export const scoreMetadataCandidate = (
   query: ResolvedMetadata,
@@ -282,15 +293,20 @@ export const scoreMetadataCandidate = (
     })
   }
 
-  const decisive = signals.filter((signal) => DECISIVE_FIELDS.has(signal.field))
+  const decisiveContradictions = signals.filter((signal) =>
+    DECISIVE_CONTRADICTION_FIELDS.has(signal.field),
+  )
+  const decisiveAgreements = signals.filter((signal) =>
+    DECISIVE_AGREEMENT_FIELDS.has(signal.field),
+  )
 
   // Contradiction wins over agreement: refusing a publication whose stated
   // identity disagrees is the recoverable mistake. Without this the average is
   // merciful to exactly the wrong candidate — a different edition agreeing on
   // title and author scores (0.8 + 0.5) / 2.3 ≈ 0.57, accepted.
-  if (decisive.some((signal) => signal.score === 0))
+  if (decisiveContradictions.some((signal) => signal.score === 0))
     return { score: 0, signals }
-  if (decisive.some((signal) => signal.score === 1))
+  if (decisiveAgreements.some((signal) => signal.score === 1))
     return { score: 1, signals }
 
   const totalWeight = signals.reduce(

--- a/packages/metadata-fetcher/src/merge/mergeResolvedMetadata.test.ts
+++ b/packages/metadata-fetcher/src/merge/mergeResolvedMetadata.test.ts
@@ -11,9 +11,15 @@ describe("mergeResolvedMetadata", () => {
     expect(
       mergeResolvedMetadata(
         { title: "Book Title" },
-        { title: "Catalog Title", publisher: "Ace" },
+        {
+          title: "Catalog Title",
+          publication: { edition: { publisher: "Ace" } },
+        },
       ),
-    ).toEqual({ title: "Book Title", publisher: "Ace" })
+    ).toEqual({
+      title: "Book Title",
+      publication: { edition: { publisher: "Ace" } },
+    })
   })
 
   it("merges field-wise, not object-wise", () => {
@@ -54,6 +60,32 @@ describe("mergeResolvedMetadata", () => {
     ).toEqual({
       series: [{ name: "Dune" }],
       collection: [{ name: "SF Masterworks" }],
+    })
+  })
+
+  it("merges publication parts and their details independently", () => {
+    expect(
+      mergeResolvedMetadata(
+        {
+          publication: {
+            original: { date: { year: 1965 } },
+            edition: { publisher: "Ace" },
+          },
+        },
+        {
+          publication: {
+            original: { publisher: "Chilton Books" },
+            edition: { date: { year: 1990 }, imprint: "Spectra" },
+          },
+        },
+      ).publication,
+    ).toEqual({
+      original: { date: { year: 1965 }, publisher: "Chilton Books" },
+      edition: {
+        date: { year: 1990 },
+        publisher: "Ace",
+        imprint: "Spectra",
+      },
     })
   })
 

--- a/packages/metadata-fetcher/src/merge/mergeResolvedMetadata.ts
+++ b/packages/metadata-fetcher/src/merge/mergeResolvedMetadata.ts
@@ -73,6 +73,29 @@ export const mergeResolvedMetadata = (
       (entry) => entry.belongsTo?.collection !== undefined,
     )?.belongsTo?.collection,
   })
+  const publicationPart = (part: "original" | "edition") => {
+    const details = omitUndefined({
+      date: defined.find(
+        (entry) => entry.publication?.[part]?.date !== undefined,
+      )?.publication?.[part]?.date,
+      publisher: defined.find(
+        (entry) => entry.publication?.[part]?.publisher !== undefined,
+      )?.publication?.[part]?.publisher,
+      imprint: defined.find(
+        (entry) => entry.publication?.[part]?.imprint !== undefined,
+      )?.publication?.[part]?.imprint,
+    })
+
+    return details.date !== undefined ||
+      details.publisher !== undefined ||
+      details.imprint !== undefined
+      ? details
+      : undefined
+  }
+  const publication = omitUndefined({
+    original: publicationPart("original"),
+    edition: publicationPart("edition"),
+  })
 
   // `Required` makes every key mandatory in this literal (values still accept
   // `undefined`), so a field added to the vocabulary is a compile error here
@@ -83,13 +106,14 @@ export const mergeResolvedMetadata = (
     title: first("title"),
     cover: first("cover"),
     description: first("description"),
-    publisher: first("publisher"),
-    imprint: first("imprint"),
+    publication:
+      publication.original !== undefined || publication.edition !== undefined
+        ? publication
+        : undefined,
     rights: first("rights"),
     languages: first("languages"),
     subjects: first("subjects"),
     contributors: first("contributors"),
-    published: first("published"),
     readingDirection: first("readingDirection"),
     renditionLayout: first("renditionLayout"),
     renditionFlow: first("renditionFlow"),

--- a/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.test.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.test.ts
@@ -7,7 +7,6 @@ const DUNE_DOC = {
   subtitle: "a novel",
   author_name: ["Frank Herbert"],
   first_publish_year: 1965,
-  publisher: ["Chilton Books", "Ace"],
   language: ["eng", "fre"],
   subject: ["Science fiction", "Desert"],
   number_of_pages_median: 412,
@@ -139,7 +138,12 @@ describe("createOpenLibraryProvider", () => {
     const fetchMock = fetchReturning()
     const provider = createOpenLibraryProvider({ fetch: fetchMock })
 
-    expect(await provider.search({ publisher: "Ace" }, context)).toEqual([])
+    expect(
+      await provider.search(
+        { publication: { edition: { publisher: "Ace" } } },
+        context,
+      ),
+    ).toEqual([])
     expect(fetchMock).not.toHaveBeenCalled()
   })
 

--- a/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.ts
@@ -5,12 +5,12 @@ import type {
   MetadataProviderContext,
 } from "../../types/provider.ts"
 import { metadataAuthors } from "../../utils/metadataAuthors.ts"
+import {
+  type ProjectGutenbergLookup,
+  projectGutenbergLookupFromMetadata,
+} from "../projectGutenberg/identifier.ts"
 import { MetadataProviderResponseError } from "../responseError.ts"
 import { type OpenLibraryDoc, parseOpenLibrarySearchResponse } from "./parse.ts"
-import {
-  type OpenLibraryProjectGutenbergLookup,
-  projectGutenbergLookupFromMetadata,
-} from "./projectGutenbergIdentifier.ts"
 import { resolveOpenLibraryDoc } from "./resolve.ts"
 
 export const OPEN_LIBRARY_PROVIDER_ID = "openLibrary"
@@ -127,7 +127,7 @@ export const createOpenLibraryProvider = (
     docs: ReadonlyArray<OpenLibraryDoc>,
     options: {
       readonly isbn?: string
-      readonly confirmedProjectGutenberg?: OpenLibraryProjectGutenbergLookup
+      readonly confirmedProjectGutenberg?: ProjectGutenbergLookup
     } = {},
   ): ReadonlyArray<MetadataCandidate> =>
     docs.map((doc) => ({

--- a/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.ts
@@ -29,7 +29,6 @@ const SEARCH_FIELDS = [
   "subtitle",
   "author_name",
   "first_publish_year",
-  "publisher",
   "language",
   "subject",
   "number_of_pages_median",

--- a/packages/metadata-fetcher/src/providers/openLibrary/parse.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/parse.ts
@@ -21,7 +21,6 @@ export type OpenLibraryDoc = {
   readonly subtitle?: string
   readonly author_name?: ReadonlyArray<string>
   readonly first_publish_year?: number
-  readonly publisher?: ReadonlyArray<string>
   /** MARC 21 language codes (`eng`, `fre`), not BCP 47. */
   readonly language?: ReadonlyArray<string>
   readonly subject?: ReadonlyArray<string>
@@ -38,7 +37,6 @@ const parseDoc = (record: Record<string, unknown>): OpenLibraryDoc => ({
   subtitle: readString(record, "subtitle"),
   author_name: readStringArray(record, "author_name"),
   first_publish_year: readNumber(record, "first_publish_year"),
-  publisher: readStringArray(record, "publisher"),
   language: readStringArray(record, "language"),
   subject: readStringArray(record, "subject"),
   number_of_pages_median: readNumber(record, "number_of_pages_median"),

--- a/packages/metadata-fetcher/src/providers/openLibrary/resolve.test.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/resolve.test.ts
@@ -81,7 +81,6 @@ describe("resolveOpenLibraryDoc", () => {
           title: "Dune",
           author_name: ["Frank Herbert"],
           first_publish_year: 1965,
-          publisher: ["Chilton Books", "Ace"],
           language: ["eng"],
           subject: ["Science fiction"],
           number_of_pages_median: 412,
@@ -93,8 +92,7 @@ describe("resolveOpenLibraryDoc", () => {
     ).toEqual({
       title: "Dune",
       contributors: [{ name: "Frank Herbert", roles: ["author"] }],
-      published: { year: 1965 },
-      publisher: "Chilton Books",
+      publication: { original: { date: { year: 1965 } } },
       languages: ["en"],
       subjects: ["Science fiction"],
       numberOfPages: 412,

--- a/packages/metadata-fetcher/src/providers/openLibrary/resolve.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/resolve.ts
@@ -1,4 +1,7 @@
-import type { ResolvedMetadata } from "@prose-reader/archive-reader"
+import type {
+  ResolvedMetadata,
+  ResolvedMetadataHome,
+} from "@prose-reader/archive-reader"
 import { omitUndefined } from "../../utils/omitUndefined.ts"
 import { marcLanguageToBcp47 } from "./marcLanguage.ts"
 import type { OpenLibraryDoc } from "./parse.ts"
@@ -21,8 +24,7 @@ export const openLibraryMetadataHomes = {
   title: "title",
   subtitle: "title",
   author_name: "contributors",
-  first_publish_year: "published",
-  publisher: "publisher",
+  first_publish_year: "publication.original.date",
   language: "languages",
   subject: "subjects",
   number_of_pages_median: "numberOfPages",
@@ -30,7 +32,7 @@ export const openLibraryMetadataHomes = {
   id_project_gutenberg: "identifiers",
 } as const satisfies Record<
   keyof OpenLibraryDoc,
-  keyof ResolvedMetadata | "identifiers"
+  ResolvedMetadataHome | "identifiers"
 >
 
 export const OPEN_LIBRARY_IDENTIFIER_SCHEME = "OpenLibrary"
@@ -106,7 +108,10 @@ export const resolveOpenLibraryDoc = (
             confidence: "derived" as const,
           }
         : undefined,
-    publisher: doc.publisher?.[0],
+    publication:
+      doc.first_publish_year !== undefined
+        ? { original: { date: { year: doc.first_publish_year } } }
+        : undefined,
     languages,
     subjects: emptyToUndefined(
       (doc.subject ?? []).slice(0, OPEN_LIBRARY_MAX_SUBJECTS),
@@ -117,10 +122,6 @@ export const resolveOpenLibraryDoc = (
         roles: ["author" as const],
       })),
     ),
-    published:
-      doc.first_publish_year !== undefined
-        ? { year: doc.first_publish_year }
-        : undefined,
     numberOfPages: doc.number_of_pages_median,
     isbn: options.isbn,
     identifiers: emptyToUndefined(identifiers),

--- a/packages/metadata-fetcher/src/providers/projectGutenberg/createProjectGutenbergProvider.test.ts
+++ b/packages/metadata-fetcher/src/providers/projectGutenberg/createProjectGutenbergProvider.test.ts
@@ -1,0 +1,158 @@
+import type { ResolvedMetadata } from "@prose-reader/archive-reader"
+import { describe, expect, it, vi } from "vitest"
+import { scoreMetadataCandidate } from "../../match/scoreMetadataCandidate.ts"
+import { createProjectGutenbergProvider } from "./createProjectGutenbergProvider.ts"
+
+const PROJECT_GUTENBERG_RDF_FIXTURE = `<rdf:RDF
+  xmlns:dcterms="http://purl.org/dc/terms/"
+  xmlns:pgterms="http://www.gutenberg.org/2009/pgterms/"
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+>
+  <pgterms:ebook rdf:about="ebooks/78139">
+    <dcterms:title>Wilhelm Meister's apprenticeship and travels, vol. 2 (of 2)</dcterms:title>
+  </pgterms:ebook>
+</rdf:RDF>`
+
+const context = { limit: 5 }
+
+describe("createProjectGutenbergProvider", () => {
+  it("fetches and confirms an official Gutenberg URL", async () => {
+    const fetchMock = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValue(new Response(PROJECT_GUTENBERG_RDF_FIXTURE))
+    const controller = new AbortController()
+    const provider = createProjectGutenbergProvider({
+      fetch: fetchMock,
+      userAgent: "MyReader/1.0 (me@example.com)",
+    })
+    const input: ResolvedMetadata = {
+      title: "A locally edited title",
+      identifiers: [
+        {
+          value: "http://www.gutenberg.org/78139",
+          scheme: "URL",
+          unique: true,
+        },
+      ],
+    }
+
+    const [candidate] = await provider.search(input, {
+      ...context,
+      signal: controller.signal,
+    })
+    const requestUrl = new URL(String(fetchMock.mock.calls[0]?.[0]))
+
+    expect(requestUrl.pathname).toBe("/cache/epub/78139/pg78139.rdf")
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      signal: controller.signal,
+      headers: {
+        Accept: "application/rdf+xml, application/xml;q=0.9",
+        "User-Agent": "MyReader/1.0 (me@example.com)",
+      },
+    })
+    expect(candidate).toMatchObject({
+      id: "78139",
+      url: "https://www.gutenberg.org/ebooks/78139",
+      metadata: {
+        title: "Wilhelm Meister's apprenticeship and travels, vol. 2 (of 2)",
+        identifiers: [
+          { value: "http://www.gutenberg.org/78139", scheme: "URL" },
+          { value: "78139", scheme: "ProjectGutenberg" },
+        ],
+      },
+    })
+    expect(scoreMetadataCandidate(input, candidate?.metadata ?? {}).score).toBe(
+      1,
+    )
+  })
+
+  it("also looks up a numeric ProjectGutenberg identifier", async () => {
+    const fetchMock = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValue(new Response(PROJECT_GUTENBERG_RDF_FIXTURE))
+    const provider = createProjectGutenbergProvider({ fetch: fetchMock })
+
+    const [candidate] = await provider.search(
+      { identifiers: [{ value: "78139", scheme: "ProjectGutenberg" }] },
+      context,
+    )
+
+    expect(candidate?.metadata.identifiers).toContainEqual({
+      value: "78139",
+      scheme: "ProjectGutenberg",
+    })
+  })
+
+  it("does not ask Gutenberg without a recognized identifier", async () => {
+    const fetchMock = vi.fn<typeof globalThis.fetch>()
+    const provider = createProjectGutenbergProvider({ fetch: fetchMock })
+
+    expect(await provider.search({ title: "Dune" }, context)).toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("treats a missing eBook as no result", async () => {
+    const fetchMock = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValue(new Response("missing", { status: 404 }))
+    const provider = createProjectGutenbergProvider({ fetch: fetchMock })
+
+    expect(
+      await provider.search(
+        {
+          identifiers: [
+            { value: "https://www.gutenberg.org/ebooks/999999", scheme: "URL" },
+          ],
+        },
+        context,
+      ),
+    ).toEqual([])
+  })
+
+  it("throws on upstream failures and invalid successful responses", async () => {
+    const unavailable = createProjectGutenbergProvider({
+      fetch: vi
+        .fn<typeof globalThis.fetch>()
+        .mockResolvedValue(new Response("nope", { status: 503 })),
+    })
+    const invalid = createProjectGutenbergProvider({
+      fetch: vi
+        .fn<typeof globalThis.fetch>()
+        .mockResolvedValue(new Response("<html/>")),
+    })
+    const input = {
+      identifiers: [
+        { value: "https://www.gutenberg.org/ebooks/78139", scheme: "URL" },
+      ],
+    }
+
+    await expect(unavailable.search(input, context)).rejects.toThrow("503")
+    await expect(invalid.search(input, context)).rejects.toThrow(
+      "did not contain the requested eBook",
+    )
+  })
+
+  it("honors a custom catalog origin", async () => {
+    const fetchMock = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValue(new Response(PROJECT_GUTENBERG_RDF_FIXTURE))
+    const provider = createProjectGutenbergProvider({
+      fetch: fetchMock,
+      baseUrl: "https://gutenberg.example.com",
+    })
+
+    const [candidate] = await provider.search(
+      {
+        identifiers: [
+          { value: "https://www.gutenberg.org/ebooks/78139", scheme: "URL" },
+        ],
+      },
+      context,
+    )
+
+    expect(new URL(String(fetchMock.mock.calls[0]?.[0])).origin).toBe(
+      "https://gutenberg.example.com",
+    )
+    expect(candidate?.url).toBe("https://gutenberg.example.com/ebooks/78139")
+  })
+})

--- a/packages/metadata-fetcher/src/providers/projectGutenberg/createProjectGutenbergProvider.ts
+++ b/packages/metadata-fetcher/src/providers/projectGutenberg/createProjectGutenbergProvider.ts
@@ -1,0 +1,95 @@
+import type { ResolvedMetadata } from "@prose-reader/archive-reader"
+import type {
+  MetadataProvider,
+  MetadataProviderContext,
+} from "../../types/provider.ts"
+import { MetadataProviderResponseError } from "../responseError.ts"
+import { projectGutenbergLookupFromMetadata } from "./identifier.ts"
+import { parseProjectGutenbergRdf } from "./parse.ts"
+import { resolveProjectGutenbergRecord } from "./resolve.ts"
+
+export const PROJECT_GUTENBERG_PROVIDER_ID = "projectGutenberg"
+
+const DEFAULT_BASE_URL = "https://www.gutenberg.org"
+
+export type ProjectGutenbergProviderOptions = {
+  /** Catalog origin. Defaults to `https://www.gutenberg.org`. */
+  readonly baseUrl?: string
+  /** For tests, a custom agent, or a caching layer. Defaults to the global one. */
+  readonly fetch?: typeof globalThis.fetch
+  /** Optional identifying user agent sent with the RDF request. */
+  readonly userAgent?: string
+}
+
+/**
+ * Project Gutenberg's official catalog, queried through its per-eBook RDF
+ * records. The provider performs exact identifier lookups only: official
+ * Gutenberg URLs and numeric `ProjectGutenberg` identifiers are accepted;
+ * titles are deliberately never used to crawl or fuzzily search the site.
+ */
+export const createProjectGutenbergProvider = (
+  options: ProjectGutenbergProviderOptions = {},
+): MetadataProvider => {
+  const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL
+
+  const search = async (
+    metadata: ResolvedMetadata,
+    context: MetadataProviderContext,
+  ) => {
+    const lookup = projectGutenbergLookupFromMetadata(metadata)
+
+    if (lookup === undefined) return []
+
+    const recordUrl = new URL(
+      `/cache/epub/${lookup.id}/pg${lookup.id}.rdf`,
+      baseUrl,
+    )
+    const doFetch = options.fetch ?? globalThis.fetch
+    const response = await doFetch(recordUrl.toString(), {
+      signal: context.signal,
+      headers: {
+        Accept: "application/rdf+xml, application/xml;q=0.9",
+        ...(options.userAgent !== undefined
+          ? { "User-Agent": options.userAgent }
+          : {}),
+      },
+    })
+
+    if (response.status === 404) return []
+
+    if (!response.ok) {
+      throw new MetadataProviderResponseError(
+        response.status,
+        `Project Gutenberg metadata lookup failed with status ${response.status}`,
+      )
+    }
+
+    const record = parseProjectGutenbergRdf(await response.text())
+
+    if (record === undefined || record.id !== lookup.id) {
+      throw new Error(
+        `Project Gutenberg RDF did not contain the requested eBook ${lookup.id}`,
+      )
+    }
+
+    const bookUrl = new URL(`/ebooks/${lookup.id}`, baseUrl).toString()
+
+    return [
+      {
+        id: record.id,
+        url: bookUrl,
+        raw: record,
+        metadata: resolveProjectGutenbergRecord(record, {
+          baseUrl,
+          matchedIdentifier: lookup.identifier,
+        }),
+      },
+    ]
+  }
+
+  return {
+    id: PROJECT_GUTENBERG_PROVIDER_ID,
+    name: "Project Gutenberg",
+    search,
+  }
+}

--- a/packages/metadata-fetcher/src/providers/projectGutenberg/identifier.test.ts
+++ b/packages/metadata-fetcher/src/providers/projectGutenberg/identifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { projectGutenbergLookupFromMetadata } from "./projectGutenbergIdentifier.ts"
+import { projectGutenbergLookupFromMetadata } from "./identifier.ts"
 
 describe("projectGutenbergLookupFromMetadata", () => {
   it.each([
@@ -16,6 +16,19 @@ describe("projectGutenbergLookupFromMetadata", () => {
     ).toEqual({ id: "78139", identifier: { value, scheme: "URL" } })
   })
 
+  it("recognizes an authored Project Gutenberg identifier", () => {
+    expect(
+      projectGutenbergLookupFromMetadata({
+        identifiers: [
+          { value: "0078139", scheme: "ProjectGutenberg", unique: true },
+        ],
+      }),
+    ).toEqual({
+      id: "78139",
+      identifier: { value: "0078139", scheme: "ProjectGutenberg" },
+    })
+  })
+
   it("does not reinterpret arbitrary URLs or authored identifier types", () => {
     expect(
       projectGutenbergLookupFromMetadata({
@@ -25,6 +38,7 @@ describe("projectGutenbergLookupFromMetadata", () => {
             value: "https://www.gutenberg.org/78139",
             scheme: "DOI",
           },
+          { value: "0", scheme: "ProjectGutenberg" },
         ],
       }),
     ).toBeUndefined()

--- a/packages/metadata-fetcher/src/providers/projectGutenberg/identifier.ts
+++ b/packages/metadata-fetcher/src/providers/projectGutenberg/identifier.ts
@@ -1,8 +1,10 @@
 import type { ResolvedMetadata } from "@prose-reader/archive-reader"
 
-export type OpenLibraryProjectGutenbergLookup = {
+export const PROJECT_GUTENBERG_IDENTIFIER_SCHEME = "ProjectGutenberg"
+
+export type ProjectGutenbergLookup = {
   readonly id: string
-  /** The book's exact identifier spelling, echoed only after OL confirms it. */
+  /** The book's exact identifier spelling, echoed only after PG confirms it. */
   readonly identifier: {
     readonly value: string
     readonly scheme?: string
@@ -21,6 +23,16 @@ const GUTENBERG_PATHS: ReadonlyArray<RegExp> = [
   /^\/(\d+)(?:\/|$)/,
 ]
 
+const normalizedProjectGutenbergId = (value: string): string | undefined => {
+  const trimmed = value.trim()
+
+  if (!/^\d+$/.test(trimmed)) return undefined
+
+  const normalized = trimmed.replace(/^0+(?=\d)/, "")
+
+  return normalized !== "0" ? normalized : undefined
+}
+
 const projectGutenbergIdFromUrl = (value: string): string | undefined => {
   try {
     const url = new URL(value.trim())
@@ -31,7 +43,7 @@ const projectGutenbergIdFromUrl = (value: string): string | undefined => {
     for (const pattern of GUTENBERG_PATHS) {
       const id = pattern.exec(url.pathname)?.[1]
 
-      if (id !== undefined) return id
+      if (id !== undefined) return normalizedProjectGutenbergId(id)
     }
   } catch {
     return undefined
@@ -41,19 +53,21 @@ const projectGutenbergIdFromUrl = (value: string): string | undefined => {
 }
 
 /**
- * Open Library-specific crosswalk: its `id_project_gutenberg` search field
- * stores the numeric id encoded by official Gutenberg URLs. Other providers
- * own their own identifier conventions; this is intentionally not generic.
+ * Recognizes Project Gutenberg's own numeric identifier and official URL
+ * forms. Calling providers decide explicitly how to use this crosswalk; the
+ * shared scorer never reinterprets arbitrary URLs.
  */
 export const projectGutenbergLookupFromMetadata = (
   metadata: ResolvedMetadata,
-): OpenLibraryProjectGutenbergLookup | undefined => {
+): ProjectGutenbergLookup | undefined => {
   for (const identifier of metadata.identifiers ?? []) {
     const scheme = identifier.scheme?.trim().toLowerCase()
-
-    if (scheme !== undefined && scheme !== "url" && scheme !== "uri") continue
-
-    const id = projectGutenbergIdFromUrl(identifier.value)
+    const id =
+      scheme === PROJECT_GUTENBERG_IDENTIFIER_SCHEME.toLowerCase()
+        ? normalizedProjectGutenbergId(identifier.value)
+        : scheme === undefined || scheme === "url" || scheme === "uri"
+          ? projectGutenbergIdFromUrl(identifier.value)
+          : undefined
 
     if (id === undefined) continue
 

--- a/packages/metadata-fetcher/src/providers/projectGutenberg/parse.test.ts
+++ b/packages/metadata-fetcher/src/providers/projectGutenberg/parse.test.ts
@@ -12,6 +12,7 @@ const PROJECT_GUTENBERG_RDF_FIXTURE = `<?xml version="1.0" encoding="utf-8"?>
   <pgterms:ebook rdf:about="ebooks/78139">
     <dcterms:publisher>Project Gutenberg</dcterms:publisher>
     <dcterms:issued>2026-03-08</dcterms:issued>
+    <pgterms:marc260>  $aNew York :$bA.L. Burt, $c1896.</pgterms:marc260>
     <dcterms:rights>Public domain in the USA.</dcterms:rights>
     <dcterms:creator>
       <pgterms:agent><pgterms:name>Goethe, Johann Wolfgang von</pgterms:name></pgterms:agent>
@@ -56,6 +57,7 @@ describe("parseProjectGutenbergRdf", () => {
       title: "Wilhelm Meister's apprenticeship and travels, vol. 2 (of 2)",
       publisher: "Project Gutenberg",
       issued: "2026-03-08",
+      originalPublication: "$aNew York :$bA.L. Burt, $c1896.",
       rights: "Public domain in the USA.",
       description: "A catalog note",
       summary: "A useful summary",

--- a/packages/metadata-fetcher/src/providers/projectGutenberg/parse.test.ts
+++ b/packages/metadata-fetcher/src/providers/projectGutenberg/parse.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest"
+import { parseProjectGutenbergRdf } from "./parse.ts"
+
+const PROJECT_GUTENBERG_RDF_FIXTURE = `<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+  xmlns:dcam="http://purl.org/dc/dcam/"
+  xmlns:dcterms="http://purl.org/dc/terms/"
+  xmlns:marcrel="http://id.loc.gov/vocabulary/relators/"
+  xmlns:pgterms="http://www.gutenberg.org/2009/pgterms/"
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+>
+  <pgterms:ebook rdf:about="ebooks/78139">
+    <dcterms:publisher>Project Gutenberg</dcterms:publisher>
+    <dcterms:issued>2026-03-08</dcterms:issued>
+    <dcterms:rights>Public domain in the USA.</dcterms:rights>
+    <dcterms:creator>
+      <pgterms:agent><pgterms:name>Goethe, Johann Wolfgang von</pgterms:name></pgterms:agent>
+    </dcterms:creator>
+    <marcrel:trl>
+      <pgterms:agent><pgterms:name>Carlyle, Thomas</pgterms:name></pgterms:agent>
+    </marcrel:trl>
+    <dcterms:title>Wilhelm Meister's apprenticeship and travels, vol. 2 (of 2)</dcterms:title>
+    <dcterms:description>A catalog note</dcterms:description>
+    <pgterms:marc520>A useful summary</pgterms:marc520>
+    <dcterms:language><rdf:Description><rdf:value>en</rdf:value></rdf:Description></dcterms:language>
+    <dcterms:subject>
+      <rdf:Description>
+        <dcam:memberOf rdf:resource="http://purl.org/dc/terms/LCSH"/>
+        <rdf:value>Bildungsromans</rdf:value>
+      </rdf:Description>
+    </dcterms:subject>
+    <dcterms:subject>
+      <rdf:Description>
+        <dcam:memberOf rdf:resource="http://purl.org/dc/terms/LCC"/>
+        <rdf:value>PT</rdf:value>
+      </rdf:Description>
+    </dcterms:subject>
+    <pgterms:bookshelf><rdf:Description><rdf:value>German Literature</rdf:value></rdf:Description></pgterms:bookshelf>
+    <dcterms:hasFormat>
+      <pgterms:file rdf:about="https://www.gutenberg.org/cache/epub/78139/pg78139.cover.small.jpg">
+        <dcterms:format><rdf:Description><rdf:value>image/jpeg</rdf:value></rdf:Description></dcterms:format>
+      </pgterms:file>
+    </dcterms:hasFormat>
+    <dcterms:hasFormat>
+      <pgterms:file rdf:about="https://www.gutenberg.org/cache/epub/78139/pg78139.cover.medium.jpg">
+        <dcterms:format><rdf:Description><rdf:value>image/jpeg</rdf:value></rdf:Description></dcterms:format>
+      </pgterms:file>
+    </dcterms:hasFormat>
+  </pgterms:ebook>
+</rdf:RDF>`
+
+describe("parseProjectGutenbergRdf", () => {
+  it("parses the metadata used by the resolver", () => {
+    expect(parseProjectGutenbergRdf(PROJECT_GUTENBERG_RDF_FIXTURE)).toEqual({
+      id: "78139",
+      title: "Wilhelm Meister's apprenticeship and travels, vol. 2 (of 2)",
+      publisher: "Project Gutenberg",
+      issued: "2026-03-08",
+      rights: "Public domain in the USA.",
+      description: "A catalog note",
+      summary: "A useful summary",
+      languages: ["en"],
+      subjects: ["Bildungsromans"],
+      bookshelves: ["German Literature"],
+      contributors: [
+        { name: "Goethe, Johann Wolfgang von", role: "aut" },
+        { name: "Carlyle, Thomas", role: "trl" },
+      ],
+      cover: {
+        uri: "https://www.gutenberg.org/cache/epub/78139/pg78139.cover.medium.jpg",
+        mediaType: "image/jpeg",
+      },
+    })
+  })
+
+  it("returns undefined for XML that is not a Gutenberg RDF record", () => {
+    expect(
+      parseProjectGutenbergRdf("<html><body>not RDF</body></html>"),
+    ).toBeUndefined()
+    expect(
+      parseProjectGutenbergRdf("<rdf:RDF xmlns:rdf='rdf'/>"),
+    ).toBeUndefined()
+  })
+
+  it("labels malformed XML", () => {
+    expect(() => parseProjectGutenbergRdf("<rdf:RDF><x></rdf:RDF>")).toThrow(
+      /Project Gutenberg RDF is malformed/,
+    )
+  })
+})

--- a/packages/metadata-fetcher/src/providers/projectGutenberg/parse.ts
+++ b/packages/metadata-fetcher/src/providers/projectGutenberg/parse.ts
@@ -1,0 +1,233 @@
+import type { XmlElement, XmlNodeBase } from "xmldoc"
+import { XmlDocument } from "xmldoc"
+
+export type ProjectGutenbergContributor = {
+  readonly name: string
+  /** MARC relator code, or `aut` for `dcterms:creator`. */
+  readonly role: string
+}
+
+export type ProjectGutenbergCover = {
+  readonly uri: string
+  readonly mediaType?: string
+}
+
+/** The subset of one official per-eBook RDF record that we consume. */
+export type ProjectGutenbergRecord = {
+  readonly id: string
+  readonly title?: string
+  readonly publisher?: string
+  readonly issued?: string
+  readonly rights?: string
+  readonly description?: string
+  readonly summary?: string
+  readonly languages?: ReadonlyArray<string>
+  readonly subjects?: ReadonlyArray<string>
+  readonly bookshelves?: ReadonlyArray<string>
+  readonly contributors?: ReadonlyArray<ProjectGutenbergContributor>
+  readonly cover?: ProjectGutenbergCover
+}
+
+const elementLocalName = (name: string): string =>
+  name.includes(":") ? name.slice(name.lastIndexOf(":") + 1) : name
+
+const isXmlElement = (node: XmlNodeBase): node is XmlElement =>
+  node.type === "element"
+
+const childrenNamedLocal = (
+  parent: XmlElement,
+  localName: string,
+): ReadonlyArray<XmlElement> =>
+  parent.children.filter(
+    (child): child is XmlElement =>
+      isXmlElement(child) &&
+      elementLocalName(child.name).toLowerCase() === localName.toLowerCase(),
+  )
+
+const childNamedLocal = (
+  parent: XmlElement,
+  localName: string,
+): XmlElement | undefined => childrenNamedLocal(parent, localName)[0]
+
+const text = (element: XmlElement | undefined): string | undefined => {
+  const trimmed = element?.val.trim()
+
+  return trimmed !== undefined && trimmed.length > 0 ? trimmed : undefined
+}
+
+const attributeNamedLocal = (
+  element: XmlElement,
+  localName: string,
+): string | undefined => {
+  for (const [name, value] of Object.entries(element.attr)) {
+    if (elementLocalName(name).toLowerCase() !== localName.toLowerCase()) {
+      continue
+    }
+
+    const trimmed = value.trim()
+
+    if (trimmed.length > 0) return trimmed
+  }
+
+  return undefined
+}
+
+const valuesFromDescriptions = (
+  ebook: XmlElement,
+  localName: string,
+): ReadonlyArray<string> =>
+  childrenNamedLocal(ebook, localName).flatMap((container) => {
+    const description = childNamedLocal(container, "Description")
+    const value = text(childNamedLocal(description ?? container, "value"))
+
+    return value !== undefined ? [value] : []
+  })
+
+const projectGutenbergIdFromEbook = (ebook: XmlElement): string | undefined => {
+  const about = attributeNamedLocal(ebook, "about")
+  const id =
+    about !== undefined ? /(?:^|\/)ebooks\/(\d+)$/.exec(about)?.[1] : undefined
+
+  if (id === undefined) return undefined
+
+  const normalized = id.replace(/^0+(?=\d)/, "")
+
+  return normalized !== "0" ? normalized : undefined
+}
+
+const contributorsFromEbook = (
+  ebook: XmlElement,
+): ReadonlyArray<ProjectGutenbergContributor> => {
+  const contributors: ProjectGutenbergContributor[] = []
+
+  for (const child of ebook.children) {
+    if (!isXmlElement(child)) continue
+
+    const isCreator = child.name.toLowerCase() === "dcterms:creator"
+    const isMarcRelator = child.name.toLowerCase().startsWith("marcrel:")
+
+    if (!isCreator && !isMarcRelator) continue
+
+    const name = text(
+      childNamedLocal(childNamedLocal(child, "agent") ?? child, "name"),
+    )
+
+    if (name === undefined) continue
+
+    contributors.push({
+      name,
+      role: isCreator ? "aut" : elementLocalName(child.name).toLowerCase(),
+    })
+  }
+
+  return contributors
+}
+
+const subjectValuesFromEbook = (ebook: XmlElement): ReadonlyArray<string> =>
+  childrenNamedLocal(ebook, "subject").flatMap((container) => {
+    const description = childNamedLocal(container, "Description")
+    const memberOf =
+      description !== undefined
+        ? attributeNamedLocal(
+            childNamedLocal(description, "memberOf") ?? description,
+            "resource",
+          )
+        : undefined
+    const value = text(
+      description !== undefined
+        ? childNamedLocal(description, "value")
+        : undefined,
+    )
+
+    return value !== undefined && memberOf?.endsWith("/LCSH") === true
+      ? [value]
+      : []
+  })
+
+const coverFromEbook = (
+  ebook: XmlElement,
+): ProjectGutenbergCover | undefined => {
+  const covers = childrenNamedLocal(ebook, "hasFormat").flatMap(
+    (formatContainer) => {
+      const file = childNamedLocal(formatContainer, "file")
+
+      if (file === undefined) return []
+
+      const uri = attributeNamedLocal(file, "about")
+      const mediaType = childrenNamedLocal(file, "format")
+        .map((format) => {
+          const description = childNamedLocal(format, "Description")
+
+          return text(childNamedLocal(description ?? format, "value"))
+        })
+        .find((value) => value?.startsWith("image/") === true)
+
+      if (
+        uri === undefined ||
+        mediaType === undefined ||
+        !/\.cover\.(?:medium|small)\.[a-z0-9]+(?:$|[?#])/i.test(uri)
+      ) {
+        return []
+      }
+
+      return [{ uri, mediaType }]
+    },
+  )
+
+  return (
+    covers.find((cover) => /\.cover\.medium\./i.test(cover.uri)) ?? covers[0]
+  )
+}
+
+const emptyToUndefined = <T>(
+  values: ReadonlyArray<T>,
+): ReadonlyArray<T> | undefined => (values.length > 0 ? values : undefined)
+
+/**
+ * Parses one official Project Gutenberg per-eBook RDF document. Unsupported
+ * XML yields `undefined`; malformed XML throws with a provider-specific label.
+ */
+export const parseProjectGutenbergRdf = (
+  xml: string,
+): ProjectGutenbergRecord | undefined => {
+  let document: XmlDocument
+
+  try {
+    document = new XmlDocument(xml)
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause)
+    throw new Error(`Project Gutenberg RDF is malformed: ${message}`, { cause })
+  }
+
+  if (elementLocalName(document.name).toLowerCase() !== "rdf") {
+    return undefined
+  }
+
+  const ebook = childNamedLocal(document, "ebook")
+
+  if (ebook === undefined) return undefined
+
+  const id = projectGutenbergIdFromEbook(ebook)
+
+  if (id === undefined) return undefined
+
+  const languages = [...new Set(valuesFromDescriptions(ebook, "language"))]
+  const subjects = [...new Set(subjectValuesFromEbook(ebook))]
+  const bookshelves = [...new Set(valuesFromDescriptions(ebook, "bookshelf"))]
+  const contributors = contributorsFromEbook(ebook)
+
+  return {
+    id,
+    title: text(childNamedLocal(ebook, "title")),
+    publisher: text(childNamedLocal(ebook, "publisher")),
+    issued: text(childNamedLocal(ebook, "issued")),
+    rights: text(childNamedLocal(ebook, "rights")),
+    description: text(childNamedLocal(ebook, "description")),
+    summary: text(childNamedLocal(ebook, "marc520")),
+    languages: emptyToUndefined(languages),
+    subjects: emptyToUndefined(subjects),
+    bookshelves: emptyToUndefined(bookshelves),
+    contributors: emptyToUndefined(contributors),
+    cover: coverFromEbook(ebook),
+  }
+}

--- a/packages/metadata-fetcher/src/providers/projectGutenberg/parse.ts
+++ b/packages/metadata-fetcher/src/providers/projectGutenberg/parse.ts
@@ -18,6 +18,8 @@ export type ProjectGutenbergRecord = {
   readonly title?: string
   readonly publisher?: string
   readonly issued?: string
+  /** Original print publication statement (`MARC 260`). */
+  readonly originalPublication?: string
   readonly rights?: string
   readonly description?: string
   readonly summary?: string
@@ -221,6 +223,7 @@ export const parseProjectGutenbergRdf = (
     title: text(childNamedLocal(ebook, "title")),
     publisher: text(childNamedLocal(ebook, "publisher")),
     issued: text(childNamedLocal(ebook, "issued")),
+    originalPublication: text(childNamedLocal(ebook, "marc260")),
     rights: text(childNamedLocal(ebook, "rights")),
     description: text(childNamedLocal(ebook, "description")),
     summary: text(childNamedLocal(ebook, "marc520")),

--- a/packages/metadata-fetcher/src/providers/projectGutenberg/resolve.test.ts
+++ b/packages/metadata-fetcher/src/providers/projectGutenberg/resolve.test.ts
@@ -7,6 +7,7 @@ const record: ProjectGutenbergRecord = {
   title: "Wilhelm Meister, vol. 2",
   publisher: "Project Gutenberg",
   issued: "2026-03-08",
+  originalPublication: "$aNew York :$bA.L. Burt, $c1896.",
   rights: "Public domain in the USA.",
   description: "Catalog note",
   summary: "Summary",
@@ -33,7 +34,13 @@ describe("resolveProjectGutenbergRecord", () => {
       }),
     ).toEqual({
       title: "Wilhelm Meister, vol. 2",
-      publisher: "Project Gutenberg",
+      publication: {
+        original: { date: { year: 1896 }, publisher: "A.L. Burt" },
+        edition: {
+          date: { year: 2026, month: 3, day: 8 },
+          publisher: "Project Gutenberg",
+        },
+      },
       description: "Summary",
       rights: "Public domain in the USA.",
       languages: ["en"],
@@ -42,7 +49,6 @@ describe("resolveProjectGutenbergRecord", () => {
         { name: "Goethe, Johann Wolfgang von", roles: ["author"] },
         { name: "Carlyle, Thomas", roles: ["translator", "editor"] },
       ],
-      published: { year: 2026, month: 3, day: 8 },
       identifiers: [
         { value: "http://www.gutenberg.org/78139", scheme: "URL" },
         { value: "78139", scheme: "ProjectGutenberg" },
@@ -73,7 +79,28 @@ describe("resolveProjectGutenbergRecord", () => {
       },
     )
 
-    expect(metadata.published).toBeUndefined()
+    expect(metadata.publication?.edition).toEqual({
+      publisher: "Project Gutenberg",
+    })
+    expect(metadata.publication?.original).toEqual({
+      date: { year: 1896 },
+      publisher: "A.L. Burt",
+    })
     expect(metadata.cover).toBeUndefined()
+  })
+
+  it("omits ambiguous original-publication subfields", () => {
+    const metadata = resolveProjectGutenbergRecord(
+      {
+        ...record,
+        originalPublication: "$bFirst$bSecond$c1896, reprinted 1901",
+      },
+      {
+        baseUrl: "https://www.gutenberg.org",
+        matchedIdentifier: { value: "78139", scheme: "ProjectGutenberg" },
+      },
+    )
+
+    expect(metadata.publication?.original).toBeUndefined()
   })
 })

--- a/packages/metadata-fetcher/src/providers/projectGutenberg/resolve.test.ts
+++ b/packages/metadata-fetcher/src/providers/projectGutenberg/resolve.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+import type { ProjectGutenbergRecord } from "./parse.ts"
+import { resolveProjectGutenbergRecord } from "./resolve.ts"
+
+const record: ProjectGutenbergRecord = {
+  id: "78139",
+  title: "Wilhelm Meister, vol. 2",
+  publisher: "Project Gutenberg",
+  issued: "2026-03-08",
+  rights: "Public domain in the USA.",
+  description: "Catalog note",
+  summary: "Summary",
+  languages: ["en", "en"],
+  subjects: ["Bildungsromans"],
+  bookshelves: ["German Literature", "Bildungsromans"],
+  contributors: [
+    { name: "Goethe, Johann Wolfgang von", role: "aut" },
+    { name: "Carlyle, Thomas", role: "trl" },
+    { name: "Carlyle, Thomas", role: "edt" },
+  ],
+  cover: { uri: "/cover.jpg", mediaType: "image/jpeg" },
+}
+
+describe("resolveProjectGutenbergRecord", () => {
+  it("normalizes a record and preserves the exact matched URL", () => {
+    expect(
+      resolveProjectGutenbergRecord(record, {
+        baseUrl: "https://www.gutenberg.org",
+        matchedIdentifier: {
+          value: "http://www.gutenberg.org/78139",
+          scheme: "URL",
+        },
+      }),
+    ).toEqual({
+      title: "Wilhelm Meister, vol. 2",
+      publisher: "Project Gutenberg",
+      description: "Summary",
+      rights: "Public domain in the USA.",
+      languages: ["en"],
+      subjects: ["Bildungsromans", "German Literature"],
+      contributors: [
+        { name: "Goethe, Johann Wolfgang von", roles: ["author"] },
+        { name: "Carlyle, Thomas", roles: ["translator", "editor"] },
+      ],
+      published: { year: 2026, month: 3, day: 8 },
+      identifiers: [
+        { value: "http://www.gutenberg.org/78139", scheme: "URL" },
+        { value: "78139", scheme: "ProjectGutenberg" },
+      ],
+      cover: {
+        uri: "https://www.gutenberg.org/cover.jpg",
+        mediaType: "image/jpeg",
+        confidence: "derived",
+      },
+    })
+  })
+
+  it("does not duplicate an already canonical identifier", () => {
+    expect(
+      resolveProjectGutenbergRecord(record, {
+        baseUrl: "https://www.gutenberg.org",
+        matchedIdentifier: { value: "78139", scheme: "ProjectGutenberg" },
+      }).identifiers,
+    ).toEqual([{ value: "78139", scheme: "ProjectGutenberg" }])
+  })
+
+  it("drops invalid dates and non-HTTP cover URLs", () => {
+    const metadata = resolveProjectGutenbergRecord(
+      { ...record, issued: "2026-99-99", cover: { uri: "javascript:bad" } },
+      {
+        baseUrl: "https://www.gutenberg.org",
+        matchedIdentifier: { value: "78139", scheme: "ProjectGutenberg" },
+      },
+    )
+
+    expect(metadata.published).toBeUndefined()
+    expect(metadata.cover).toBeUndefined()
+  })
+})

--- a/packages/metadata-fetcher/src/providers/projectGutenberg/resolve.ts
+++ b/packages/metadata-fetcher/src/providers/projectGutenberg/resolve.ts
@@ -1,0 +1,167 @@
+import type {
+  ResolvedContributor,
+  ResolvedContributorRole,
+  ResolvedCover,
+  ResolvedDate,
+  ResolvedMetadata,
+} from "@prose-reader/archive-reader"
+import { omitUndefined } from "../../utils/omitUndefined.ts"
+import { PROJECT_GUTENBERG_IDENTIFIER_SCHEME } from "./identifier.ts"
+import type { ProjectGutenbergRecord } from "./parse.ts"
+
+export const PROJECT_GUTENBERG_MAX_SUBJECTS = 25
+
+/** Compile-enforced map from every parsed RDF field to its resolved home. */
+export const projectGutenbergMetadataHomes = {
+  id: "identifiers",
+  title: "title",
+  publisher: "publisher",
+  issued: "published",
+  rights: "rights",
+  description: "description",
+  summary: "description",
+  languages: "languages",
+  subjects: "subjects",
+  bookshelves: "subjects",
+  contributors: "contributors",
+  cover: "cover",
+} as const satisfies Record<
+  keyof ProjectGutenbergRecord,
+  keyof ResolvedMetadata | "identifiers"
+>
+
+const MARC_RELATOR_TO_ROLE: Readonly<
+  Partial<Record<string, ResolvedContributorRole>>
+> = {
+  art: "artist",
+  aut: "author",
+  clr: "colorist",
+  ctb: "contributor",
+  edt: "editor",
+  ill: "illustrator",
+  nrt: "narrator",
+  trl: "translator",
+}
+
+const resolvedContributors = (
+  record: ProjectGutenbergRecord,
+): ReadonlyArray<ResolvedContributor> | undefined => {
+  const contributors = new Map<string, { name: string; roles: string[] }>()
+
+  for (const contributor of record.contributors ?? []) {
+    const key = contributor.name.trim().toLowerCase()
+    const role =
+      MARC_RELATOR_TO_ROLE[contributor.role.trim().toLowerCase()] ??
+      contributor.role
+    const existing = contributors.get(key)
+
+    if (existing === undefined) {
+      contributors.set(key, { name: contributor.name, roles: [role] })
+    } else if (!existing.roles.includes(role)) {
+      existing.roles.push(role)
+    }
+  }
+
+  return contributors.size > 0 ? [...contributors.values()] : undefined
+}
+
+const resolvedIssuedDate = (
+  issued: string | undefined,
+): ResolvedDate | undefined => {
+  if (issued === undefined) return undefined
+
+  const match = /^(\d{4})(?:-(\d{2})(?:-(\d{2}))?)?$/.exec(issued.trim())
+
+  if (match === null) return undefined
+
+  const year = Number(match[1])
+  const month = match[2] !== undefined ? Number(match[2]) : undefined
+  const day = match[3] !== undefined ? Number(match[3]) : undefined
+
+  if (
+    !Number.isInteger(year) ||
+    year <= 0 ||
+    (month !== undefined && (month < 1 || month > 12)) ||
+    (day !== undefined && (day < 1 || day > 31))
+  ) {
+    return undefined
+  }
+
+  return {
+    year,
+    ...(month !== undefined ? { month } : {}),
+    ...(day !== undefined ? { day } : {}),
+  }
+}
+
+const absoluteHttpUrl = (
+  value: string,
+  baseUrl: string,
+): string | undefined => {
+  try {
+    const url = new URL(value, baseUrl)
+
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.toString()
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const emptyToUndefined = <T>(
+  values: ReadonlyArray<T>,
+): ReadonlyArray<T> | undefined => (values.length > 0 ? values : undefined)
+
+export const resolveProjectGutenbergRecord = (
+  record: ProjectGutenbergRecord,
+  options: {
+    readonly baseUrl: string
+    readonly matchedIdentifier: {
+      readonly value: string
+      readonly scheme?: string
+    }
+  },
+): ResolvedMetadata => {
+  const identifiers = [
+    options.matchedIdentifier,
+    { value: record.id, scheme: PROJECT_GUTENBERG_IDENTIFIER_SCHEME },
+  ].filter(
+    (identifier, index, all) =>
+      all.findIndex(
+        (other) =>
+          other.value.trim().toLowerCase() ===
+            identifier.value.trim().toLowerCase() &&
+          other.scheme?.trim().toLowerCase() ===
+            identifier.scheme?.trim().toLowerCase(),
+      ) === index,
+  )
+  const subjects = [
+    ...new Set([...(record.subjects ?? []), ...(record.bookshelves ?? [])]),
+  ].slice(0, PROJECT_GUTENBERG_MAX_SUBJECTS)
+  const coverUri =
+    record.cover !== undefined
+      ? absoluteHttpUrl(record.cover.uri, options.baseUrl)
+      : undefined
+  const cover: ResolvedCover | undefined =
+    coverUri !== undefined
+      ? {
+          uri: coverUri,
+          mediaType: record.cover?.mediaType,
+          confidence: "derived",
+        }
+      : undefined
+
+  return omitUndefined({
+    title: record.title,
+    publisher: record.publisher,
+    description: record.summary ?? record.description,
+    rights: record.rights,
+    languages: emptyToUndefined([...new Set(record.languages ?? [])]),
+    subjects: emptyToUndefined(subjects),
+    contributors: resolvedContributors(record),
+    published: resolvedIssuedDate(record.issued),
+    identifiers,
+    cover,
+  })
+}

--- a/packages/metadata-fetcher/src/providers/projectGutenberg/resolve.ts
+++ b/packages/metadata-fetcher/src/providers/projectGutenberg/resolve.ts
@@ -4,6 +4,8 @@ import type {
   ResolvedCover,
   ResolvedDate,
   ResolvedMetadata,
+  ResolvedMetadataHome,
+  ResolvedPublication,
 } from "@prose-reader/archive-reader"
 import { omitUndefined } from "../../utils/omitUndefined.ts"
 import { PROJECT_GUTENBERG_IDENTIFIER_SCHEME } from "./identifier.ts"
@@ -15,8 +17,9 @@ export const PROJECT_GUTENBERG_MAX_SUBJECTS = 25
 export const projectGutenbergMetadataHomes = {
   id: "identifiers",
   title: "title",
-  publisher: "publisher",
-  issued: "published",
+  publisher: "publication.edition.publisher",
+  issued: "publication.edition.date",
+  originalPublication: "publication.original",
   rights: "rights",
   description: "description",
   summary: "description",
@@ -27,7 +30,7 @@ export const projectGutenbergMetadataHomes = {
   cover: "cover",
 } as const satisfies Record<
   keyof ProjectGutenbergRecord,
-  keyof ResolvedMetadata | "identifiers"
+  ResolvedMetadataHome | "identifiers"
 >
 
 const MARC_RELATOR_TO_ROLE: Readonly<
@@ -94,6 +97,55 @@ const resolvedIssuedDate = (
   }
 }
 
+const marc260Subfields = (
+  statement: string,
+  code: string,
+): ReadonlyArray<string> =>
+  statement
+    .split("$")
+    .slice(1)
+    .flatMap((subfield) =>
+      subfield[0]?.toLowerCase() === code.toLowerCase()
+        ? [subfield.slice(1).trim()]
+        : [],
+    )
+    .filter((value) => value.length > 0)
+
+const originalPublicationFromMarc260 = (
+  statement: string | undefined,
+): ResolvedPublication | undefined => {
+  if (statement === undefined) return undefined
+
+  const publisherValues = marc260Subfields(statement, "b")
+  const rawPublisher =
+    publisherValues.length === 1 ? publisherValues[0] : undefined
+  const publisher = rawPublisher?.replace(/[\s,;:/]+$/u, "").trim()
+  const dateValues = marc260Subfields(statement, "c")
+  const years = [
+    ...new Set(
+      dateValues.flatMap((value) =>
+        [...value.matchAll(/\d{4}/g)].flatMap((match) =>
+          match[0] !== undefined ? [Number(match[0])] : [],
+        ),
+      ),
+    ),
+  ]
+  const date = years.length === 1 ? { year: years[0] } : undefined
+  const details = omitUndefined({
+    date,
+    publisher:
+      publisher !== undefined &&
+      publisher.length > 0 &&
+      !/^\[?s\.n\.?\]?$/i.test(publisher)
+        ? publisher
+        : undefined,
+  })
+
+  return details.date !== undefined || details.publisher !== undefined
+    ? details
+    : undefined
+}
+
 const absoluteHttpUrl = (
   value: string,
   baseUrl: string,
@@ -151,16 +203,30 @@ export const resolveProjectGutenbergRecord = (
           confidence: "derived",
         }
       : undefined
+  const edition = omitUndefined({
+    date: resolvedIssuedDate(record.issued),
+    publisher: record.publisher,
+  })
+  const original = originalPublicationFromMarc260(record.originalPublication)
+  const publication = omitUndefined({
+    original,
+    edition:
+      edition.date !== undefined || edition.publisher !== undefined
+        ? edition
+        : undefined,
+  })
 
   return omitUndefined({
     title: record.title,
-    publisher: record.publisher,
+    publication:
+      publication.original !== undefined || publication.edition !== undefined
+        ? publication
+        : undefined,
     description: record.summary ?? record.description,
     rights: record.rights,
     languages: emptyToUndefined([...new Set(record.languages ?? [])]),
     subjects: emptyToUndefined(subjects),
     contributors: resolvedContributors(record),
-    published: resolvedIssuedDate(record.issued),
     identifiers,
     cover,
   })

--- a/packages/metadata-fetcher/src/types/match.ts
+++ b/packages/metadata-fetcher/src/types/match.ts
@@ -11,15 +11,17 @@ export type MetadataMatchField =
   | "title"
   | "contributors"
   | "series"
-  | "publisher"
-  | "published"
+  | "publication.original.date"
+  | "publication.original.publisher"
+  | "publication.edition.date"
+  | "publication.edition.publisher"
   | "languages"
   | "numberOfPages"
 
 /**
  * One field comparison. The compared values sit next to the score so a match
- * is explainable to a user — "same title, different publisher" — without
- * re-deriving anything.
+ * is explainable to a user — "same title, different edition publisher" —
+ * without re-deriving anything.
  */
 export type MetadataMatchSignal = {
   readonly field: MetadataMatchField

--- a/packages/metadata-fetcher/src/types/match.ts
+++ b/packages/metadata-fetcher/src/types/match.ts
@@ -41,10 +41,10 @@ export type MetadataMatch = {
   readonly providerId: string
   /**
    * Aggregate confidence, `0` to `1`: the weight-averaged score of every
-   * comparable field — except when both sides state an identifier, which
-   * settles it outright: `1` if it agrees (an ISBN/GTIN match *is* the book),
-   * `0` if it contradicts. `0` too when the two sides had no field in common
-   * to compare.
+   * comparable field — except when an ISBN, GTIN or shared scheme-scoped
+   * identifier confirms identity, which settles it at `1`. A contradictory
+   * ISBN or GTIN settles it at `0`. `0` too when the two sides had no field in
+   * common to compare.
    */
   readonly score: number
   readonly signals: ReadonlyArray<MetadataMatchSignal>

--- a/packages/metadata-fetcher/src/utils/hasSearchTerms.test.ts
+++ b/packages/metadata-fetcher/src/utils/hasSearchTerms.test.ts
@@ -23,10 +23,12 @@ describe("hasSearchTerms", () => {
     expect(hasSearchTerms({})).toBe(false)
     expect(
       hasSearchTerms({
-        publisher: "Ace",
+        publication: {
+          original: { date: { year: 1965 } },
+          edition: { publisher: "Ace" },
+        },
         languages: ["en"],
         numberOfPages: 412,
-        published: { year: 1965 },
       }),
     ).toBe(false)
   })

--- a/packages/metadata-fetcher/src/utils/hasSearchTerms.ts
+++ b/packages/metadata-fetcher/src/utils/hasSearchTerms.ts
@@ -3,8 +3,8 @@ import { metadataAuthors } from "./metadataAuthors.ts"
 
 /**
  * Whether a catalog has anything to go on, so a lookup with nothing to ask
- * about costs no round trip. Descriptive fields alone — a publisher, a
- * language, a page count — narrow a search but cannot start one.
+ * about costs no round trip. Publication details, a language, or a page count
+ * narrow a search but cannot start one.
  */
 export const hasSearchTerms = (metadata: ResolvedMetadata): boolean =>
   [


### PR DESCRIPTION
## Summary

- add an exact-identifier Project Gutenberg provider backed by Gutenberg's official per-eBook RDF records
- replace ambiguous top-level publication fields with `publication.original` and `publication.edition`, keeping each event's date, publisher, and imprint together
- map EPUB and ComicInfo publication data to the concrete edition, Open Library's `first_publish_year` to the original publication, and Gutenberg's release plus publisher to its edition
- parse an unambiguous Gutenberg MARC 260 print statement into original publication details while retaining the full provider record as raw provenance when requested
- score original and edition dates/publishers only against the same publication scope and expose those scopes in API query parsing and playground results
- recognize official Gutenberg URL forms and typed `ProjectGutenberg` identifiers without treating arbitrary URLs generically
- bump `ResolvedArchive` and `FetchedMetadata` schema versions to 2 and update the public documentation

## Why

Open Library does not currently carry `id_project_gutenberg:78139`, even though Gutenberg itself has the record. When an uploaded EPUB contains Gutenberg's canonical URL, Gutenberg should be queried as the authority for its own identifier instead of relying on Open Library's incomplete cross-reference.

The previous `published` field also mixed incompatible facts: an EPUB edition's publication date, Open Library's first-publication year, and Gutenberg's ebook release date. The explicit publication scopes preserve all useful normalized values without presenting a catalog edition's release as the book's original publication.

The lookup makes one exact RDF request and does not crawl or fuzzy-search Gutenberg. The response is parsed and normalized entirely in memory; the provider adds no database, cache, file writes, browser storage, or other persistence.

## Impact

`ResolvedMetadata.publisher`, `ResolvedMetadata.imprint`, and `ResolvedMetadata.published` are replaced by `ResolvedMetadata.publication`. This is an intentional breaking public-type change and requires a semver-major release.

## Validation

- `npm test --workspace @prose-reader/archive-reader` — 23 files, 237 tests passed
- `npm test --workspace @prose-reader/metadata-fetcher` — 12 files, 102 tests passed
- `npm test --workspace prose-reader-metadata-fetcher-api` — 4 files, 36 tests passed
- `npm run tsc` — all 8 projects passed
- `npm run build --workspace @prose-reader/archive-reader` — ESM, CJS, and declarations built
- `npm run build --workspace @prose-reader/metadata-fetcher` — ESM, CJS, and declarations built
