### PR TITLE
Render avif images correctly

### DIFF
--- a/packages/cbz/src/panoramaSplitManifest.test.ts
+++ b/packages/cbz/src/panoramaSplitManifest.test.ts
@@ -112,6 +112,19 @@ describe("isPanoramaSplitSupportedArchiveRecord", () => {
       }),
     ).toBe(true)
   })
+
+  it("should accept avif image resource paths", () => {
+    expect(
+      isPanoramaSplitSupportedArchiveRecord({
+        ...fakeContent,
+        basename: "p002-003.avif",
+        dir: false,
+        encodingFormat: "image/avif",
+        size: 1,
+        uri: "p002-003.avif",
+      }),
+    ).toBe(true)
+  })
 })
 
 describe("panoramaSplit", () => {

--- a/packages/cbz/src/panoramaSplitManifest.ts
+++ b/packages/cbz/src/panoramaSplitManifest.ts
@@ -29,6 +29,7 @@ const supportedImageMediaTypes = new Set([
   `image/jpeg`,
   `image/png`,
   `image/webp`,
+  `image/avif`,
 ])
 
 export const isPanoramaSplitSupportedImage = (mimeType: string | undefined) => {

--- a/packages/core/src/enhancers/html/renderer/attachFrameSrc.ts
+++ b/packages/core/src/enhancers/html/renderer/attachFrameSrc.ts
@@ -11,7 +11,10 @@ import {
 import { Report } from "../../../report"
 import type { ReaderSettingsManager } from "../../../settings/ReaderSettingsManager"
 import type { ResourceHandler } from "../../../spineItem/resources/ResourceHandler"
-import { createHtmlPageFromResource } from "./createHtmlPageFromResource"
+import {
+  createHtmlPageFromResource,
+  IMAGE_MEDIA_TYPES_REQUIRING_TRANSFORM,
+} from "./createHtmlPageFromResource"
 
 /**
  * For these resources, we want to digest and wrap them into custom html pages.
@@ -26,13 +29,11 @@ const ITEM_EXTENSION_REQUIRES_TRANSFORM = [
   `.jpeg`,
   `.png`,
   `.webp`,
+  `.avif`,
 ]
 const ITEM_MEDIA_TYPE_REQUIRES_TRANSFORM = [
   `text/plain`,
-  `image/jpg`,
-  `image/jpeg`,
-  `image/png`,
-  `image/webp`,
+  ...IMAGE_MEDIA_TYPES_REQUIRING_TRANSFORM,
 ]
 
 export const revokeFrameObjectUrl = (

--- a/packages/core/src/enhancers/html/renderer/createHtmlPageFromResource.test.ts
+++ b/packages/core/src/enhancers/html/renderer/createHtmlPageFromResource.test.ts
@@ -43,3 +43,39 @@ test(`keeps generated image object URLs alive for cloned gallery frames`, async 
   )
   expect(html).not.toContain(`revokeObjectURL`)
 })
+
+test(`wraps avif images into a generated html page`, async () => {
+  const objectUrl = `blob:http://localhost/image-2`
+
+  vi.stubGlobal(`URL`, {
+    createObjectURL: vi.fn(() => objectUrl),
+  })
+  vi.stubGlobal(
+    `createImageBitmap`,
+    vi.fn(async () => ({
+      width: 800,
+      height: 1200,
+      close: vi.fn(),
+    })),
+  )
+
+  const item: Manifest[`spineItems`][number] = {
+    id: `page-1`,
+    index: 0,
+    href: `page-1.avif`,
+    mediaType: `image/avif`,
+    renditionLayout: `pre-paginated`,
+  }
+  const response = new Response(new Blob([`image`], { type: `image/avif` }), {
+    headers: { "Content-Type": `image/avif` },
+  })
+
+  const htmlBlob = await createHtmlPageFromResource(response, item)
+  const html = await htmlBlob.text()
+
+  expect(htmlBlob.type).toBe(`text/html`)
+  expect(html).toContain(`src="${objectUrl}"`)
+  expect(html).toContain(
+    `<meta name="viewport" content="width=800, height=1200">`,
+  )
+})

--- a/packages/core/src/enhancers/html/renderer/createHtmlPageFromResource.ts
+++ b/packages/core/src/enhancers/html/renderer/createHtmlPageFromResource.ts
@@ -2,6 +2,20 @@ import { detectMimeTypeFromName, parseContentType } from "@prose-reader/shared"
 import type { Manifest } from "../../.."
 
 /**
+ * Raster images we wrap into a generated html page (viewport metadata,
+ * sizing). Shared with the transform decision in `attachFrameSrc`: a type
+ * gated in only one of the two places would reach the frame as a raw image
+ * blob without viewport metadata and lay out incorrectly.
+ */
+export const IMAGE_MEDIA_TYPES_REQUIRING_TRANSFORM = [
+  `image/jpg`,
+  `image/jpeg`,
+  `image/png`,
+  `image/webp`,
+  `image/avif`,
+]
+
+/**
  * Document is application/xhtml+xml
  * @todo move this into a enhancer
  * @todo only keep a very basic default one which just put the resource as <media> inside html page
@@ -20,9 +34,7 @@ export const createHtmlPageFromResource = async (
     detectMimeTypeFromName(item.href)
 
   if (
-    [`image/jpg`, `image/jpeg`, `image/png`, `image/webp`].some(
-      (mime) => mime === contentType,
-    )
+    IMAGE_MEDIA_TYPES_REQUIRING_TRANSFORM.some((mime) => mime === contentType)
   ) {
     const blob = await resourceResponse.blob()
     const objectUrl = URL.createObjectURL(blob)


### PR DESCRIPTION
## Problem

Books whose pages are AVIF images did not render correctly. The shared MIME detector (`@prose-reader/shared`) already recognized `.avif`, so manifests and resource URLs were correct — but the core html renderer's raw-image allowlists omitted `image/avif`:

- `attachFrameSrc.ts` did not consider avif items as requiring a transform, and
- `createHtmlPageFromResource.ts` did not wrap avif responses into a generated html page.

Avif spine items therefore reached the frame as raw image blobs without the generated page's viewport metadata and sizing, breaking pre-paginated layout. The cbz panorama-split allowlist also omitted avif, so wide avif spreads were never split.

## Changes

- **`@prose-reader/core`**: extract a single `IMAGE_MEDIA_TYPES_REQUIRING_TRANSFORM` list shared between the transform decision (`attachFrameSrc`) and the transform itself (`createHtmlPageFromResource`) so the two lists can no longer drift, and add `image/avif` to it plus `.avif` to the extension fallback.
- **`@prose-reader/cbz`**: accept `image/avif` in the panorama split. The split only uses `createImageBitmap` to read dimensions and css-crops the original image in a generated xhtml — no re-encoding — so avif works wherever the browser renders it.
- Tests: avif html-page wrap in `createHtmlPageFromResource.test.ts`, avif acceptance in `panoramaSplitManifest.test.ts`.

No public surface change (the new export is internal to the core renderer), so no gitbook update is needed — checked, the docs don't enumerate supported raster formats.

## Verification

- `packages/core`: 29 test files, 187 tests pass; `tsc` clean
- `packages/cbz`: 5 test files, 37 tests pass; `tsc` clean
- biome check clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHhvN3mU7hYzTDheJK571V

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHhvN3mU7hYzTDheJK571V)_