### PR TITLE
Fix range CFI resolution for single-step start/end paths

### DIFF
--- a/packages/cfi/src/resolve.range.test.ts
+++ b/packages/cfi/src/resolve.range.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { generate } from "./generate"
 import { resolve } from "./resolve"
 
 describe("CFI Range handling", () => {
@@ -117,6 +118,85 @@ describe("CFI Range handling", () => {
     if (result.node instanceof Range) {
       expect(result.node.startContainer).toBe(doc.getElementById("para01"))
       expect(result.node.endContainer).toBe(doc.getElementById("para02"))
+    }
+  })
+
+  it("should resolve single-step start/end paths as children of the parent", () => {
+    const parser = new DOMParser()
+    const doc = parser.parseFromString(
+      `<html xmlns="http://www.w3.org/1999/xhtml"><body id="body01"><p id="para01">Hello <b>big</b> world</p></body></html>`,
+      "application/xhtml+xml",
+    )
+
+    // Start/end paths are relative to the parent path: /1 and /3 are the two
+    // text nodes of para01, not offsets on para01 itself.
+    const cfi = "epubcfi(/2[body01]/2[para01],/1:2,/3:3)"
+    const result = resolve(cfi, doc)
+
+    expect(result.isRange).toBe(true)
+    expect(result.node).toBeInstanceOf(Range)
+
+    if (result.node instanceof Range) {
+      const para01 = doc.getElementById("para01")
+      expect(result.node.startContainer).toBe(para01?.childNodes[0])
+      expect(result.node.startOffset).toBe(2)
+      expect(result.node.endContainer).toBe(para01?.childNodes[2])
+      expect(result.node.endOffset).toBe(3)
+      expect(result.node.toString()).toBe("llo big wo")
+    }
+  })
+
+  it("should round-trip a generated range crossing an inline element", () => {
+    const parser = new DOMParser()
+    const doc = parser.parseFromString(
+      `<html xmlns="http://www.w3.org/1999/xhtml"><body id="body01"><p id="para01">abcdefghij<i>X</i>klmnopqrst</p></body></html>`,
+      "application/xhtml+xml",
+    )
+
+    const para01 = doc.getElementById("para01")
+    const startNode = para01?.childNodes[0]
+    const endNode = para01?.childNodes[2]
+
+    if (!startNode || !endNode) throw new Error("missing text nodes")
+
+    const cfi = generate({
+      start: { node: startNode, offset: 8 },
+      end: { node: endNode, offset: 6 },
+    })
+    const result = resolve(cfi, doc)
+
+    expect(result.isRange).toBe(true)
+    expect(result.node).toBeInstanceOf(Range)
+
+    if (result.node instanceof Range) {
+      expect(result.node.startContainer).toBe(startNode)
+      expect(result.node.startOffset).toBe(8)
+      expect(result.node.endContainer).toBe(endNode)
+      expect(result.node.endOffset).toBe(6)
+      expect(result.node.toString()).toBe("ijXklmnop")
+    }
+  })
+
+  it("should resolve offset-only ranges attached to a text node parent", () => {
+    const parser = new DOMParser()
+    const doc = parser.parseFromString(
+      `<html xmlns="http://www.w3.org/1999/xhtml"><body id="body01"><p id="para01">0123456789</p></body></html>`,
+      "application/xhtml+xml",
+    )
+
+    const cfi = "epubcfi(/2[body01]/2[para01]/1,:2,:5)"
+    const result = resolve(cfi, doc)
+
+    expect(result.isRange).toBe(true)
+    expect(result.node).toBeInstanceOf(Range)
+
+    if (result.node instanceof Range) {
+      const textNode = doc.getElementById("para01")?.firstChild
+      expect(result.node.startContainer).toBe(textNode)
+      expect(result.node.startOffset).toBe(2)
+      expect(result.node.endContainer).toBe(textNode)
+      expect(result.node.endOffset).toBe(5)
+      expect(result.node.toString()).toBe("234")
     }
   })
 

--- a/packages/cfi/src/resolve.ts
+++ b/packages/cfi/src/resolve.ts
@@ -194,13 +194,12 @@ function resolveRange(range: CfiRange, document: Document): ResolveResult {
         ? lastEndPart.offset[0]
         : lastEndPart?.offset) ?? 0
   } else {
-    // If startPath/endPath are empty or only have offset, use parentNode directly
-    const isStartOffsetOnly =
-      startPath.length === 0 ||
-      (startPath.length === 1 && typeof startPath[0]?.offset === "number")
-    const isEndOffsetOnly =
-      endPath.length === 0 ||
-      (endPath.length === 1 && typeof endPath[0]?.offset === "number")
+    // Offset-only local paths (`,:5`) are attached to the parent path during
+    // parsing, so a non-empty path here always carries real steps that must be
+    // traversed — a single step with an offset (`/1:2`) is a path to a child
+    // node, not an offset on the parent.
+    const isStartOffsetOnly = startPath.length === 0
+    const isEndOffsetOnly = endPath.length === 0
 
     if (isStartOffsetOnly) {
       if (!parentNode)


### PR DESCRIPTION
## The bug

`resolve()` in `@prose-reader/cfi` returns the wrong DOM Range — or silently `null` — for range CFIs whose start/end local path is a single step, e.g. `epubcfi(/2[body01]/2[para01],/1:2,/3:3)`. This is exactly the shape `generate()` itself produces for any selection that crosses an inline element inside one block, so the library fails to round-trip its own output:

```ts
// <p id="p1">Hello <b>big</b> world</p>
const cfi = generate({
  start: { node: t0, offset: 2 }, // "Hello ", offset 2
  end: { node: t2, offset: 3 },   // " world", offset 3
})
// → epubcfi(/4[body01]/2[p1],/1:2,/3:3)

resolve(cfi, document).node.toString()
// → " world"        (expected "llo big wo")
```

And when the character offset exceeds the parent's child count, `setStart`/`setEnd` throw an `IndexSizeError` that the outer try/catch converts into a silent `node: null` — the highlight simply vanishes:

```ts
// <p id="p5">abcdefghij<i>X</i>klmnopqrst</p>, select across the <i>
resolve(generatedCfi, document).node // → null
```

Downstream, `core`'s `generateCfiFromRange` produces this CFI shape for user selections, so annotations/highlights crossing a `<b>`/`<i>`/`<span>` either land on the wrong text or fail to resolve.

## Root cause

In `resolveRange` (`packages/cfi/src/resolve.ts`), the predicate deciding whether a local path is "offset-only" was:

```ts
startPath.length === 0 ||
  (startPath.length === 1 && typeof startPath[0]?.offset === "number")
```

A genuine single-step path like `/1:2` (`{ index: 1, offset: 2 }`) matches the second clause, so the resolver used the **parent element** as the range container and the character offset as a child index, instead of descending into child node 1.

The second clause is also unreachable for its intended purpose: offset-only local paths (`,:5`) are attached to the parent path during parsing (`attachOffsetToParent` in `parse.ts` clones the parent path and puts the offset on its last part), and `parsePart` only ever creates parts from `/` steps — so a surviving non-empty path always carries real steps.

## The fix

Tighten the predicate to `startPath.length === 0` / `endPath.length === 0`, so any non-empty local path is traversed relative to the parent. Two-line change in `resolveRange`, no public surface change.

## Verification

Added three regression tests to `packages/cfi/src/resolve.range.test.ts`:

- single-step start/end paths resolve to the parent's child text nodes (failed before: resolved to the parent with wrong offsets),
- a `generate()` → `resolve()` round trip across an inline element (failed before: `null`),
- an offset-only range attached to a text-node parent (`epubcfi(.../1,:2,:5)`) still resolves (guards the preserved branch; passed before and after).

Gates: biome format/lint clean, `npm run build` + `npm run tsc` clean, and all 15 package test targets pass (`lerna run test --ignore prose-reader-tests`; cfi: 106 passed / 2 skipped). The `apps/tests` Playwright suite could not run in this environment at baseline or after the fix (pinned browser binaries unavailable in the container), identically before and after the change.

Docs: no gitbook update needed — the fix restores the documented `resolve` behavior; no public surface or documented contract changed.

## Other findings (not addressed in this PR)

Confirmed by code reading or concrete traces during this hunt, left untouched to keep this PR narrow:

1. **enhancer-annotations**: deleting an annotation never removes its highlight from the page. In `SpineItemHighlights.ts:52-55` the only removal condition (`highlight.highlight.itemIndex !== this.spineItem.item.index`) can never be true because the stream is pre-filtered by that same index in `ReaderHighlights.ts:38-44`; the stale highlight stays painted, re-renders on every `layout()`, and stays tappable. The removal branch also does `this.highlights = this.highlights.splice(index, 1)` (`:64`), which would corrupt the list (assigns the *removed* elements) if it ever ran.
2. **core / settings**: three call sites pair `computedPageTurnDirection` with the **raw** `pageTurnMode` (`SpineItem.ts:228`, `locationResolver.ts:101` and `:176`). For `renditionFlow: "scrolled-continuous"` books, `computedPageTurnMode` is forced to `scrollable` while raw stays `controlled`, so `getSpineItemNumberOfPages`'s "vertical + scrollable → 1 page" rule never fires and page counts are inflated (a 5000px item in an 800px viewport reports 7 pages, all mapping to the same position).
3. **core / layout**: `shouldEnableSpreadModeForViewport` (`enhancers/layout/spreadMode.ts:29`) doesn't treat `renditionSpread: "both"` as spread-enabled in portrait orientation, though EPUB rendition:spread `both` means spreads in both orientations (the landscape helper in the same file already includes `both`).
4. **cfi / generate**: text-node steps are computed as `childNodes.indexOf(node) + 1` (`generate.ts:198`, `:340`), which yields an *even* (element-typed) step when an element precedes the text node — `<p><b>big</b> world</p>` generates `/2:2` for `" world"` instead of the spec's `/3:2`, which then resolves to the `<b>` element.
5. **cfi / parse**: the tokenizer drops `^` escapes inside bracket assertions and then splits assertion text on every comma (`parse.ts:144-153`, `:303-307`), corrupting text assertions containing commas; and a first bracket on a character-data step is misclassified as an ID assertion (`parse.ts:296-299`), which can hijack resolution to an unrelated element via `getElementById`.
6. **streamer**: `calibreFixHook.ts:27` runs strict XML parsing (`new XmlDocument`) on every `.xhtml` resource before any Calibre check; a single non-well-formed document (e.g. a bare `&` or `<br>`) throws, and the streamer converts it into an HTTP 500 — the chapter never renders. A try/catch pass-through would restore the hook's cosmetic-only contract.
7. **enhancer-search**: `search.ts:25` compares `node.nodeName === "head"` (never matches in HTML documents where `nodeName` is uppercase), so `<title>`/`<style>`/`<script>` text is searched and produces non-navigable results; the user query is also interpolated unescaped into a `RegExp` (`search.ts:61-67`) — quantifier queries like `who?` desynchronize range lengths (or throw), and patterns matching the empty string loop forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wpStPXXKaW2mkqs4cqfys

---
_Generated by [Claude Code](https://claude.ai/code/session_012wpStPXXKaW2mkqs4cqfys)_