### PR TITLE
Model typed titles and identified collections

### DIFF
--- a/apps/front/src/App.tsx
+++ b/apps/front/src/App.tsx
@@ -1,5 +1,4 @@
-import { Heading, Image, Link, Text } from "@chakra-ui/react"
-import { Box } from "@chakra-ui/react"
+import { Box, Heading, Image, Link, Text } from "@chakra-ui/react"
 import { FaDiscord, FaGithub } from "react-icons/fa"
 import { LuExternalLink } from "react-icons/lu"
 import headerLogo from "./assets/header_logo.svg"

--- a/apps/front/src/components/ui/color-mode.tsx
+++ b/apps/front/src/components/ui/color-mode.tsx
@@ -2,8 +2,8 @@
 
 import type { IconButtonProps } from "@chakra-ui/react"
 import { ClientOnly, IconButton, Skeleton } from "@chakra-ui/react"
-import { ThemeProvider, useTheme } from "next-themes"
 import type { ThemeProviderProps } from "next-themes"
+import { ThemeProvider, useTheme } from "next-themes"
 import { forwardRef } from "react"
 import { LuMoon, LuSun } from "react-icons/lu"
 

--- a/apps/front/src/sections/DeveloperFriendlySection.tsx
+++ b/apps/front/src/sections/DeveloperFriendlySection.tsx
@@ -1,7 +1,6 @@
 import { Box, Button, Icon, Link, Text } from "@chakra-ui/react"
 import { FaExternalLinkAlt } from "react-icons/fa"
-import { SiTypescript } from "react-icons/si"
-import { SiReactiveresume } from "react-icons/si"
+import { SiReactiveresume, SiTypescript } from "react-icons/si"
 import { Section, SectionTitle } from "./Section"
 
 export const DeveloperFriendlySection = () => {

--- a/apps/front/src/sections/ReadAnythingSection.tsx
+++ b/apps/front/src/sections/ReadAnythingSection.tsx
@@ -2,9 +2,9 @@ import { Box, Button, Icon, Image, Link, Text } from "@chakra-ui/react"
 import { FaCloud, FaExternalLinkAlt } from "react-icons/fa"
 import { FaFilePdf } from "react-icons/fa6"
 import { TbFileTypeZip } from "react-icons/tb"
+import formatA from "../assets/demo.prose-reader.com_books.png"
 import formatB from "../assets/demo.prose-reader.com_books (4).png"
 import formatC from "../assets/demo.prose-reader.com_books (5).png"
-import formatA from "../assets/demo.prose-reader.com_books.png"
 import { Section, SectionTitle } from "./Section"
 
 const images = [

--- a/apps/metadata-fetcher-api/src/createApp.test.ts
+++ b/apps/metadata-fetcher-api/src/createApp.test.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises"
+import { mainTitle } from "@prose-reader/archive-reader"
 import {
   type FetchedMetadata,
   type FetchMetadataInput,
@@ -41,12 +42,12 @@ const duneProvider: MetadataProvider = {
         url: "https://example.com/works/OL893415W",
         raw: { note: "verbatim" },
         metadata: {
-          title: "Dune",
+          titles: [{ value: "Dune" }],
           publication: { edition: { publisher: "Chilton Books" } },
           contributors: [{ name: "Frank Herbert", roles: ["author"] }],
         },
       },
-      { metadata: { title: "Neuromancer" } },
+      { metadata: { titles: [{ value: "Neuromancer" }] } },
     ]),
 }
 
@@ -190,7 +191,7 @@ describe("metadata-fetcher-api", () => {
       providerId: "stub",
       accepted: true,
       url: "https://example.com/works/OL893415W",
-      metadata: { title: "Dune" },
+      metadata: { titles: [{ value: "Dune" }] },
     })
     expect(fetched.sources.stub?.provider.name).toBe("Stub Catalog")
   })
@@ -247,7 +248,7 @@ describe("metadata-fetcher-api", () => {
     })
 
     expect(response.status).toBe(200)
-    expect((await readFetched(response)).matches[0]?.metadata.title).toBe(
+    expect(mainTitle((await readFetched(response)).matches[0]?.metadata)).toBe(
       "Dune",
     )
   })
