### PR TITLE
Show playground titles as the catalog states them

### DIFF
--- a/apps/metadata-fetcher-api/src/playground/playground.html
+++ b/apps/metadata-fetcher-api/src/playground/playground.html
@@ -70,6 +70,7 @@
   .match.accepted { border-left-color: var(--ok); }
   .match img { grid-row: 1 / span 3; width: 62px; border-radius: 4px; background: var(--line); }
   .match h2 { grid-column: 2; font-size: 1rem; margin: 0; }
+  .subtitle { grid-column: 2; font-size: 0.92rem; margin: 0.1rem 0 0; opacity: 0.85; }
   .titles { grid-column: 2; color: var(--muted); font-size: 0.86rem; margin: 0.15rem 0 0; }
   .meta { grid-column: 2; color: var(--muted); font-size: 0.82rem; margin: 0.2rem 0 0; }
   .meta a { color: inherit; }

--- a/apps/metadata-fetcher-api/src/playground/playground.js
+++ b/apps/metadata-fetcher-api/src/playground/playground.js
@@ -67,28 +67,67 @@ const renderMatch = (match) => {
   }
 
   const titles = metadata.titles ?? []
+  const [mainTitle, ...otherTitles] = titles
 
-  card.append(el("h2", null, titles[0]?.value ?? "(untitled)"))
+  // titles exactly as the catalog states them: nothing joined, nothing
+  // reordered, the subtitle on its own line rather than glued onto the title
+  card.append(el("h2", null, mainTitle?.value ?? "(untitled)"))
 
-  const otherTitles = (metadata.titles ?? [])
-    .slice(1)
-    .map((title) =>
-      title.type ? `${title.value} (${title.type})` : title.value,
+  const subtitles = otherTitles.filter(({ type }) => type === "subtitle")
+  const alternates = otherTitles.filter(({ type }) => type !== "subtitle")
+
+  if (subtitles.length > 0) {
+    card.append(
+      el("p", "subtitle", subtitles.map(({ value }) => value).join(" · ")),
     )
-
-  if (otherTitles.length > 0) {
-    card.append(el("p", "titles", otherTitles.join(" · ")))
   }
 
-  const series = (metadata.belongsTo?.series ?? [])
-    .map((entry) =>
-      [entry.name, entry.position !== undefined && `#${entry.position}`]
-        .filter(Boolean)
-        .join(" "),
+  if (alternates.length > 0) {
+    card.append(
+      el(
+        "p",
+        "titles",
+        alternates
+          .map(({ value, type }) => (type ? `${value} (${type})` : value))
+          .join(" · "),
+      ),
     )
-    .filter(Boolean)
+  }
 
-  if (series.length > 0) card.append(el("p", "titles", series.join(" · ")))
+  const collections = [
+    ...(metadata.belongsTo?.series ?? []).map((entry) => ({
+      entry,
+      label: "series",
+    })),
+    ...(metadata.belongsTo?.collection ?? []).map((entry) => ({
+      entry,
+      label: "collection",
+    })),
+  ].map(({ entry, label }) => {
+    // a catalog can identify a series without naming it — Google states only
+    // a series id — so the number stands on its own when that is all there is
+    const identifier = entry.identifiers?.[0]
+    const position =
+      entry.position === undefined
+        ? undefined
+        : entry.total === undefined
+          ? `#${entry.position}`
+          : `#${entry.position} of ${entry.total}`
+
+    return [
+      entry.name ?? label,
+      position,
+      entry.name === undefined && identifier
+        ? `${identifier.scheme}:${identifier.value}`
+        : undefined,
+    ]
+      .filter(Boolean)
+      .join(" · ")
+  })
+
+  if (collections.length > 0) {
+    card.append(el("p", "titles", collections.join(" · ")))
+  }
 
   const meta = el("p", "meta")
   const verdict = match.accepted ? "accepted" : "rejected"


### PR DESCRIPTION
A card rendered the first title and hung every other one behind a parenthesised type, so a title and its subtitle ran together on one line — `Much to Blame, Vol. 1 of 3` followed by `A Tale (Classic Reprint) (subtitle)` — and a volume or issue number was nowhere to be seen.

Now a card reads like a listing:

- **main title** — the first stated title, verbatim
- **subtitle** on its own line, unlabelled, since that is what a subtitle is
- **remaining typed titles** (`short`, `edition`, `expanded`…) keep their type, being the unusual case
- **series / collection** on its own line: name, position (`#1`, or `#1 of 6` when the total is known), and the identifier when a catalog names no series — which is exactly how Google states one

### Verified against the live API

`Ebb6DQAAQBAJ` renders as:

```
BLAME!
series · #1 · GoogleBooks:z5f3GgAAABA5jM
1.00 ACCEPTED · googleBooks · Tsutomu Nihei · edition: 2016, Kodansha Comics · 408 pages · en
```

and a Google search hit renders its subtitle as a second line:

```
Much to Blame, Vol. 1 of 3
A Tale (Classic Reprint)
0.90 ACCEPTED · googleBooks · edition: 2016-11-12, Forgotten Books · 304 pages · en
```

One thing worth knowing that surfaced while checking this: Google returns `seriesInfo` **only on a single-volume lookup**, not in search results. So the series line appears for an exact Google Books id lookup and stays absent for title searches — the data simply isn't in the search payload.

Playground only; no library change. 35 API tests pass, tsc clean across 8 projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)