@@ -501,7 +502,7 @@ describe("metadata-fetcher-api failures", () => {
       const fetched = await readFetched(response)
 
       expect(response.status).toBe(200)
-      expect(fetched.matches[0]?.metadata.title).toBe("Dune")
+      expect(mainTitle(fetched.matches[0]?.metadata)).toBe("Dune")
     } finally {
       await api.close()
     }

--- a/apps/metadata-fetcher-api/src/playground/playground.js
+++ b/apps/metadata-fetcher-api/src/playground/playground.js
@@ -66,7 +66,9 @@ const renderMatch = (match) => {
     card.append(cover)
   }
 
-  card.append(el("h2", null, metadata.title ?? "(untitled)"))
+  const titles = metadata.titles ?? []
+
+  card.append(el("h2", null, titles[0]?.value ?? "(untitled)"))
 
   const meta = el("p", "meta")
   const verdict = match.accepted ? "accepted" : "rejected"

--- a/gitbook/archive-reader/resolved-metadata.md
+++ b/gitbook/archive-reader/resolved-metadata.md
@@ -16,6 +16,14 @@
 /** "derived" = declared or properly computed; "assumed" = a best-effort convention */
 type ResolvedConfidence = "derived" | "assumed"
 
+type Collection = {
+  name?: string
+  /** EPUB `dcterms:identifier` refinement of the collection, catalog series ids */
+  identifiers?: { value: string; scheme: string }[]
+  position?: number
+  total?: number
+}
+
 type ResolvedCover = {
   /** container-relative uri (rebase like reading-order uris), or an absolute url from a remote catalog */
   uri: string
@@ -24,7 +32,15 @@ type ResolvedCover = {
 }
 
 type ResolvedMetadata = {
+  /** the main title: EPUB 3 makes it the first `dc:title` in document order */
   title?: string
+  /** every stated title, in document order — a subtitle is an entry, never appended to `title` */
+  titles?: {
+    value: string
+    type?: "main" | "subtitle" | "short" | "collection" | "edition" | "extended" | (string & {})
+    displaySeq?: number
+    sortAs?: string
+  }[]
   /** the cover image; resolved against the container, so `resolveArchive` only */
   cover?: ResolvedCover
   description?: string
@@ -58,9 +74,10 @@ type ResolvedMetadata = {
             (string & {})
     unique?: true
   }[]
+  /** a collection is identified by a name, by identifiers, or by both — sources differ */
   belongsTo?: {
-    series?: { name: string; position?: number; total?: number }[]
-    collection?: { name: string; position?: number; total?: number }[]
+    series?: Collection[]
+    collection?: Collection[]
   }
   /** open-world channel: every OPF <meta>, verbatim */
   properties?: { property?: string; refines?: string; name?: string; content?: string; value?: string }[]
@@ -137,7 +154,7 @@ These mirror the compile-enforced tables shipped next to each resolver — the l
 | `Manga` | `readingDirection` | `YesAndRightToLeft` → `rtl`; also `comic.manga` |
 | `PageCount` | `numberOfPages` | declared count; a page-like container without it is counted at the archive level |
 | `GTIN` | `identifiers` | scheme `GTIN`; ISBN-shaped values remain searchable as ISBNs by metadata-fetcher |
-| `Series`, `Number`, `Count` | `belongsTo.series` | name / position / total |
+| `Series`, `Number`, `Count` | `belongsTo.series` | name / position / total; `Number` or `Count` without a `Series` still states this issue's place, so the entry is kept without a name |
 | `SeriesGroup` | `belongsTo.collection` | comma-split |
 | `AlternateSeries`, `AlternateNumber`, `AlternateCount` | `comic.alternateSeries` | |
 | `StoryArc`, `StoryArcNumber` | `comic.storyArcs` | comma-split, zipped positionally |
@@ -159,7 +176,8 @@ These mirror the compile-enforced tables shipped next to each resolver — the l
 
 | OPF field | Home | Notes |
 | --- | --- | --- |
-| `dc:title` | `title` | first non-empty |
+| `dc:title` | `title`, `titles` | every non-empty one, in document order; the first is `title` — EPUB 3 makes it the main title whatever a later `title-type` claims |
+| `title-type`, `display-seq`, `file-as` refinements | `titles[].type` / `displaySeq` / `sortAs` | `type` lowercased, unknown values verbatim |
 | `dc:description` | `description` | |
 | `dc:publisher` | `publication.edition.publisher` | |
 | `dc:rights` | `rights` | |
@@ -173,6 +191,7 @@ These mirror the compile-enforced tables shipped next to each resolver — the l
 | `rendition:flow` meta | `renditionFlow` | validated |
 | `rendition:spread` meta | `renditionSpread` | validated |
 | `belongs-to-collection` metas | `belongsTo` | `collection-type` `series` → series (with `group-position`), else collection |
+| `dcterms:identifier` refinement of a collection | `belongsTo.*[].identifiers` | scheme from an `identifier-type` refinement of that identifier, else inferred |
 | `calibre:series` / `calibre:series_index` | `belongsTo.series` | fallback when no EPUB 3 series meta |
 | every `<meta>` | `properties` | verbatim, the open-world channel |
 | manifest items, spine itemrefs | `readingOrder` | structural |

--- a/gitbook/archive-reader/resolved-metadata.md
+++ b/gitbook/archive-reader/resolved-metadata.md
@@ -32,12 +32,10 @@ type ResolvedCover = {
 }
 
 type ResolvedMetadata = {
-  /** the main title: EPUB 3 makes it the first `dc:title` in document order */
-  title?: string
-  /** every stated title, in document order — a subtitle is an entry, never appended to `title` */
+  /** every stated title, in document order — the first is the main title (`mainTitle(metadata)`) */
   titles?: {
     value: string
-    type?: "main" | "subtitle" | "short" | "collection" | "edition" | "extended" | (string & {})
+    type?: "main" | "subtitle" | "short" | "collection" | "edition" | "expanded" | (string & {})
     displaySeq?: number
     sortAs?: string
   }[]
@@ -119,7 +117,7 @@ When several sources are present, `resolveMetadata` merges field-wise:
 
 | Field | Rule |
 | --- | --- |
-| descriptive fields (`title`, `titles`, `description`, `languages`, `subjects`, `contributors`, `belongsTo`) | **OPF wins over ComicInfo** — the package document is the publication's own metadata; the sidecar fills gaps |
+| descriptive fields (`titles`, `description`, `languages`, `subjects`, `contributors`, `belongsTo`) | **OPF wins over ComicInfo** — the package document is the publication's own metadata; the sidecar fills gaps |
 | `publication.edition` details (`date`, `publisher`, `imprint`) | merged field-wise, **OPF wins over ComicInfo** and the sidecar fills gaps |
 | `readingDirection` | **ComicInfo wins over OPF** (`Manga` beats `page-progression-direction`) — deliberate, preserving the historical pipeline behavior |
 | `renditionLayout` | **OPF explicit → Apple → Kobo**, first defined wins; the [`layoutScan`](README.md#resolving-a-publication) promotion applies on top, inside the resolver |
@@ -136,7 +134,7 @@ These mirror the compile-enforced tables shipped next to each resolver — the l
 
 | ComicInfo field | Home | Notes |
 | --- | --- | --- |
-| `Title` | `title`, `titles` | trimmed; the sidecar states one title, so `titles` has the single entry |
+| `Title` | `titles` | trimmed; the sidecar states one title, so `titles` has the single entry |
 | `Summary` | `description` | |
 | `Publisher` | `publication.edition.publisher` | |
 | `Imprint` | `publication.edition.imprint` | |
@@ -176,7 +174,7 @@ These mirror the compile-enforced tables shipped next to each resolver — the l
 
 | OPF field | Home | Notes |
 | --- | --- | --- |
-| `dc:title` | `title`, `titles` | every non-empty one, in document order; the first is `title` — EPUB 3 makes it the main title whatever a later `title-type` claims |
+| `dc:title` | `titles` | every non-empty one, in document order; EPUB 3 makes the first the main title whatever a later `title-type` claims — `mainTitle(metadata)` reads it |
 | `title-type`, `display-seq`, `file-as` refinements | `titles[].type` / `displaySeq` / `sortAs` | `type` lowercased, unknown values verbatim |
 | `dc:description` | `description` | |
 | `dc:publisher` | `publication.edition.publisher` | |

--- a/gitbook/archive-reader/resolved-metadata.md
+++ b/gitbook/archive-reader/resolved-metadata.md
@@ -119,7 +119,7 @@ When several sources are present, `resolveMetadata` merges field-wise:
 
 | Field | Rule |
 | --- | --- |
-| descriptive fields (`title`, `description`, `languages`, `subjects`, `contributors`, `belongsTo`) | **OPF wins over ComicInfo** — the package document is the publication's own metadata; the sidecar fills gaps |
+| descriptive fields (`title`, `titles`, `description`, `languages`, `subjects`, `contributors`, `belongsTo`) | **OPF wins over ComicInfo** — the package document is the publication's own metadata; the sidecar fills gaps |
 | `publication.edition` details (`date`, `publisher`, `imprint`) | merged field-wise, **OPF wins over ComicInfo** and the sidecar fills gaps |
 | `readingDirection` | **ComicInfo wins over OPF** (`Manga` beats `page-progression-direction`) — deliberate, preserving the historical pipeline behavior |
 | `renditionLayout` | **OPF explicit → Apple → Kobo**, first defined wins; the [`layoutScan`](README.md#resolving-a-publication) promotion applies on top, inside the resolver |
@@ -136,7 +136,7 @@ These mirror the compile-enforced tables shipped next to each resolver — the l
 
 | ComicInfo field | Home | Notes |
 | --- | --- | --- |
-| `Title` | `title` | trimmed |
+| `Title` | `title`, `titles` | trimmed; the sidecar states one title, so `titles` has the single entry |
 | `Summary` | `description` | |
 | `Publisher` | `publication.edition.publisher` | |
 | `Imprint` | `publication.edition.imprint` | |

--- a/gitbook/metadata-fetcher/README.md
+++ b/gitbook/metadata-fetcher/README.md
@@ -321,7 +321,7 @@ Each request makes at most three total attempts. Network failures and HTTP `500`
 | Google Books | Resolved | |
 | --- | --- | --- |
 | `id` | `identifiers` | scheme `GoogleBooks`; also `id` on the match |
-| `volumeInfo.title` + `subtitle` | `title` | joined with `:`, then `seriesInfo.bookDisplayNumber` is appended as `Vol …` only when no volume marker is already present |
+| `volumeInfo.title` + `subtitle` | `titles` | joined with `:`, then `seriesInfo.bookDisplayNumber` is appended as `Vol …` only when no volume marker is already present |
 | `authors` | `contributors` | role `author` |
 | `publisher`, `publishedDate` | `publication.edition` | partial dates retain the available year/month/day |
 | `description` | `description` | Google may provide simple HTML formatting |
@@ -357,7 +357,7 @@ const provider = createOpenLibraryProvider({
 
 | Open Library | Resolved | |
 | --- | --- | --- |
-| `title` + `subtitle` | `title` | joined (`Dune: a novel`) — `ResolvedMetadata` has one title field, and an OPF `dc:title` normally carries the subtitle too |
+| `title` + `subtitle` | `titles` | joined (`Dune: a novel`) — `ResolvedMetadata` has one title field, and an OPF `dc:title` normally carries the subtitle too |
 | `author_name` | `contributors` | role `author` |
 | `first_publish_year` | `publication.original.date.year` | |
 | `language` | `languages` | MARC 21 → BCP 47 (`eng` → `en`); unknown codes pass through, `und`/`mul`/`zxx` are dropped |

--- a/packages/archive-reader/src/index.ts
+++ b/packages/archive-reader/src/index.ts
@@ -125,10 +125,13 @@ export type {
   ResolvedKoboMetadata,
   ResolvedMetadata,
   ResolvedMetadataHome,
+  ResolvedMetadataHomes,
   ResolvedMetadataIdentifier,
   ResolvedProperty,
   ResolvedPublication,
   ResolvedPublicationInfo,
+  ResolvedTitle,
+  ResolvedTitleType,
 } from "./types/resolvedMetadata.ts"
 export { normalizeGtin } from "./utils/normalizeGtin.ts"
 export { normalizeIsbn } from "./utils/normalizeIsbn.ts"

--- a/packages/archive-reader/src/index.ts
+++ b/packages/archive-reader/src/index.ts
@@ -133,6 +133,7 @@ export type {
   ResolvedTitle,
   ResolvedTitleType,
 } from "./types/resolvedMetadata.ts"
+export { mainTitle } from "./utils/mainTitle.ts"
 export { normalizeGtin } from "./utils/normalizeGtin.ts"
 export { normalizeIsbn } from "./utils/normalizeIsbn.ts"
 export { parseW3cDtfDate } from "./utils/parseW3cDtfDate.ts"

--- a/packages/archive-reader/src/metadata/comicInfo/resolve.test.ts
+++ b/packages/archive-reader/src/metadata/comicInfo/resolve.test.ts
@@ -274,6 +274,16 @@ describe("resolveComicInfo", () => {
     })
   })
 
+  it("keeps Number and Count stated without a Series", () => {
+    const parsed = parseComicInfo(
+      comicInfoWrap("<Number>1</Number><Count>12</Count>"),
+    )
+
+    expect(resolveComicInfo(parsed).belongsTo).toEqual({
+      series: [{ position: 1, total: 12 }],
+    })
+  })
+
   it("maps SeriesGroup entries into belongsTo.collection", () => {
     const parsed = parseComicInfo(
       comicInfoWrap("<SeriesGroup>Family A, Family B</SeriesGroup>"),

--- a/packages/archive-reader/src/metadata/comicInfo/resolve.test.ts
+++ b/packages/archive-reader/src/metadata/comicInfo/resolve.test.ts
@@ -90,7 +90,7 @@ describe("resolveComicInfo", () => {
     )
 
     expect(resolveComicInfo(parsed)).toMatchObject({
-      title: "Sample Story",
+      titles: [{ value: "Sample Story" }],
       publication: { edition: { publisher: "Acme" } },
     })
   })
@@ -100,7 +100,7 @@ describe("resolveComicInfo", () => {
       comicInfoWrap("<Series>Sample Series</Series><Number>1</Number>"),
     )
 
-    expect(resolveComicInfo(parsed).title).toBeUndefined()
+    expect(resolveComicInfo(parsed).titles).toBeUndefined()
   })
 
   it("splits Writer on commas into author contributors", () => {
@@ -278,7 +278,6 @@ describe("resolveComicInfo", () => {
     const parsed = parseComicInfo(comicInfoWrap("<Title>Sample Issue</Title>"))
     const resolved = resolveComicInfo(parsed)
 
-    expect(resolved.title).toBe("Sample Issue")
     expect(resolved.titles).toEqual([{ value: "Sample Issue" }])
   })
 
@@ -405,7 +404,6 @@ describe("resolveComicInfo", () => {
     expect(resolveComicInfo(parsed)).toEqual({
       identifiers: [{ value: "978-3-16-148410-0", scheme: "GTIN" }],
       readingDirection: "rtl",
-      title: "Sample Story",
       titles: [{ value: "Sample Story" }],
       contributors: [
         { name: "Alice", roles: ["author"] },

--- a/packages/archive-reader/src/metadata/comicInfo/resolve.test.ts
+++ b/packages/archive-reader/src/metadata/comicInfo/resolve.test.ts
@@ -274,6 +274,14 @@ describe("resolveComicInfo", () => {
     })
   })
 
+  it("lists the single Title it states in titles too", () => {
+    const parsed = parseComicInfo(comicInfoWrap("<Title>Sample Issue</Title>"))
+    const resolved = resolveComicInfo(parsed)
+
+    expect(resolved.title).toBe("Sample Issue")
+    expect(resolved.titles).toEqual([{ value: "Sample Issue" }])
+  })
+
   it("keeps Number and Count stated without a Series", () => {
     const parsed = parseComicInfo(
       comicInfoWrap("<Number>1</Number><Count>12</Count>"),
@@ -398,6 +406,7 @@ describe("resolveComicInfo", () => {
       identifiers: [{ value: "978-3-16-148410-0", scheme: "GTIN" }],
       readingDirection: "rtl",
       title: "Sample Story",
+      titles: [{ value: "Sample Story" }],
       contributors: [
         { name: "Alice", roles: ["author"] },
         { name: "Bob", roles: ["author"] },

--- a/packages/archive-reader/src/metadata/comicInfo/resolve.ts
+++ b/packages/archive-reader/src/metadata/comicInfo/resolve.ts
@@ -55,7 +55,7 @@ export const comicInfoMetadataHomes = {
   Summary: "description",
   Tags: "subjects",
   Teams: "comic.teams",
-  Title: ["title", "titles"],
+  Title: "titles",
   Translator: "contributors",
   Volume: "comic.volume",
   Web: "comic.web",
@@ -318,7 +318,6 @@ export const resolveComicInfo = (info: ComicInfo): ResolvedMetadata => {
   const title = trimToUndefined(info.Title)
 
   return omitUndefined({
-    title,
     titles: title !== undefined ? [{ value: title }] : undefined,
     description: trimToUndefined(info.Summary),
     publication:

--- a/packages/archive-reader/src/metadata/comicInfo/resolve.ts
+++ b/packages/archive-reader/src/metadata/comicInfo/resolve.ts
@@ -183,17 +183,21 @@ const contributorsFromComicInfo = (info: ComicInfo): ResolvedContributor[] => {
   return [...byName.values()]
 }
 
+/**
+ * `Number` and `Count` are facts about this issue's place in its series,
+ * which a sidecar can state without naming the series — so a nameless entry
+ * is still emitted rather than dropping what the file says.
+ */
 const seriesFromComicInfo = (
   info: ComicInfo,
 ): ResolvedCollection | undefined => {
-  const name = trimToUndefined(info.Series)
-  if (name === undefined) return undefined
-
-  return omitUndefined({
-    name,
+  const series = omitUndefined({
+    name: trimToUndefined(info.Series),
     position: parseDecimal(info.Number),
     total: parseNonNegativeInt(info.Count),
   })
+
+  return Object.keys(series).length > 0 ? series : undefined
 }
 
 const alternateSeriesFromComicInfo = (

--- a/packages/archive-reader/src/metadata/comicInfo/resolve.ts
+++ b/packages/archive-reader/src/metadata/comicInfo/resolve.ts
@@ -4,7 +4,7 @@ import type {
   ResolvedContributorRole,
   ResolvedDate,
   ResolvedMetadata,
-  ResolvedMetadataHome,
+  ResolvedMetadataHomes,
   ResolvedMetadataIdentifier,
 } from "../../types/resolvedMetadata.ts"
 import { omitUndefined } from "../../utils/omitUndefined.ts"
@@ -55,13 +55,13 @@ export const comicInfoMetadataHomes = {
   Summary: "description",
   Tags: "subjects",
   Teams: "comic.teams",
-  Title: "title",
+  Title: ["title", "titles"],
   Translator: "contributors",
   Volume: "comic.volume",
   Web: "comic.web",
   Writer: "contributors",
   Year: "publication.edition.date",
-} as const satisfies Record<ComicInfoKnownField, ResolvedMetadataHome>
+} as const satisfies Record<ComicInfoKnownField, ResolvedMetadataHomes>
 
 const readingDirection = (info: ComicInfo): "ltr" | "rtl" | undefined => {
   switch (info.Manga) {
@@ -315,8 +315,11 @@ export const resolveComicInfo = (info: ComicInfo): ResolvedMetadata => {
     imprint: trimToUndefined(info.Imprint),
   })
 
+  const title = trimToUndefined(info.Title)
+
   return omitUndefined({
-    title: trimToUndefined(info.Title),
+    title,
+    titles: title !== undefined ? [{ value: title }] : undefined,
     description: trimToUndefined(info.Summary),
     publication:
       edition.date !== undefined ||

--- a/packages/archive-reader/src/metadata/opf/parse.test.ts
+++ b/packages/archive-reader/src/metadata/opf/parse.test.ts
@@ -11,7 +11,7 @@ const opfWrap = (body: string) =>
 const noPackageMetadata: Pick<
   OpfMetadata,
   | "identifiers"
-  | "title"
+  | "titles"
   | "creators"
   | "contributors"
   | "publisher"
@@ -30,7 +30,7 @@ const noPackageMetadata: Pick<
   | "metas"
 > = {
   identifiers: [],
-  title: undefined,
+  titles: [],
   creators: [],
   contributors: [],
   publisher: undefined,
@@ -165,7 +165,7 @@ describe("parseOpf", () => {
       manifestItems: [{ id: "x", href: "x.xhtml" }],
       spineRows: [{ idref: "x", id: "x", href: "x.xhtml" }],
       identifiers: [{ scheme: "ISBN", value: "978-3-16-148410-0" }],
-      title: "My Book",
+      titles: [{ value: "My Book" }],
       renditionLayoutMeta: "pre-paginated",
       renditionFlowMeta: "paginated",
       renditionSpreadMeta: "both",
@@ -177,6 +177,23 @@ describe("parseOpf", () => {
         { property: "rendition:spread", value: "both" },
       ],
     })
+  })
+
+  it("keeps every dc:title in document order with the ids refinements target", () => {
+    const xml = opfWrap(
+      `<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">` +
+        `<dc:title id="t1">Dune</dc:title>` +
+        `<dc:title id="t2">  A Novel  </dc:title>` +
+        `<dc:title>   </dc:title>` +
+        `<dc:title>Untagged</dc:title>` +
+        `</metadata>`,
+    )
+
+    expect(parseOpf(xml).titles).toEqual([
+      { value: "Dune", id: "t1" },
+      { value: "A Novel", id: "t2" },
+      { value: "Untagged" },
+    ])
   })
 
   it("keeps every identifier and marks the package unique identifier", () => {
@@ -312,7 +329,7 @@ describe("parseOpf", () => {
           mediaType: "application/xhtml+xml",
         },
       ],
-      title: "Prefixed roots",
+      titles: [{ value: "Prefixed roots" }],
       renditionLayoutMeta: "reflowable",
       spineTocIdref: "ncx",
       guide: [{ href: "c.xhtml", title: "Cover", type: "cover" }],

--- a/packages/archive-reader/src/metadata/opf/parse.ts
+++ b/packages/archive-reader/src/metadata/opf/parse.ts
@@ -19,6 +19,12 @@ export type OpfIdentifier = {
   readonly unique?: true
 }
 
+export type OpfTitle = {
+  readonly value: string
+  /** Element `id`, which `meta refines` entries target. */
+  readonly id?: string
+}
+
 export type OpfSpineRow = {
   readonly idref: string
   readonly id: string
@@ -146,6 +152,26 @@ const identifiersFromMetadata = (
   })
 
   return identifiers
+}
+
+const titlesFromMetadata = (metadataEl: XmlElement): OpfTitle[] => {
+  const titles: OpfTitle[] = []
+
+  metadataEl.eachChild((child) => {
+    if (elementLocalName(child.name).toLowerCase() !== "title") return
+
+    const value = child.val.trim()
+    if (value.length === 0) return
+
+    const id = child.attr.id?.trim()
+
+    titles.push({
+      value,
+      ...(id !== undefined && id.length > 0 ? { id } : {}),
+    })
+  })
+
+  return titles
 }
 
 const firstTextByLocalName = (
@@ -453,7 +479,12 @@ export type OpfMetadata = {
   readonly spineRows: ReadonlyArray<OpfSpineRow>
   readonly spineTocIdref: string | undefined
   readonly identifiers: ReadonlyArray<OpfIdentifier>
-  readonly title: string | undefined
+  /**
+   * Every non-empty `dc:title`, in document order — the first is the main
+   * title per EPUB 3. Ids are retained so `meta refines` entries
+   * (`title-type`, `display-seq`, `file-as`) can be attached to their title.
+   */
+  readonly titles: ReadonlyArray<OpfTitle>
   /** `dc:creator` values, in document order, trimmed; empty when none. */
   readonly creators: ReadonlyArray<string>
   /**
@@ -548,7 +579,7 @@ export const parseOpf = (opfXml: string): OpfMetadata => {
       ? spineTocRaw.trim()
       : undefined
 
-  let title: string | undefined
+  let titles: OpfTitle[] = []
   let publisher: string | undefined
   let description: string | undefined
   let rights: string | undefined
@@ -564,7 +595,7 @@ export const parseOpf = (opfXml: string): OpfMetadata => {
   const identifiers: OpfIdentifier[] = []
 
   if (metadataEl !== undefined) {
-    title = firstTextByLocalName(metadataEl, "title")
+    titles = titlesFromMetadata(metadataEl)
     publisher = firstTextByLocalName(metadataEl, "publisher")
     description = firstTextByLocalName(metadataEl, "description")
     rights = firstTextByLocalName(metadataEl, "rights")
@@ -593,7 +624,7 @@ export const parseOpf = (opfXml: string): OpfMetadata => {
     spineRows,
     spineTocIdref,
     identifiers,
-    title,
+    titles,
     creators,
     contributors,
     publisher,

--- a/packages/archive-reader/src/metadata/opf/resolve.test.ts
+++ b/packages/archive-reader/src/metadata/opf/resolve.test.ts
@@ -8,7 +8,7 @@ const emptyOpf = (): OpfMetadata => ({
   spineRows: [],
   spineTocIdref: undefined,
   identifiers: [],
-  title: undefined,
+  titles: [],
   creators: [],
   contributors: [],
   publisher: undefined,
@@ -253,7 +253,7 @@ describe("resolveOpf", () => {
     expect(
       resolveOpf({
         ...emptyOpf(),
-        title: "Norwegian Wood",
+        titles: [{ value: "Norwegian Wood" }],
         publisher: "Vintage",
         description: "A nostalgic story.",
         rights: "Copyright 2024",
@@ -262,6 +262,7 @@ describe("resolveOpf", () => {
       }),
     ).toEqual({
       title: "Norwegian Wood",
+      titles: [{ value: "Norwegian Wood" }],
       publication: { edition: { publisher: "Vintage" } },
       description: "A nostalgic story.",
       rights: "Copyright 2024",
@@ -371,6 +372,50 @@ describe("resolveOpf", () => {
     ).toBe(undefined)
   })
 
+  it("keeps every title with the typing its refinements state", () => {
+    const resolved = resolveOpf({
+      ...emptyOpf(),
+      titles: [
+        { value: "Dune", id: "t1" },
+        { value: "A Novel", id: "t2" },
+        { value: "Herbert, Dune", id: "t3" },
+      ],
+      metas: [
+        { property: "title-type", refines: "#t1", value: "main" },
+        { property: "title-type", refines: "#t2", value: "Subtitle" },
+        { property: "display-seq", refines: "#t2", value: "2" },
+        { property: "title-type", refines: "#t3", value: "short" },
+        { property: "file-as", refines: "#t3", value: "Dune" },
+      ],
+    })
+
+    expect(resolved.title).toBe("Dune")
+    expect(resolved.titles).toEqual([
+      { value: "Dune", type: "main" },
+      { value: "A Novel", type: "subtitle", displaySeq: 2 },
+      { value: "Herbert, Dune", type: "short", sortAs: "Dune" },
+    ])
+  })
+
+  // EPUB 3: reading systems must take the first dc:title in document order as
+  // the main title, whatever a later title-type says.
+  it("keeps the first title as the main one when a later one claims main", () => {
+    const resolved = resolveOpf({
+      ...emptyOpf(),
+      titles: [
+        { value: "First", id: "t1" },
+        { value: "Second", id: "t2" },
+      ],
+      metas: [{ property: "title-type", refines: "#t2", value: "main" }],
+    })
+
+    expect(resolved.title).toBe("First")
+    expect(resolved.titles).toEqual([
+      { value: "First" },
+      { value: "Second", type: "main" },
+    ])
+  })
+
   it("maps belongs-to-collection metas into belongsTo, series versus collection", () => {
     expect(
       resolveOpf({
@@ -386,6 +431,58 @@ describe("resolveOpf", () => {
       series: [{ name: "My Series", position: 3 }],
       collection: [{ name: "My Set" }],
     })
+  })
+
+  it("identifies a collection from its dcterms:identifier refinement", () => {
+    expect(
+      resolveOpf({
+        ...emptyOpf(),
+        metas: [
+          { property: "belongs-to-collection", id: "s1", value: "My Series" },
+          { property: "collection-type", refines: "#s1", value: "series" },
+          {
+            property: "dcterms:identifier",
+            refines: "#s1",
+            id: "sid",
+            value: "9780441013593",
+          },
+          {
+            property: "identifier-type",
+            refines: "#sid",
+            scheme: "onix:codelist5",
+            value: "15",
+          },
+        ],
+      }).belongsTo,
+    ).toEqual({
+      series: [
+        {
+          name: "My Series",
+          identifiers: [{ value: "9780441013593", scheme: "ISBN" }],
+        },
+      ],
+    })
+  })
+
+  it("infers the scheme of a collection identifier stating no type", () => {
+    expect(
+      resolveOpf({
+        ...emptyOpf(),
+        metas: [
+          { property: "belongs-to-collection", id: "c1", value: "My Set" },
+          {
+            property: "dcterms:identifier",
+            refines: "#c1",
+            value: "https://example.com/sets/1",
+          },
+        ],
+      }).belongsTo?.collection,
+    ).toEqual([
+      {
+        name: "My Set",
+        identifiers: [{ value: "https://example.com/sets/1", scheme: "URL" }],
+      },
+    ])
   })
 
   it("falls back to calibre series metas when no EPUB 3 series exists", () => {

--- a/packages/archive-reader/src/metadata/opf/resolve.test.ts
+++ b/packages/archive-reader/src/metadata/opf/resolve.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { mainTitle } from "../../utils/mainTitle"
 import type { OpfMetadata } from "./parse"
 import { resolveOpf } from "./resolve"
 
@@ -261,7 +262,6 @@ describe("resolveOpf", () => {
         subjects: ["Fiction", "Modern Japanese Literature"],
       }),
     ).toEqual({
-      title: "Norwegian Wood",
       titles: [{ value: "Norwegian Wood" }],
       publication: { edition: { publisher: "Vintage" } },
       description: "A nostalgic story.",
@@ -389,7 +389,7 @@ describe("resolveOpf", () => {
       ],
     })
 
-    expect(resolved.title).toBe("Dune")
+    expect(mainTitle(resolved)).toBe("Dune")
     expect(resolved.titles).toEqual([
       { value: "Dune", type: "main" },
       { value: "A Novel", type: "subtitle", displaySeq: 2 },
@@ -409,7 +409,7 @@ describe("resolveOpf", () => {
       metas: [{ property: "title-type", refines: "#t2", value: "main" }],
     })
 
-    expect(resolved.title).toBe("First")
+    expect(mainTitle(resolved)).toBe("First")
     expect(resolved.titles).toEqual([
       { value: "First" },
       { value: "Second", type: "main" },

--- a/packages/archive-reader/src/metadata/opf/resolve.ts
+++ b/packages/archive-reader/src/metadata/opf/resolve.ts
@@ -28,7 +28,7 @@ export const opfMetadataHomes = {
   spineRows: "readingOrder",
   spineTocIdref: "toc",
   identifiers: "identifiers",
-  titles: ["title", "titles"],
+  titles: "titles",
   creators: "contributors",
   contributors: "contributors",
   publisher: "publication.edition.publisher",
@@ -231,8 +231,8 @@ const refiningValue = (
 /**
  * EPUB 3 states a multipart title as several `dc:title` elements refined
  * with `title-type`, `display-seq` and `file-as`. All of them are kept, in
- * document order; `title` separately stays the first one, which the spec
- * makes the main title whatever the refinements say.
+ * document order — the order matters, since the spec makes the first one the
+ * main title whatever the refinements say (see `mainTitle`).
  */
 const titlesFromOpf = (input: OpfMetadata): ResolvedTitle[] =>
   input.titles.map((title) =>
@@ -402,7 +402,6 @@ export const resolveOpf = (input: OpfMetadata): ResolvedMetadata => {
   })
 
   return omitUndefined({
-    title: titles[0]?.value,
     titles: titles.length > 0 ? titles : undefined,
     description: input.description,
     publication:

--- a/packages/archive-reader/src/metadata/opf/resolve.ts
+++ b/packages/archive-reader/src/metadata/opf/resolve.ts
@@ -1,9 +1,11 @@
 import type {
+  MetadataIdentifier,
   ResolvedCollection,
   ResolvedContributor,
   ResolvedContributorRole,
   ResolvedMetadata,
-  ResolvedMetadataHome,
+  ResolvedMetadataHomes,
+  ResolvedTitle,
 } from "../../types/resolvedMetadata.ts"
 import { normalizeGtin } from "../../utils/normalizeGtin.ts"
 import { normalizeIsbn } from "../../utils/normalizeIsbn.ts"
@@ -26,7 +28,7 @@ export const opfMetadataHomes = {
   spineRows: "readingOrder",
   spineTocIdref: "toc",
   identifiers: "identifiers",
-  title: "title",
+  titles: ["title", "titles"],
   creators: "contributors",
   contributors: "contributors",
   publisher: "publication.edition.publisher",
@@ -44,7 +46,7 @@ export const opfMetadataHomes = {
   metas: "properties",
 } as const satisfies Record<
   Exclude<keyof OpfMetadata, "kind">,
-  ResolvedMetadataHome
+  ResolvedMetadataHomes
 >
 
 const inferredIdentifierScheme = (value: string): string => {
@@ -198,6 +200,96 @@ const parseDecimal = (raw: string | undefined): number | undefined => {
   return Number.isFinite(n) ? n : undefined
 }
 
+const parseNonNegativeInt = (raw: string | undefined): number | undefined => {
+  const trimmed = raw?.trim()
+  if (trimmed === undefined || !/^\d+$/.test(trimmed)) return undefined
+  const n = Number.parseInt(trimmed, 10)
+  return Number.isFinite(n) ? n : undefined
+}
+
+const trimToUndefined = (raw: string | undefined): string | undefined => {
+  const trimmed = raw?.trim()
+
+  return trimmed !== undefined && trimmed.length > 0 ? trimmed : undefined
+}
+
+/** The value of the `meta refines="#id"` entry stating `property`. */
+const refiningValue = (
+  metas: ReadonlyArray<OpfMetaEntry>,
+  id: string | undefined,
+  property: string,
+): string | undefined =>
+  id === undefined
+    ? undefined
+    : metas.find(
+        (meta) =>
+          metaRefinesId(meta, id) &&
+          meta.property === property &&
+          meta.value !== undefined,
+      )?.value
+
+/**
+ * EPUB 3 states a multipart title as several `dc:title` elements refined
+ * with `title-type`, `display-seq` and `file-as`. All of them are kept, in
+ * document order; `title` separately stays the first one, which the spec
+ * makes the main title whatever the refinements say.
+ */
+const titlesFromOpf = (input: OpfMetadata): ResolvedTitle[] =>
+  input.titles.map((title) =>
+    omitUndefined({
+      value: title.value,
+      type: trimToUndefined(
+        refiningValue(input.metas, title.id, "title-type"),
+      )?.toLowerCase(),
+      displaySeq: parseNonNegativeInt(
+        refiningValue(input.metas, title.id, "display-seq"),
+      ),
+      sortAs: trimToUndefined(refiningValue(input.metas, title.id, "file-as")),
+    }),
+  )
+
+/**
+ * A collection can be identified as well as named: `dcterms:identifier`
+ * refines the `belongs-to-collection` meta, and an `identifier-type`
+ * refinement of that identifier names its scheme.
+ */
+const collectionIdentifiers = (
+  metas: ReadonlyArray<OpfMetaEntry>,
+  id: string | undefined,
+): ReadonlyArray<MetadataIdentifier> | undefined => {
+  if (id === undefined) return undefined
+
+  const identifiers = metas.flatMap<MetadataIdentifier>((meta) => {
+    if (!metaRefinesId(meta, id) || meta.property !== "dcterms:identifier") {
+      return []
+    }
+
+    const value = trimToUndefined(meta.value)
+
+    if (value === undefined) return []
+
+    const declaredType = normalizedIdentifierType(
+      metas.find(
+        (candidate) =>
+          meta.id !== undefined &&
+          metaRefinesId(candidate, meta.id) &&
+          candidate.property === "identifier-type",
+      ),
+    )
+
+    return [
+      {
+        value,
+        scheme: normalizedIdentifierScheme(
+          declaredType ?? inferredIdentifierScheme(value),
+        ),
+      },
+    ]
+  })
+
+  return identifiers.length > 0 ? identifiers : undefined
+}
+
 /**
  * Series/collection membership from the metas: EPUB 3
  * `belongs-to-collection` (a `collection-type` refine of `series` selects
@@ -217,18 +309,12 @@ const collectionsFromOpfMetas = (
 
     const id = meta.id
     const refining = (property: string): string | undefined =>
-      id === undefined
-        ? undefined
-        : metas.find(
-            (candidate) =>
-              metaRefinesId(candidate, id) &&
-              candidate.property === property &&
-              candidate.value !== undefined,
-          )?.value
+      refiningValue(metas, id, property)
 
     const type = refining("collection-type")?.trim().toLowerCase()
     const entry = omitUndefined({
       name: meta.value,
+      identifiers: collectionIdentifiers(metas, id),
       position: parseDecimal(refining("group-position")),
     })
 
@@ -300,6 +386,7 @@ export const resolveOpf = (input: OpfMetadata): ResolvedMetadata => {
     rl === "reflowable" || rl === "pre-paginated" ? rl : undefined
 
   const contributors = contributorsFromOpf(input)
+  const titles = titlesFromOpf(input)
   const { series, collection } = collectionsFromOpfMetas(input.metas)
 
   const belongsTo =
@@ -315,7 +402,8 @@ export const resolveOpf = (input: OpfMetadata): ResolvedMetadata => {
   })
 
   return omitUndefined({
-    title: input.title,
+    title: titles[0]?.value,
+    titles: titles.length > 0 ? titles : undefined,
     description: input.description,
     publication:
       edition.date !== undefined || edition.publisher !== undefined

--- a/packages/archive-reader/src/resolveArchive.test.ts
+++ b/packages/archive-reader/src/resolveArchive.test.ts
@@ -79,7 +79,6 @@ describe(`Given an EPUB`, () => {
       version: 3,
       unreadableSources: [],
       metadata: {
-        title: `My Book`,
         titles: [{ value: `My Book` }],
         contributors: [{ name: `Jane Author`, roles: [`author`] }],
       },
@@ -335,7 +334,6 @@ describe(`Given a CBZ with a ComicInfo sidecar`, () => {
     )
 
     expect(resolved.metadata).toEqual({
-      title: `Vol 1`,
       titles: [{ value: `Vol 1` }],
       // resolved for the whole archive: the cover is the first page (assumed,
       // the sidecar declared none) and the page count is the image count

--- a/packages/archive-reader/src/resolveArchive.test.ts
+++ b/packages/archive-reader/src/resolveArchive.test.ts
@@ -80,6 +80,7 @@ describe(`Given an EPUB`, () => {
       unreadableSources: [],
       metadata: {
         title: `My Book`,
+        titles: [{ value: `My Book` }],
         contributors: [{ name: `Jane Author`, roles: [`author`] }],
       },
       readingOrder: [
@@ -115,7 +116,7 @@ describe(`Given an EPUB`, () => {
     >()
 
     expect(resolved.version).toBe(3)
-    expect(resolved.sources.opf?.opf.title).toBe(`My Book`)
+    expect(resolved.sources.opf?.opf.titles[0]?.value).toBe(`My Book`)
     expect(resolved.sources.opf?.basePath).toBe(`OEBPS`)
     expect(`metadata` in resolved).toBe(false)
     expect(`readingOrder` in resolved).toBe(false)

--- a/packages/archive-reader/src/resolveArchive.test.ts
+++ b/packages/archive-reader/src/resolveArchive.test.ts
@@ -336,6 +336,7 @@ describe(`Given a CBZ with a ComicInfo sidecar`, () => {
 
     expect(resolved.metadata).toEqual({
       title: `Vol 1`,
+      titles: [{ value: `Vol 1` }],
       // resolved for the whole archive: the cover is the first page (assumed,
       // the sidecar declared none) and the page count is the image count
       cover: {

--- a/packages/archive-reader/src/resolveArchive.ts
+++ b/packages/archive-reader/src/resolveArchive.ts
@@ -236,7 +236,7 @@ const RESOLVED_ARCHIVE_VERSION = 3
  *
  * // library-shelf scan: metadata (incl. cover) only, skip the toc read
  * const { metadata } = await resolveArchive(archive, { include: ["metadata"] })
- * renderShelfItem({ title: metadata.title, cover: metadata.cover?.uri })
+ * renderShelfItem({ title: mainTitle(metadata), cover: metadata.cover?.uri })
  *
  * // your own per-source precedence via the raw sources escape hatch
  * // (resolveArchiveMetadata normalizes a single source at a time)

--- a/packages/archive-reader/src/resolveMetadata.test.ts
+++ b/packages/archive-reader/src/resolveMetadata.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import { parseComicInfo } from "./metadata/comicInfo/parse"
 import { parseOpf } from "./metadata/opf/parse"
 import { resolveMetadata } from "./resolveMetadata"
+import { mainTitle } from "./utils/mainTitle"
 
 const opfWrap = (metadata: string) =>
   `<?xml version="1.0"?>` +
@@ -32,7 +33,7 @@ describe("resolveMetadata", () => {
       resolveMetadata({
         comicInfo: comicInfoWith("<Title>Vol 1</Title>"),
       }),
-    ).toEqual({ title: "Vol 1", titles: [{ value: "Vol 1" }] })
+    ).toEqual({ titles: [{ value: "Vol 1" }] })
   })
 
   it("prefers OPF over ComicInfo for descriptive fields", () => {
@@ -51,7 +52,7 @@ describe("resolveMetadata", () => {
       ),
     })
 
-    expect(resolved.title).toBe("Package Title")
+    expect(mainTitle(resolved)).toBe("Package Title")
     expect(resolved.publication?.edition?.publisher).toBe("Package Publisher")
     expect(resolved.languages).toEqual(["en"])
     expect(resolved.contributors).toEqual([
@@ -65,7 +66,7 @@ describe("resolveMetadata", () => {
       comicInfo: comicInfoWith(`<Summary>From the sidecar.</Summary>`),
     })
 
-    expect(resolved.title).toBe("Package Title")
+    expect(mainTitle(resolved)).toBe("Package Title")
     expect(resolved.description).toBe("From the sidecar.")
   })
 
@@ -232,7 +233,7 @@ describe("resolveMetadata", () => {
     })
 
     expect(resolved).toMatchObject({
-      title: "My Book",
+      titles: [{ value: "My Book" }],
       contributors: [{ name: "Jane Author", roles: ["author"] }],
       belongsTo: { series: [{ name: "My Series", position: 2 }] },
       renditionLayout: "pre-paginated",

--- a/packages/archive-reader/src/resolveMetadata.test.ts
+++ b/packages/archive-reader/src/resolveMetadata.test.ts
@@ -32,7 +32,7 @@ describe("resolveMetadata", () => {
       resolveMetadata({
         comicInfo: comicInfoWith("<Title>Vol 1</Title>"),
       }),
-    ).toEqual({ title: "Vol 1" })
+    ).toEqual({ title: "Vol 1", titles: [{ value: "Vol 1" }] })
   })
 
   it("prefers OPF over ComicInfo for descriptive fields", () => {

--- a/packages/archive-reader/src/resolveMetadata.ts
+++ b/packages/archive-reader/src/resolveMetadata.ts
@@ -21,7 +21,8 @@ export type ResolveMetadataSources = {
  * {@link ResolvedMetadata}, with explicit precedence:
  *
  * - Descriptive fields (`title`, `description`, `publication`, `languages`,
- *   `subjects`, `contributors`, `belongsTo`):
+ *   `subjects`, `contributors`, `belongsTo`; `titles` has only the OPF as a
+ *   producer, a ComicInfo sidecar stating a single `Title`):
  *   **OPF wins over ComicInfo** — the package document is the publication's
  *   own metadata; a ComicInfo sidecar fills the gaps.
  * - `readingDirection`: **ComicInfo wins over OPF** (`Manga` beats
@@ -69,6 +70,7 @@ export const resolveMetadata = (
 
   return omitUndefined({
     title: opf?.title ?? comicInfo?.title,
+    titles: opf?.titles,
     description: opf?.description ?? comicInfo?.description,
     publication:
       edition.date !== undefined ||

--- a/packages/archive-reader/src/resolveMetadata.ts
+++ b/packages/archive-reader/src/resolveMetadata.ts
@@ -20,9 +20,8 @@ export type ResolveMetadataSources = {
  * Merges the per-source resolved metadata of every parsed source into one
  * {@link ResolvedMetadata}, with explicit precedence:
  *
- * - Descriptive fields (`title`, `description`, `publication`, `languages`,
- *   `subjects`, `contributors`, `belongsTo`; `titles` has only the OPF as a
- *   producer, a ComicInfo sidecar stating a single `Title`):
+ * - Descriptive fields (`title`, `titles`, `description`, `publication`,
+ *   `languages`, `subjects`, `contributors`, `belongsTo`):
  *   **OPF wins over ComicInfo** — the package document is the publication's
  *   own metadata; a ComicInfo sidecar fills the gaps.
  * - `readingDirection`: **ComicInfo wins over OPF** (`Manga` beats
@@ -70,7 +69,7 @@ export const resolveMetadata = (
 
   return omitUndefined({
     title: opf?.title ?? comicInfo?.title,
-    titles: opf?.titles,
+    titles: opf?.titles ?? comicInfo?.titles,
     description: opf?.description ?? comicInfo?.description,
     publication:
       edition.date !== undefined ||

--- a/packages/archive-reader/src/resolveMetadata.ts
+++ b/packages/archive-reader/src/resolveMetadata.ts
@@ -20,7 +20,7 @@ export type ResolveMetadataSources = {
  * Merges the per-source resolved metadata of every parsed source into one
  * {@link ResolvedMetadata}, with explicit precedence:
  *
- * - Descriptive fields (`title`, `titles`, `description`, `publication`,
+ * - Descriptive fields (`titles`, `description`, `publication`,
  *   `languages`, `subjects`, `contributors`, `belongsTo`):
  *   **OPF wins over ComicInfo** — the package document is the publication's
  *   own metadata; a ComicInfo sidecar fills the gaps.
@@ -68,7 +68,6 @@ export const resolveMetadata = (
   })
 
   return omitUndefined({
-    title: opf?.title ?? comicInfo?.title,
     titles: opf?.titles ?? comicInfo?.titles,
     description: opf?.description ?? comicInfo?.description,
     publication:

--- a/packages/archive-reader/src/types/resolvedMetadata.ts
+++ b/packages/archive-reader/src/types/resolvedMetadata.ts
@@ -68,7 +68,7 @@ export type ResolvedTitleType =
   | "short"
   | "collection"
   | "edition"
-  | "extended"
+  | "expanded"
 
 /**
  * One title as the source states it. EPUB expresses a multipart title as
@@ -291,18 +291,17 @@ export type ResolvedCover = {
  */
 export type ResolvedMetadata = {
   /**
-   * The main title, which EPUB 3 defines as the first `dc:title` in document
-   * order — a `title-type` of `main` on a later one does not displace it.
-   * ComicInfo `Title`.
-   */
-  readonly title?: string
-  /**
    * Every title the source states, in document order, with the typing it
-   * gives them (see {@link ResolvedTitle}). A subtitle lives here as an entry
-   * of type `subtitle`, never appended to {@link ResolvedMetadata.title}:
-   * composing the two for display is the consumer's decision, not ours.
-   * Populated by sources that distinguish titles at all — an EPUB package,
-   * or a catalog that returns a subtitle of its own.
+   * gives them (see {@link ResolvedTitle}). OPF `dc:title`, ComicInfo
+   * `Title`.
+   *
+   * **The first entry is the main title**: EPUB 3 requires reading systems to
+   * take the first `dc:title` in document order as the publication's title,
+   * and a later `title-type` of `main` does not displace it. Use
+   * {@link mainTitle} rather than re-deriving that rule.
+   *
+   * A subtitle is an entry of type `subtitle`, never appended to the main
+   * one: composing the two for display is the consumer's decision, not ours.
    */
   readonly titles?: ReadonlyArray<ResolvedTitle>
   /**

--- a/packages/archive-reader/src/types/resolvedMetadata.ts
+++ b/packages/archive-reader/src/types/resolvedMetadata.ts
@@ -59,6 +59,34 @@ export type ResolvedMetadataIdentifier = MetadataIdentifier & {
 }
 
 /**
+ * EPUB 3 `title-type` vocabulary. Unknown source tokens pass through
+ * verbatim, like contributor roles.
+ */
+export type ResolvedTitleType =
+  | "main"
+  | "subtitle"
+  | "short"
+  | "collection"
+  | "edition"
+  | "extended"
+
+/**
+ * One title as the source states it. EPUB expresses a multipart title as
+ * several `dc:title` elements, each optionally refined with `title-type`,
+ * `display-seq` and `file-as`, so a publication can state a main title, a
+ * subtitle, a short form and more.
+ */
+export type ResolvedTitle = {
+  readonly value: string
+  /** EPUB `title-type` refinement, lowercased; absent when untyped. */
+  readonly type?: ResolvedTitleType | (string & {})
+  /** EPUB `display-seq` refinement: the order the source wants them shown. */
+  readonly displaySeq?: number
+  /** Sorting form of the title (OPF `file-as`). */
+  readonly sortAs?: string
+}
+
+/**
  * Contributor role vocabulary: the Readium WPM role terms our sources can
  * express, plus the prose-reader extension `coverArtist` (ComicInfo
  * `CoverArtist` — Readium has no cover-art term). Resolvers normalize
@@ -94,11 +122,22 @@ export type ResolvedContributor = {
 
 /**
  * Membership in a series or collection (Readium `belongsTo` shape).
+ *
+ * Identity is whatever the source states: EPUB names the collection in the
+ * `belongs-to-collection` value and may add a `dcterms:identifier`
+ * refinement, while a catalog can know it the other way around — Google
+ * Books identifies a series by `seriesId` alone and never states its name.
+ * Both halves are therefore optional, and an entry stating only a position
+ * ("issue 1 of something") is still the source's own fact.
+ *
  * `total` is a prose-reader extension: the announced number of entries in
  * the collection (ComicInfo `Count`), useful to library apps.
  */
 export type ResolvedCollection = {
-  readonly name: string
+  /** EPUB `belongs-to-collection` value, ComicInfo `Series`. */
+  readonly name?: string
+  /** EPUB `dcterms:identifier` refinement, catalog series ids. */
+  readonly identifiers?: ReadonlyArray<MetadataIdentifier>
   /** Position of this publication in the collection; floats allowed ("1.5"). */
   readonly position?: number
   /** Announced total number of entries in the collection. */
@@ -251,8 +290,21 @@ export type ResolvedCover = {
  * @see module doc above for design rules.
  */
 export type ResolvedMetadata = {
-  /** Human-readable title of the work. OPF `dc:title`, ComicInfo `Title`. */
+  /**
+   * The main title, which EPUB 3 defines as the first `dc:title` in document
+   * order — a `title-type` of `main` on a later one does not displace it.
+   * ComicInfo `Title`.
+   */
   readonly title?: string
+  /**
+   * Every title the source states, in document order, with the typing it
+   * gives them (see {@link ResolvedTitle}). A subtitle lives here as an entry
+   * of type `subtitle`, never appended to {@link ResolvedMetadata.title}:
+   * composing the two for display is the consumer's decision, not ours.
+   * Populated by sources that distinguish titles at all — an EPUB package,
+   * or a catalog that returns a subtitle of its own.
+   */
+  readonly titles?: ReadonlyArray<ResolvedTitle>
   /**
    * The publication's cover image: the OPF-declared cover (EPUB 3
    * `cover-image` property, the EPUB 2 `<meta name="cover">` convention, or a
@@ -369,3 +421,12 @@ export type ResolvedMetadataHome =
   | "readingOrder"
   | "toc"
   | "guide"
+
+/**
+ * A source field's declared home(s). One field legitimately lands in more
+ * than one place — an EPUB's `dc:title` elements populate both `title` (the
+ * first of them) and `titles` (all of them) — so the tables accept a list.
+ */
+export type ResolvedMetadataHomes =
+  | ResolvedMetadataHome
+  | ReadonlyArray<ResolvedMetadataHome>

--- a/packages/archive-reader/src/utils/mainTitle.ts
+++ b/packages/archive-reader/src/utils/mainTitle.ts
@@ -1,0 +1,14 @@
+import type { ResolvedMetadata } from "../types/resolvedMetadata.ts"
+
+/**
+ * The publication's main title: the first title the source states, in
+ * document order.
+ *
+ * EPUB 3 requires reading systems to present the first `dc:title` as the
+ * title of the publication, so a `title-type` of `main` on a later element
+ * does not displace it — searching the list for that type is the mistake this
+ * helper exists to prevent.
+ */
+export const mainTitle = (
+  metadata: Pick<ResolvedMetadata, "titles"> | undefined,
+): string | undefined => metadata?.titles?.[0]?.value

--- a/packages/enhancer-search/src/index.ts
+++ b/packages/enhancer-search/src/index.ts
@@ -6,7 +6,7 @@ import type { SearchResult } from "./search"
 import { searchInDocument } from "./search"
 import type { ResultItem, SearchEnhancerAPI } from "./types"
 
-export type { SearchEnhancerAPI, ResultItem, SearchResult }
+export type { ResultItem, SearchEnhancerAPI, SearchResult }
 
 /**
  * Contract of search enhancer.

--- a/packages/metadata-fetcher/src/fetchMetadata.test.ts
+++ b/packages/metadata-fetcher/src/fetchMetadata.test.ts
@@ -1,3 +1,4 @@
+import { mainTitle } from "@prose-reader/archive-reader"
 import { describe, expect, it, vi } from "vitest"
 import { fetchMetadata } from "./fetchMetadata.ts"
 import { MetadataProviderResponseError } from "./providers/responseError.ts"
@@ -30,7 +31,7 @@ describe("fetchMetadata", () => {
       providerReturning("a", [
         {
           metadata: {
-            title: "Dune",
+            titles: [{ value: "Dune" }],
             publication: { edition: { publisher: "Ace" } },
           },
         },
@@ -39,7 +40,7 @@ describe("fetchMetadata", () => {
     const fetched = await fetchMetadata(book, { providers })
 
     expect(fetched.matches[0]?.metadata).toEqual({
-      title: "Dune",
+      titles: [{ value: "Dune" }],
       publication: { edition: { publisher: "Ace" } },
     })
   })
@@ -61,8 +62,12 @@ describe("fetchMetadata", () => {
   it("ranks matches across providers, best first", async () => {
     const fetched = await fetchMetadata(book, {
       providers: [
-        providerReturning("weak", [{ metadata: { title: "Duna" } }]),
-        providerReturning("strong", [{ metadata: { title: "Dune" } }]),
+        providerReturning("weak", [
+          { metadata: { titles: [{ value: "Duna" }] } },
+        ]),
+        providerReturning("strong", [
+          { metadata: { titles: [{ value: "Dune" }] } },
+        ]),
       ],
     })
 
@@ -76,8 +81,12 @@ describe("fetchMetadata", () => {
   it("breaks ties in the order the providers were declared", async () => {
     const fetched = await fetchMetadata(book, {
       providers: [
-        providerReturning("first", [{ metadata: { title: "Dune" } }]),
-        providerReturning("second", [{ metadata: { title: "Dune" } }]),
+        providerReturning("first", [
+          { metadata: { titles: [{ value: "Dune" }] } },
+        ]),
+        providerReturning("second", [
+          { metadata: { titles: [{ value: "Dune" }] } },
+        ]),
       ],
     })
 
@@ -93,13 +102,13 @@ describe("fetchMetadata", () => {
         providerReturning("weak", [
           {
             metadata: {
-              title: "Something Else",
+              titles: [{ value: "Something Else" }],
               publication: { edition: { publisher: "Wrong" } },
             },
           },
         ]),
         providerReturning("strong", [
-          { metadata: { title: "Dune", numberOfPages: 412 } },
+          { metadata: { titles: [{ value: "Dune" }], numberOfPages: 412 } },
         ]),
       ],
     })
@@ -118,7 +127,9 @@ describe("fetchMetadata", () => {
   it("keeps the rejected matches, ranked, for manual confirmation", async () => {
     const fetched = await fetchMetadata(book, {
       providers: [
-        providerReturning("a", [{ metadata: { title: "Neuromancer" } }]),
+        providerReturning("a", [
+          { metadata: { titles: [{ value: "Neuromancer" }] } },
+        ]),
       ],
     })
 
@@ -131,7 +142,9 @@ describe("fetchMetadata", () => {
 
   it("honors minScore", async () => {
     const providers = [
-      providerReturning("a", [{ metadata: { title: "Dune Messiah" } }]),
+      providerReturning("a", [
+        { metadata: { titles: [{ value: "Dune Messiah" }] } },
+      ]),
     ]
 
     expect(
@@ -148,16 +161,16 @@ describe("fetchMetadata", () => {
     const fetched = await fetchMetadata(book, {
       providers: [
         providerReturning("a", [
-          { metadata: { title: "Neuromancer" } },
-          { metadata: { title: "Dune" } },
-          { metadata: { title: "Duna" } },
+          { metadata: { titles: [{ value: "Neuromancer" }] } },
+          { metadata: { titles: [{ value: "Dune" }] } },
+          { metadata: { titles: [{ value: "Duna" }] } },
         ]),
       ],
       limit: 2,
     })
 
     expect(
-      fetched.sources.a?.matches.map((match) => match.metadata.title),
+      fetched.sources.a?.matches.map((match) => mainTitle(match.metadata)),
     ).toEqual(["Dune", "Duna"])
   })
 
@@ -203,13 +216,17 @@ describe("fetchMetadata", () => {
     const fetched = await fetchMetadata(book, {
       providers: [
         failingProvider("down"),
-        providerReturning("up", [{ metadata: { title: "Dune" } }]),
+        providerReturning("up", [
+          { metadata: { titles: [{ value: "Dune" }] } },
+        ]),
       ],
     })
 
     expect(fetched.failedProviders).toEqual([{ id: "down" }])
     expect(fetched.sources).not.toHaveProperty("down")
-    expect(fetched.matches[0]?.metadata).toEqual({ title: "Dune" })
+    expect(fetched.matches[0]?.metadata).toEqual({
+      titles: [{ value: "Dune" }],
+    })
   })
 
   it("rejects when the caller aborts", async () => {
@@ -227,7 +244,9 @@ describe("fetchMetadata", () => {
 
   it("keeps the provider payload only when asked", async () => {
     const providers = [
-      providerReturning("a", [{ metadata: { title: "Dune" }, raw: { id: 1 } }]),
+      providerReturning("a", [
+        { metadata: { titles: [{ value: "Dune" }] }, raw: { id: 1 } },
+      ]),
     ]
 
     expect(

--- a/packages/metadata-fetcher/src/match/scoreMetadataCandidate.test.ts
+++ b/packages/metadata-fetcher/src/match/scoreMetadataCandidate.test.ts
@@ -22,7 +22,7 @@ describe("scoreMetadataCandidate", () => {
   it("only compares fields both sides state", () => {
     const { signals } = score(
       { title: "Dune", publisher: "Ace" },
-      { title: "Dune", numberOfPages: 412 },
+      { titles: [{ value: "Dune" }], numberOfPages: 412 },
     )
 
     expect(signals.map((signal) => signal.field)).toEqual(["title"])
@@ -37,7 +37,7 @@ describe("scoreMetadataCandidate", () => {
       },
       {
         identifiers: [{ value: "9780441013593", scheme: "ISBN" }],
-        title: "Dune",
+        titles: [{ value: "Dune" }],
         publication: { edition: { publisher: "Ace" } },
       },
     )
@@ -68,7 +68,7 @@ describe("scoreMetadataCandidate", () => {
       },
       {
         identifiers: [{ value: "9780345391803", scheme: "ISBN" }],
-        title: "Dune",
+        titles: [{ value: "Dune" }],
         contributors: [{ name: "Frank Herbert", roles: ["author"] }],
       },
     )
@@ -103,7 +103,7 @@ describe("scoreMetadataCandidate", () => {
         authors: ["Herbert, Frank"],
       },
       {
-        title: "Dune",
+        titles: [{ value: "Dune" }],
         contributors: [{ name: "Frank Herbert", roles: ["author"] }],
       },
     )
@@ -117,7 +117,7 @@ describe("scoreMetadataCandidate", () => {
     const { signals } = score(
       { title: "Dune" },
       {
-        title: "Dune: Messiah",
+        titles: [{ value: "Dune: Messiah" }],
         publication: { edition: { publisher: "Ace" } },
       },
     )
@@ -178,7 +178,7 @@ describe("scoreMetadataCandidate", () => {
         ],
       },
       {
-        title: "The catalog title",
+        titles: [{ value: "The catalog title" }],
         identifiers: [
           { value: "http://www.gutenberg.org/78139", scheme: "URL" },
           { value: "78139", scheme: "ProjectGutenberg" },
@@ -199,7 +199,7 @@ describe("scoreMetadataCandidate", () => {
         identifiers: [{ value: "zyTCAlFPjgYC", scheme: "GoogleBooks" }],
       },
       {
-        title: "The catalog title",
+        titles: [{ value: "The catalog title" }],
         identifiers: [{ value: "zytcalfpjgyc", scheme: "googlebooks" }],
       },
     )
@@ -217,7 +217,7 @@ describe("scoreMetadataCandidate", () => {
         identifiers: [{ value: "78139", scheme: "Unknown" }],
       },
       {
-        title: "Neuromancer",
+        titles: [{ value: "Neuromancer" }],
         identifiers: [{ value: "78139", scheme: "ProjectGutenberg" }],
       },
     )
@@ -235,7 +235,7 @@ describe("scoreMetadataCandidate", () => {
         identifiers: [{ value: "one", scheme: "CatalogA" }],
       },
       {
-        title: "Dune",
+        titles: [{ value: "Dune" }],
         identifiers: [{ value: "two", scheme: "CatalogB" }],
       },
     )
@@ -255,7 +255,7 @@ describe("scoreMetadataCandidate", () => {
     const result = score(
       { title: "Dune", publisher: "Ace" },
       {
-        title: "Dune",
+        titles: [{ value: "Dune" }],
         publication: { edition: { publisher: "Chilton Books" } },
       },
     )
@@ -273,7 +273,7 @@ describe("scoreMetadataCandidate", () => {
         publishedYear: 1965,
       },
       {
-        title: "Dune",
+        titles: [{ value: "Dune" }],
         publication: { edition: { date: { year: 1965 } } },
       },
     )
@@ -325,7 +325,12 @@ describe("scoreMetadataCandidate", () => {
         publisher: "Project Gutenberg",
       },
       {
-        title: "Wilhelm Meister's Apprenticeship and Travels, Vol. I (of 2)",
+        titles: [
+          {
+            value:
+              "Wilhelm Meister's Apprenticeship and Travels, Vol. I (of 2)",
+          },
+        ],
         contributors: [
           { name: "Johann Wolfgang von Goethe", roles: ["author"] },
         ],

--- a/packages/metadata-fetcher/src/match/scoreMetadataCandidate.ts
+++ b/packages/metadata-fetcher/src/match/scoreMetadataCandidate.ts
@@ -1,6 +1,7 @@
-import type {
-  MetadataIdentifier,
-  ResolvedMetadata,
+import {
+  type MetadataIdentifier,
+  mainTitle,
+  type ResolvedMetadata,
 } from "@prose-reader/archive-reader"
 import type { FetchMetadataInput } from "../types/fetchMetadataInput.ts"
 import type { MetadataMatchField, MetadataMatchSignal } from "../types/match.ts"
@@ -317,7 +318,7 @@ export const scoreMetadataCandidate = (
     })
   }
 
-  compareStrings("title", query.title, candidate.title, titleSimilarity)
+  compareStrings("title", query.title, mainTitle(candidate), titleSimilarity)
   addSignal(
     "publisher",
     bestStringComparison(query.publisher, [

--- a/packages/metadata-fetcher/src/metadataInputFromResolvedArchive.test.ts
+++ b/packages/metadata-fetcher/src/metadataInputFromResolvedArchive.test.ts
@@ -10,7 +10,7 @@ describe("metadataInputFromResolvedArchive", () => {
   it("projects only lookup and matching fields into the flat input", () => {
     const resolved: Pick<ResolvedArchive, "metadata"> = {
       metadata: {
-        title: "Dune",
+        titles: [{ value: "Dune" }],
         cover: { uri: "cover.jpg", confidence: "derived" },
         description: "A desert planet.",
         contributors: [

--- a/packages/metadata-fetcher/src/metadataInputFromResolvedArchive.ts
+++ b/packages/metadata-fetcher/src/metadataInputFromResolvedArchive.ts
@@ -1,4 +1,4 @@
-import type { ResolvedArchive } from "@prose-reader/archive-reader"
+import { mainTitle, type ResolvedArchive } from "@prose-reader/archive-reader"
 import type { FetchMetadataInput } from "./types/fetchMetadataInput.ts"
 import { metadataAuthors } from "./utils/metadataAuthors.ts"
 import { omitUndefined } from "./utils/omitUndefined.ts"
@@ -20,7 +20,7 @@ export const metadataInputFromResolvedArchive = (
   }))
 
   return omitUndefined({
-    title: metadata.title,
+    title: mainTitle(metadata),
     authors: authors.length > 0 ? authors : undefined,
     identifiers:
       identifiers !== undefined && identifiers.length > 0

--- a/packages/metadata-fetcher/src/providers/googleBooks/createGoogleBooksProvider.test.ts
+++ b/packages/metadata-fetcher/src/providers/googleBooks/createGoogleBooksProvider.test.ts
@@ -1,3 +1,4 @@
+import { mainTitle } from "@prose-reader/archive-reader"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { scoreMetadataCandidate } from "../../match/scoreMetadataCandidate.ts"
 import type { FetchMetadataInput } from "../../types/fetchMetadataInput.ts"
@@ -171,7 +172,7 @@ describe("createGoogleBooksProvider", () => {
     expect(requestedUrl(fetchMock, 2).searchParams.get("q")).toBe(
       'intitle:"Dune" inauthor:"Frank Herbert"',
     )
-    expect(candidates[0]?.metadata.title).toBe("Dune")
+    expect(mainTitle(candidates[0]?.metadata)).toBe("Dune")
   })
 
   it("falls back to title-only when author makes the query too narrow", async () => {

--- a/packages/metadata-fetcher/src/providers/googleBooks/resolve.test.ts
+++ b/packages/metadata-fetcher/src/providers/googleBooks/resolve.test.ts
@@ -100,7 +100,7 @@ describe("resolveGoogleBooksVolume", () => {
         },
       }),
     ).toEqual({
-      title: "Dune: A Novel",
+      titles: [{ value: "Dune: A Novel" }],
       description: "<p>A desert epic.</p>",
       publication: {
         edition: {
@@ -164,7 +164,7 @@ describe("resolveGoogleBooksVolume", () => {
           title: "Saga",
           seriesInfo: { bookDisplayNumber: "2" },
         },
-      }).title,
+      }).titles?.[0]?.value,
     ).toBe("Saga Vol 2")
     expect(
       resolveGoogleBooksVolume({
@@ -172,7 +172,7 @@ describe("resolveGoogleBooksVolume", () => {
           title: "Saga Vol. 2",
           seriesInfo: { bookDisplayNumber: "2" },
         },
-      }).title,
+      }).titles?.[0]?.value,
     ).toBe("Saga Vol. 2")
   })
 
@@ -185,7 +185,7 @@ describe("resolveGoogleBooksVolume", () => {
             title,
             seriesInfo: { bookDisplayNumber: "2" },
           },
-        }).title,
+        }).titles?.[0]?.value,
       ).toBe(title)
     },
   )
@@ -197,7 +197,7 @@ describe("resolveGoogleBooksVolume", () => {
           title: "The Book Thief",
           seriesInfo: { bookDisplayNumber: "2" },
         },
-      }).title,
+      }).titles?.[0]?.value,
     ).toBe("The Book Thief Vol 2")
   })
 

--- a/packages/metadata-fetcher/src/providers/googleBooks/resolve.ts
+++ b/packages/metadata-fetcher/src/providers/googleBooks/resolve.ts
@@ -25,8 +25,8 @@ export const googleBooksVolumeMetadataHomes = {
 
 /** Compile-enforced map from every parsed Google Books field to its home. */
 export const googleBooksVolumeInfoMetadataHomes = {
-  title: "title",
-  subtitle: "title",
+  title: "titles",
+  subtitle: "titles",
   authors: "contributors",
   publisher: "publication.edition.publisher",
   publishedDate: "publication.edition.date",
@@ -38,7 +38,7 @@ export const googleBooksVolumeInfoMetadataHomes = {
   imageLinks: "cover",
   infoLink: "candidate.url",
   canonicalVolumeLink: "candidate.url",
-  seriesInfo: "title",
+  seriesInfo: "titles",
 } satisfies Record<
   keyof GoogleBooksVolumeInfo,
   ResolvedMetadataHome | "identifiers" | "candidate.url"
@@ -197,8 +197,10 @@ export const resolveGoogleBooksVolume = (
     GOOGLE_BOOKS_MAX_SUBJECTS,
   )
 
+  const title = titleWithSeriesNumber(volumeInfo)
+
   return omitUndefined({
-    title: titleWithSeriesNumber(volumeInfo),
+    titles: title !== undefined ? [{ value: title }] : undefined,
     description: volumeInfo.description,
     publication:
       edition.date !== undefined || edition.publisher !== undefined

--- a/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.test.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.test.ts
@@ -1,3 +1,4 @@
+import { mainTitle } from "@prose-reader/archive-reader"
 import { describe, expect, it, vi } from "vitest"
 import { createOpenLibraryProvider } from "./createOpenLibraryProvider.ts"
 
@@ -120,7 +121,7 @@ describe("createOpenLibraryProvider", () => {
       "Irina: The Vampire Cosmonaut Vol. 1 Keisuke Makino",
     )
     expect(fallback.searchParams.get("title")).toBeNull()
-    expect(candidates[0]?.metadata.title).toBe(
+    expect(mainTitle(candidates[0]?.metadata)).toBe(
       "Irina: The Vampire Cosmonaut (Light Novel) Vol. 1",
     )
   })

--- a/packages/metadata-fetcher/src/providers/openLibrary/resolve.test.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/resolve.test.ts
@@ -90,7 +90,7 @@ describe("resolveOpenLibraryDoc", () => {
         { coversBaseUrl },
       ),
     ).toEqual({
-      title: "Dune",
+      titles: [{ value: "Dune" }],
       contributors: [{ name: "Frank Herbert", roles: ["author"] }],
       publication: { original: { date: { year: 1965 } } },
       languages: ["en"],
@@ -113,7 +113,7 @@ describe("resolveOpenLibraryDoc", () => {
       resolveOpenLibraryDoc(
         { title: "Dune", subtitle: "a novel" },
         { coversBaseUrl },
-      ).title,
+      ).titles?.[0]?.value,
     ).toBe("Dune: a novel")
   })
 

--- a/packages/metadata-fetcher/src/providers/openLibrary/resolve.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/resolve.ts
@@ -23,8 +23,8 @@ export const OPEN_LIBRARY_MAX_SUBJECTS = 25
  */
 export const openLibraryMetadataHomes = {
   key: "identifiers",
-  title: "title",
-  subtitle: "title",
+  title: "titles",
+  subtitle: "titles",
   author_name: "contributors",
   first_publish_year: "publication.original.date",
   language: "languages",
@@ -98,7 +98,7 @@ export const resolveOpenLibraryDoc = (
   ]
 
   return omitUndefined({
-    title,
+    titles: title !== undefined ? [{ value: title }] : undefined,
     cover:
       doc.cover_i !== undefined
         ? {

--- a/packages/metadata-fetcher/src/providers/projectGutenberg/createProjectGutenbergProvider.test.ts
+++ b/packages/metadata-fetcher/src/providers/projectGutenberg/createProjectGutenbergProvider.test.ts
@@ -53,7 +53,12 @@ describe("createProjectGutenbergProvider", () => {
       id: "78139",
       url: "https://www.gutenberg.org/ebooks/78139",
       metadata: {
-        title: "Wilhelm Meister's apprenticeship and travels, vol. 2 (of 2)",
+        titles: [
+          {
+            value:
+              "Wilhelm Meister's apprenticeship and travels, vol. 2 (of 2)",
+          },
+        ],
         identifiers: [
           { value: "http://www.gutenberg.org/78139", scheme: "URL" },
           { value: "78139", scheme: "ProjectGutenberg" },

--- a/packages/metadata-fetcher/src/providers/projectGutenberg/resolve.test.ts
+++ b/packages/metadata-fetcher/src/providers/projectGutenberg/resolve.test.ts
@@ -33,7 +33,7 @@ describe("resolveProjectGutenbergRecord", () => {
         },
       }),
     ).toEqual({
-      title: "Wilhelm Meister, vol. 2",
+      titles: [{ value: "Wilhelm Meister, vol. 2" }],
       publication: {
         original: { date: { year: 1896 }, publisher: "A.L. Burt" },
         edition: {

--- a/packages/metadata-fetcher/src/providers/projectGutenberg/resolve.ts
+++ b/packages/metadata-fetcher/src/providers/projectGutenberg/resolve.ts
@@ -17,7 +17,7 @@ export const PROJECT_GUTENBERG_MAX_SUBJECTS = 25
 /** Compile-enforced map from every parsed RDF field to its resolved home. */
 export const projectGutenbergMetadataHomes = {
   id: "identifiers",
-  title: "title",
+  title: "titles",
   publisher: "publication.edition.publisher",
   issued: "publication.edition.date",
   originalPublication: "publication.original",
@@ -215,7 +215,7 @@ export const resolveProjectGutenbergRecord = (
   })
 
   return omitUndefined({
-    title: record.title,
+    titles: record.title !== undefined ? [{ value: record.title }] : undefined,
     publication:
       publication.original !== undefined || publication.edition !== undefined
         ? publication

--- a/packages/react-reader/src/components/ui/drawer.tsx
+++ b/packages/react-reader/src/components/ui/drawer.tsx
@@ -1,6 +1,6 @@
 import { Drawer as ChakraDrawer, Portal } from "@chakra-ui/react"
-import { CloseButton } from "./close-button"
 import * as React from "react"
+import { CloseButton } from "./close-button"
 
 interface DrawerContentProps extends ChakraDrawer.ContentProps {
   portalled?: boolean

--- a/packages/react-reader/src/components/ui/popover.tsx
+++ b/packages/react-reader/src/components/ui/popover.tsx
@@ -1,6 +1,6 @@
 import { Popover as ChakraPopover, Portal } from "@chakra-ui/react"
-import { CloseButton } from "./close-button"
 import * as React from "react"
+import { CloseButton } from "./close-button"
 
 interface PopoverContentProps extends ChakraPopover.ContentProps {
   portalled?: boolean

--- a/packages/react-reader/src/components/ui/progress.tsx
+++ b/packages/react-reader/src/components/ui/progress.tsx
@@ -1,6 +1,6 @@
 import { Progress as ChakraProgress } from "@chakra-ui/react"
-import { InfoTip } from "./toggle-tip"
 import * as React from "react"
+import { InfoTip } from "./toggle-tip"
 
 export const ProgressBar = React.forwardRef<
   HTMLDivElement,

--- a/packages/react-reader/src/components/ui/toaster.tsx
+++ b/packages/react-reader/src/components/ui/toaster.tsx
@@ -2,11 +2,11 @@
 
 import {
   Toaster as ChakraToaster,
+  createToaster,
   Portal,
   Spinner,
   Stack,
   Toast,
-  createToaster,
 } from "@chakra-ui/react"
 
 type Toaster = ReturnType<typeof createToaster>

--- a/packages/streamer/src/generators/manifest/manifestFromResolvedArchive.ts
+++ b/packages/streamer/src/generators/manifest/manifestFromResolvedArchive.ts
@@ -1,7 +1,8 @@
-import type {
-  Archive,
-  ArchiveTocItem,
-  ResolvedArchive,
+import {
+  type Archive,
+  type ArchiveTocItem,
+  mainTitle,
+  type ResolvedArchive,
 } from "@prose-reader/archive-reader"
 import type { Manifest } from "@prose-reader/shared"
 import { createXmlSafeIdFactory, urlJoin } from "@prose-reader/shared"
@@ -78,7 +79,7 @@ const epubManifest = (
 
   return {
     filename: archive.filename ?? ``,
-    title: metadata.title || firstDirectoryTitle(archive) || ``,
+    title: mainTitle(metadata) || firstDirectoryTitle(archive) || ``,
     renditionLayout: metadata.renditionLayout,
     renditionFlow: metadata.renditionFlow ?? `auto`,
     renditionSpread: metadata.renditionSpread,
@@ -131,7 +132,10 @@ const recordsManifest = (
   const manifest: Manifest = {
     filename: archive.filename ?? ``,
     title:
-      metadata.title || firstDirectoryTitle(archive) || archive.filename || ``,
+      mainTitle(metadata) ||
+      firstDirectoryTitle(archive) ||
+      archive.filename ||
+      ``,
     renditionLayout: metadata.renditionLayout,
     renditionSpread: `auto`,
     readingDirection: metadata.readingDirection,


### PR DESCRIPTION
`ResolvedMetadata` could only say one thing about a title, and could only describe a collection it had a name for. Both limits push presentation into data — the metadata providers compose `"Dune: A Novel"` and `"BLAME! Vol 1"` because a subtitle and a volume number have nowhere else to go. This adds the two missing capabilities, both grounded in what an EPUB can state.

### Typed titles

EPUB states a multipart title as several `dc:title` elements refined with `title-type` (`main`, `subtitle`, `short`, `collection`, `edition`, `extended`), `display-seq` and `file-as`. `titles` keeps all of them with that typing.

`title` is unchanged in meaning: the first `dc:title` in document order, which [EPUB 3.3 makes the main title](https://www.w3.org/TR/epub-33/) whatever a later `title-type` claims — there is a test for exactly that. The OPF parser previously read only that first element and dropped every other `dc:title` on the floor.

### Identified collections

A collection can be identified rather than named: EPUB refines `belongs-to-collection` with `dcterms:identifier` (whose scheme an `identifier-type` refinement can state), and catalogs such as Google Books know a series by id alone — its volumes payload has `seriesId` and `orderNumber` but never the series name.

So `ResolvedCollection.name` becomes optional next to a new `identifiers`. The same relaxation lets a ComicInfo `Number`/`Count` survive when the sidecar states no `Series`, which `resolveComicInfo` dropped entirely before.

### Deliberately out

A non-numeric position label (ComicInfo allows `Number` to be `"Annual"` or `"½"`) has no EPUB twin — `group-position` is numeric — so it stays out of the generic model. `comic.*` is where it would belong.

### Breaking (semver major)

- `ResolvedCollection.name` is now optional
- `OpfMetadata.title` is replaced by `OpfMetadata.titles`
- the mapping tables accept a list of homes (`ResolvedMetadataHomes`)

Docs updated in `gitbook/archive-reader/resolved-metadata.md`. `@prose-reader/archive-reader` 247 tests pass; `metadata-fetcher` and `streamer` unaffected and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)