### PR TITLE
feat(metadata): resolve aggregate ratings from catalogs and ComicInfo

### DIFF
--- a/apps/metadata-fetcher-api/src/playground/playground.js
+++ b/apps/metadata-fetcher-api/src/playground/playground.js
@@ -38,6 +38,15 @@ const describePublication = (label, publication) => {
   return details.length > 0 ? `${label}: ${details.join(", ")}` : undefined
 }
 
+// the scale is stated because a bare "3.96" reads as a score out of anything
+const describeRating = (rating) => {
+  if (typeof rating?.value !== "number") return undefined
+
+  const mean = `${rating.value.toFixed(1)}/5`
+
+  return rating.count !== undefined ? `${mean} (${rating.count})` : mean
+}
+
 const describe = (metadata) =>
   [
     (metadata.contributors ?? [])
@@ -46,6 +55,7 @@ const describe = (metadata) =>
     describePublication("original", metadata.publication?.original),
     describePublication("edition", metadata.publication?.edition),
     metadata.numberOfPages && `${metadata.numberOfPages} pages`,
+    describeRating(metadata.aggregateRating),
     metadata.languages?.join("/"),
   ]
     .filter(Boolean)

--- a/gitbook/archive-reader/resolved-metadata.md
+++ b/gitbook/archive-reader/resolved-metadata.md
@@ -65,6 +65,8 @@ type ResolvedMetadata = {
   renditionSpread?: "none" | "landscape" | "portrait" | "both" | "auto"
   /** declared count, else counted page-like pages; `resolveArchive` only when counted */
   numberOfPages?: number
+  /** aggregate community score, 0–5 (schema.org `aggregateRating`) */
+  aggregateRating?: { value: number; count?: number }
   identifiers?: {
     value: string
     scheme: "ISBN" | "GTIN" | "DOI" | "GoogleBooks" |
@@ -92,6 +94,17 @@ Two fields are resolved for the whole **container**, not just its descriptive si
 
 - **`cover`** — the OPF-declared cover image (EPUB 3 `cover-image` property, the EPUB 2 `<meta name="cover">` convention, or a `cover`-ish image id), rebased onto a container-relative `uri` (`confidence: "derived"`); else the first image of the reading order for image-content containers — comics, image archives, synthetic image-spine OPFs such as `createArchiveFromUrls` lists (`confidence: "assumed"`). It stays absent when nothing image-like is a reading resource: an authored reflowable EPUB (text spine, so an interior illustration is never promoted) or an audiobook/video archive has no cover — a container with no cover of its own is exactly the case [metadata-fetcher](../metadata-fetcher/README.md) answers, with an absolute url into the catalog's cover service.
 - **`numberOfPages`** — the declared ComicInfo `PageCount`, else the count of page-like reading-order items (images and fixed-layout documents). Reflowable documents are not pages, and audio/video tracks are not pages, so both are excluded: a reflowable book or an audiobook has no page count.
+
+### Aggregate rating
+
+`aggregateRating` is an aggregate community score on a **0–5 star scale** — the scale every source stating one uses (ComicInfo `CommunityRating`, and the catalogs behind [metadata-fetcher](../metadata-fetcher/README.md)). A source on another scale is rescaled by its resolver, exactly like MARC language codes and W3C-DTF dates; which source stated it is already structural (`sources.*` here, `providerId` on a fetched match), so the original scale is never needed to interpret the value. `count` is the number of ratings the mean is over, absent when the source doesn't state one — ComicInfo never does.
+
+A score outside 0–5, or one announced over zero ratings, is dropped instead of passed on: it would render as a real star count.
+
+Two things deliberately do not land here:
+
+- **EPUB has no rating.** The specification defines no rating property — not in DCMES, not in the package metadata vocabulary — so an OPF contributes none. An authored one (`calibre:rating`, or a `schema:aggregateRating` meta through the reserved `schema` prefix) arrives verbatim in `properties`.
+- **A personal score is not an aggregate.** calibre's `calibre:rating` is one owner's own rating on its own 0–10 scale: a different fact about a different subject, so it stays in `properties` rather than being folded in.
 
 ### Publication details
 
@@ -124,7 +137,7 @@ When several sources are present, `resolveMetadata` merges field-wise:
 | `identifiers` | concatenated, OPF first (identifier systems coexist) |
 | `cover` | OPF-declared cover, else the first-image fallback for image-content containers (`resolveArchive` only) |
 | `numberOfPages` | declared ComicInfo `PageCount`, else the counted page-like reading-order items (`resolveArchive` only) |
-| corners (`comicInfo`, `apple`, `kobo`) and single-source fields (`rights`, `properties`) | from their only producer |
+| corners (`comicInfo`, `apple`, `kobo`) and single-source fields (`rights`, `properties`, `aggregateRating`) | from their only producer |
 
 ## Mapping tables
 
@@ -160,7 +173,7 @@ These mirror the compile-enforced tables shipped next to each resolver — the l
 | `Volume` | `comicInfo.volume` | numeric |
 | `Format` | `comicInfo.format` | |
 | `AgeRating` | `comicInfo.ageRating` | |
-| `CommunityRating` | `comicInfo.communityRating` | numeric |
+| `CommunityRating` | `aggregateRating` | the schema's 0–5 mean, already the shared scale; no count is stated, and a value out of range is dropped |
 | `Notes` | `comicInfo.notes` | |
 | `Review` | `comicInfo.review` | |
 | `Web` | `comicInfo.web`, `identifiers` | whitespace-split reference list; valid absolute HTTP(S) values also become scheme `URL` identifiers |

--- a/gitbook/metadata-fetcher/README.md
+++ b/gitbook/metadata-fetcher/README.md
@@ -170,6 +170,7 @@ The rules:
 - **Confirmed identity settles it.** An agreeing ISBN or GTIN pins the score to `1` whatever else disagrees, and a provider-confirmed shared identifier does the same when both sides state the same non-`Unknown` scheme. An `Unknown` raw value is not decisive because it could collide with another catalog's identifier. A *contradicting* ISBN or GTIN scores `0`, which sinks a plausible-looking wrong edition. Disjoint provider-specific identifier lists are not treated as contradictions: catalogs naturally use different id spaces. ISBN-10 and ISBN-13 of the same book compare equal (`toIsbn13` is exported).
 - **Comparisons are fuzzy where the world is.** Titles compare on character bigrams, against both the candidate's main title and that title composed with its `subtitle` entry — a book states `Dune: A Novel` in one `dc:title` where a catalog splits it in two, and only the comparison string is composed, never the returned metadata. The subtitle asymmetry is repaired on top (`Dune` ≡ `Dune: a novel`, but `Dune: Book One` ≠ `Dune: Messiah`). An explicit conflicting volume, part, or book number makes the title score `0` (`Vol. I` ≠ `vol. 2`) — in **any** compared form, so a bare `Irina` cannot launder the candidate's own `Vol. 1` against a query for `Vol. 2`, and a number the query states in its title is also compared against the candidate's series `position`, where a catalog keeps the same fact. Names compare on their token set (`Herbert, Frank` ≡ `Frank Herbert`); diacritics and punctuation are folded (`Les Misérables` ≡ `Les Miserables`); languages compare on their primary subtag (`en-US` ≡ `en`).
 - **Flat publication evidence uses the best candidate value.** `publisher` and `publishedYear` compare against both the candidate's original and edition publication details when present; the closest value supplies the single signal.
+- **A rating is never evidence.** `aggregateRating` is returned but deliberately not scored: how much a crowd liked a book says nothing about whether it is *this* book, and a popular edition must not outrank the right one.
 
 `minScore` (default `0.5`) decides which matches are `accepted`. Rejected matches are **kept and ranked**, not dropped: "the catalog found three books, none convincing" is an answer, and it is exactly what a "did you mean?" picker renders.
 
@@ -238,6 +239,8 @@ Each candidate remains a `ResolvedMetadata`, so it can be handled with the same 
 {% hint style="info" %}
 A remote `cover.uri` is an **absolute url**, not a container-relative uri: a catalog addresses its cover in its own space and there is nothing to rebase it onto. `cover.confidence` is `derived` — the catalog declares it.
 {% endhint %}
+
+`aggregateRating` is each provider's own crowd, normalized to the shared 0–5 scale — Google's mean and Open Library's are different populations of readers, not two measurements of one number, so a picker showing both should attribute them (`match.providerId`) rather than average them. It is also the most volatile thing in a persisted `FetchedMetadata`: a title, an ISBN and a page count do not move, a rating does. Refresh it on its own schedule, or treat a cached one as indicative.
 
 ## Providers
 
@@ -329,12 +332,13 @@ Each request makes at most three total attempts. Network failures and HTTP `500`
 | `description` | `description` | Google may provide simple HTML formatting |
 | `industryIdentifiers` | `identifiers` | ISBN schemes normalize to `ISBN`; every announced identifier is retained |
 | `pageCount` | `numberOfPages` | |
+| `averageRating`, `ratingsCount` | `aggregateRating` | Google's mean is already on the shared 0–5 scale (it rounds to a half star); a count alone states no rating, and a mean over zero ratings is dropped |
 | `categories` | `subjects` | deduped and capped at 25 |
 | `language` | `languages` | Google's best ISO 639-1 language |
 | `imageLinks` | `cover` | largest announced size preferred; upgraded to HTTPS while Google's query parameters are preserved because changing them can yield a placeholder |
 | `canonicalVolumeLink`, then `infoLink` | match `url` | upgraded to HTTPS; a stable Google Books URL is synthesized from `id` when absent |
 
-Google-specific values without a cross-format home (ratings, access and sale data, and so on) remain available on `match.raw` when `includeRaw` is enabled.
+Google-specific values without a cross-format home (access and sale data, reading-mode flags, and so on) remain available on `match.raw` when `includeRaw` is enabled.
 
 ### Open Library
 
@@ -366,6 +370,7 @@ const provider = createOpenLibraryProvider({
 | `language` | `languages` | MARC 21 → BCP 47 (`eng` → `en`); unknown codes pass through, `und`/`mul`/`zxx` are dropped |
 | `subject` | `subjects` | capped at the first 25 — a popular work carries hundreds, most of them long-tail noise |
 | `number_of_pages_median` | `numberOfPages` | |
+| `ratings_average`, `ratings_count` | `aggregateRating` | the catalog's raw 0–5 mean of the *work*'s ratings, unrounded. `ratings_sortable` is deliberately not mapped: it is Open Library's internal ranking key, not a rating it states |
 | `cover_i` | `cover` | absolute url on the cover service, `confidence: "derived"` |
 | `id_project_gutenberg` | `identifiers` | scheme `ProjectGutenberg`; an exact lookup also echoes the book's original Gutenberg URL so the shared scorer can recognize the agreement |
 | `key` | `identifiers` | scheme `OpenLibrary`, e.g. `/works/OL893415W`; also `id` and `url` on the match |

--- a/packages/archive-reader/src/index.ts
+++ b/packages/archive-reader/src/index.ts
@@ -111,6 +111,7 @@ export type {
   KnownMetadataIdentifierScheme,
   MetadataIdentifier,
   MetadataIdentifierScheme,
+  ResolvedAggregateRating,
   ResolvedAppleMetadata,
   ResolvedCollection,
   ResolvedComicInfoMetadata,

--- a/packages/archive-reader/src/metadata/comicInfo/resolve.test.ts
+++ b/packages/archive-reader/src/metadata/comicInfo/resolve.test.ts
@@ -354,7 +354,6 @@ describe("resolveComicInfo", () => {
       volume: 3,
       format: "TPB",
       ageRating: "Teen",
-      communityRating: 4.5,
       notes: "scanned",
       review: "great",
       web: ["https://a.example", "https://b.example"],
@@ -364,6 +363,32 @@ describe("resolveComicInfo", () => {
       teams: ["Team A"],
       locations: ["City"],
     })
+  })
+
+  it("promotes CommunityRating to the shared aggregate rating, countless", () => {
+    const parsed = parseComicInfo(
+      comicInfoWrap("<CommunityRating>4.5</CommunityRating>"),
+    )
+    const resolved = resolveComicInfo(parsed)
+
+    expect(resolved.aggregateRating).toEqual({ value: 4.5 })
+    expect(resolved.comicInfo).toBeUndefined()
+  })
+
+  it("drops a CommunityRating the schema's 0–5 range cannot hold", () => {
+    const above = parseComicInfo(
+      comicInfoWrap("<CommunityRating>8</CommunityRating>"),
+    )
+    const negative = parseComicInfo(
+      comicInfoWrap("<CommunityRating>-1</CommunityRating>"),
+    )
+    const wording = parseComicInfo(
+      comicInfoWrap("<CommunityRating>great</CommunityRating>"),
+    )
+
+    expect(resolveComicInfo(above).aggregateRating).toBeUndefined()
+    expect(resolveComicInfo(negative).aggregateRating).toBeUndefined()
+    expect(resolveComicInfo(wording).aggregateRating).toBeUndefined()
   })
 
   it("maps PageCount, Summary and Imprint into the shared vocabulary", () => {

--- a/packages/archive-reader/src/metadata/comicInfo/resolve.ts
+++ b/packages/archive-reader/src/metadata/comicInfo/resolve.ts
@@ -1,5 +1,6 @@
 import type { Exhaustive } from "../../types/exhaustive.ts"
 import type {
+  ResolvedAggregateRating,
   ResolvedCollection,
   ResolvedComicInfoMetadata,
   ResolvedContributor,
@@ -213,7 +214,6 @@ const comicCornerFromComicInfo = (
     volume: parseNonNegativeInt(info.Volume),
     format: trimToUndefined(info.Format),
     ageRating: trimToUndefined(info.AgeRating),
-    communityRating: parseDecimal(info.CommunityRating),
     notes: trimToUndefined(info.Notes),
     review: trimToUndefined(info.Review),
     web: emptyToUndefined(webValues),
@@ -227,6 +227,19 @@ const comicCornerFromComicInfo = (
   } satisfies Exhaustive<ResolvedComicInfoMetadata>)
 
   return Object.keys(corner).length > 0 ? corner : undefined
+}
+
+/**
+ * `CommunityRating` is already the schema's 0–5 star mean, so it needs no
+ * rescaling — only the range check the field promises. The sidecar states no
+ * number of ratings.
+ */
+const aggregateRatingFromComicInfo = (
+  info: ComicInfo,
+): ResolvedAggregateRating | undefined => {
+  const value = parseDecimal(info.CommunityRating)
+
+  return value !== undefined && value <= 5 ? { value } : undefined
 }
 
 const belongsToFromComicInfo = (
@@ -279,6 +292,7 @@ export const resolveComicInfo = (info: ComicInfo): ResolvedMetadata => {
     contributors: emptyToUndefined(contributorsFromComicInfo(info)),
     readingDirection: readingDirection(info),
     numberOfPages: parseNonNegativeInt(info.PageCount),
+    aggregateRating: aggregateRatingFromComicInfo(info),
     identifiers: emptyToUndefined(identifiers),
     belongsTo: belongsToFromComicInfo(info),
     comicInfo: comicCornerFromComicInfo(info, web),

--- a/packages/archive-reader/src/resolveMetadata.ts
+++ b/packages/archive-reader/src/resolveMetadata.ts
@@ -36,8 +36,8 @@ export type ResolveMetadataSources = {
  * - `identifiers` concatenates (OPF first) — different identifier systems
  *   coexist rather than compete.
  * - Format-scoped corners (`comicInfo`, `apple`, `kobo`) and single-source
- *   fields (`rights`, `properties`, `numberOfPages`…) come from
- *   their only producer.
+ *   fields (`rights`, `properties`, `numberOfPages`, `aggregateRating`…) come
+ *   from their only producer.
  */
 export const resolveMetadata = (
   sources: ResolveMetadataSources,
@@ -86,6 +86,7 @@ export const resolveMetadata = (
     renditionFlow: opf?.renditionFlow,
     renditionSpread: opf?.renditionSpread,
     numberOfPages: comicInfo?.numberOfPages,
+    aggregateRating: comicInfo?.aggregateRating,
     identifiers: identifiers.length > 0 ? identifiers : undefined,
     belongsTo: opf?.belongsTo ?? comicInfo?.belongsTo,
     properties: opf?.properties,

--- a/packages/archive-reader/src/types/resolvedMetadata.ts
+++ b/packages/archive-reader/src/types/resolvedMetadata.ts
@@ -190,6 +190,28 @@ export type ResolvedProperty = {
 }
 
 /**
+ * An aggregate community score for the publication (schema.org
+ * `aggregateRating`), on a **0–5 star scale** — the scale every source we read
+ * one from states it on. A source using another scale is rescaled by its
+ * resolver, like MARC languages and W3C-DTF dates; which source stated it is
+ * already structural (`sources.*` on a resolved archive, `providerId` on a
+ * fetched match), so nothing is lost by not carrying the original scale.
+ *
+ * Deliberately *aggregate* only: one owner's personal score — calibre's
+ * `calibre:rating`, on its own 0–10 scale — is a different fact about a
+ * different subject, and stays in {@link ResolvedMetadata.properties}.
+ *
+ * A score outside 0–5, or one announced over zero ratings, is dropped rather
+ * than passed on: it would render as a real star count.
+ */
+export type ResolvedAggregateRating = {
+  /** Mean score, `0` to `5`. */
+  readonly value: number
+  /** How many ratings the mean is over; absent when the source doesn't say. */
+  readonly count?: number
+}
+
+/**
  * ComicInfo-scoped concepts with no cross-format twin. Normalized (typed,
  * parsed), but deliberately not renamed into pseudo-generic fields.
  */
@@ -204,8 +226,6 @@ export type ResolvedComicInfoMetadata = {
   readonly format?: string
   /** `AgeRating` verbatim (trimmed); the schema enum is loose in the wild. */
   readonly ageRating?: string
-  /** `CommunityRating`, when numeric (schema range 0–5). */
-  readonly communityRating?: number
   readonly notes?: string
   readonly review?: string
   /** `Web`, split on whitespace; valid HTTP(S) values also become URL identifiers. */
@@ -368,6 +388,14 @@ export type ResolvedMetadata = {
    * `resolveArchive`.
    */
   readonly numberOfPages?: number
+  /**
+   * Aggregate community score on a 0–5 scale (see
+   * {@link ResolvedAggregateRating}). ComicInfo `CommunityRating`, which states
+   * no count; a catalog's average and count when the metadata comes from
+   * `@prose-reader/metadata-fetcher`. The OPF contributes none: EPUB defines no
+   * rating property, so an authored one arrives through {@link properties}.
+   */
+  readonly aggregateRating?: ResolvedAggregateRating
   /**
    * Raw identifier values, trimmed. OPF contributes every `dc:identifier`,
    * retaining its announced EPUB 2 scheme or EPUB 3 `identifier-type`

--- a/packages/metadata-fetcher/src/providers/googleBooks/createGoogleBooksProvider.test.ts
+++ b/packages/metadata-fetcher/src/providers/googleBooks/createGoogleBooksProvider.test.ts
@@ -11,9 +11,11 @@ const DUNE_VOLUME = {
     authors: ["Frank Herbert"],
     industryIdentifiers: [{ type: "ISBN_13", identifier: "9780441013593" }],
     averageRating: 4.5,
+    ratingsCount: 128,
     canonicalVolumeLink:
       "http://books.google.com/books/about/Dune.html?id=zyTCAlFPjgYC",
   },
+  saleInfo: { saleability: "FOR_SALE" },
 }
 
 const jsonResponse = (payload: unknown, status = 200) =>
@@ -79,10 +81,11 @@ describe("createGoogleBooksProvider", () => {
         identifiers: expect.arrayContaining([
           { value: "zyTCAlFPjgYC", scheme: "GoogleBooks" },
         ]),
+        aggregateRating: { value: 4.5, count: 128 },
       },
     })
     expect(candidate?.raw).toMatchObject({
-      volumeInfo: { averageRating: 4.5 },
+      saleInfo: { saleability: "FOR_SALE" },
     })
     expect(scoreMetadataCandidate(input, candidate?.metadata ?? {}).score).toBe(
       1,

--- a/packages/metadata-fetcher/src/providers/googleBooks/parse.ts
+++ b/packages/metadata-fetcher/src/providers/googleBooks/parse.ts
@@ -50,6 +50,9 @@ export type GoogleBooksVolumeInfo = {
   readonly industryIdentifiers?: ReadonlyArray<GoogleBooksIndustryIdentifier>
   readonly pageCount?: number
   readonly categories?: ReadonlyArray<string>
+  /** Mean review rating; Google states it on a 1–5 scale, rounded to a half. */
+  readonly averageRating?: number
+  readonly ratingsCount?: number
   readonly language?: string
   readonly imageLinks?: GoogleBooksImageLinks
   readonly infoLink?: string
@@ -151,6 +154,8 @@ const parseVolumeInfo = (
     industryIdentifiers: parseIndustryIdentifiers(volumeInfo),
     pageCount: readNumber(volumeInfo, "pageCount"),
     categories: readStringArray(volumeInfo, "categories"),
+    averageRating: readNumber(volumeInfo, "averageRating"),
+    ratingsCount: readNumber(volumeInfo, "ratingsCount"),
     language: readString(volumeInfo, "language"),
     imageLinks: parseImageLinks(volumeInfo),
     infoLink: readString(volumeInfo, "infoLink"),

--- a/packages/metadata-fetcher/src/providers/googleBooks/resolve.test.ts
+++ b/packages/metadata-fetcher/src/providers/googleBooks/resolve.test.ts
@@ -92,6 +92,8 @@ describe("resolveGoogleBooksVolume", () => {
           ],
           pageCount: 412,
           categories: ["Fiction", "Science fiction"],
+          averageRating: 4.5,
+          ratingsCount: 128,
           language: "en",
           imageLinks: {
             thumbnail:
@@ -112,6 +114,7 @@ describe("resolveGoogleBooksVolume", () => {
       subjects: ["Fiction", "Science fiction"],
       contributors: [{ name: "Frank Herbert", roles: ["author"] }],
       numberOfPages: 412,
+      aggregateRating: { value: 4.5, count: 128 },
       identifiers: [
         { value: "zyTCAlFPjgYC", scheme: "GoogleBooks" },
         { value: "0441013597", scheme: "ISBN" },
@@ -250,6 +253,20 @@ describe("resolveGoogleBooksVolume", () => {
         volumeInfo: { categories: [categories[0] ?? "", ...categories] },
       }).subjects,
     ).toHaveLength(GOOGLE_BOOKS_MAX_SUBJECTS)
+  })
+
+  it("keeps a rating Google states without a count", () => {
+    expect(
+      resolveGoogleBooksVolume({ volumeInfo: { averageRating: 3 } })
+        .aggregateRating,
+    ).toEqual({ value: 3 })
+  })
+
+  it("states no rating from a count alone", () => {
+    expect(
+      resolveGoogleBooksVolume({ volumeInfo: { ratingsCount: 128 } })
+        .aggregateRating,
+    ).toBeUndefined()
   })
 
   it("stays sparse for an empty volume", () => {

--- a/packages/metadata-fetcher/src/providers/googleBooks/resolve.ts
+++ b/packages/metadata-fetcher/src/providers/googleBooks/resolve.ts
@@ -7,6 +7,7 @@ import {
   type ResolvedMetadata,
   type ResolvedTitle,
 } from "@prose-reader/archive-reader"
+import { resolvedAggregateRating } from "../../utils/aggregateRating.ts"
 import { omitUndefined } from "../../utils/omitUndefined.ts"
 import { GOOGLE_BOOKS_IDENTIFIER_SCHEME } from "./identifier.ts"
 import type {
@@ -169,6 +170,8 @@ export const resolveGoogleBooksVolume = (
     industryIdentifiers,
     pageCount,
     categories,
+    averageRating,
+    ratingsCount,
     language,
     imageLinks,
     seriesInfo,
@@ -229,6 +232,7 @@ export const resolveGoogleBooksVolume = (
     subjects: emptyToUndefined(subjects),
     contributors: resolvedContributors(authors ?? []),
     numberOfPages: pageCount,
+    aggregateRating: resolvedAggregateRating(averageRating, ratingsCount),
     identifiers,
     cover,
   })

--- a/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.test.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.test.ts
@@ -57,6 +57,9 @@ describe("createOpenLibraryProvider", () => {
     expect(url.searchParams.get("isbn")).toBe("9780441013593")
     expect(url.searchParams.get("limit")).toBe("5")
     expect(url.searchParams.get("fields")).toContain("number_of_pages_median")
+    // ratings are only returned when explicitly requested
+    expect(url.searchParams.get("fields")).toContain("ratings_average")
+    expect(url.searchParams.get("fields")).toContain("ratings_count")
     // the catalog confirmed the identity, so the record carries it
     expect(candidates[0]?.metadata.identifiers).toContainEqual({
       value: "9780441013593",

--- a/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/createOpenLibraryProvider.ts
@@ -32,6 +32,8 @@ const SEARCH_FIELDS = [
   "language",
   "subject",
   "number_of_pages_median",
+  "ratings_average",
+  "ratings_count",
   "cover_i",
   "id_project_gutenberg",
 ].join(",")

--- a/packages/metadata-fetcher/src/providers/openLibrary/parse.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/parse.ts
@@ -25,6 +25,9 @@ export type OpenLibraryDoc = {
   readonly language?: ReadonlyArray<string>
   readonly subject?: ReadonlyArray<string>
   readonly number_of_pages_median?: number
+  /** Mean of the work's star ratings, on the catalog's 1–5 scale. */
+  readonly ratings_average?: number
+  readonly ratings_count?: number
   /** Cover id, addressing `covers.openlibrary.org`. */
   readonly cover_i?: number
   /** Project Gutenberg ebook ids attached to the work's editions. */
@@ -40,6 +43,8 @@ const parseDoc = (record: Record<string, unknown>): OpenLibraryDoc => ({
   language: readStringArray(record, "language"),
   subject: readStringArray(record, "subject"),
   number_of_pages_median: readNumber(record, "number_of_pages_median"),
+  ratings_average: readNumber(record, "ratings_average"),
+  ratings_count: readNumber(record, "ratings_count"),
   cover_i: readNumber(record, "cover_i"),
   id_project_gutenberg: readStringArray(record, "id_project_gutenberg"),
 })

--- a/packages/metadata-fetcher/src/providers/openLibrary/resolve.test.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/resolve.test.ts
@@ -84,6 +84,8 @@ describe("resolveOpenLibraryDoc", () => {
           language: ["eng"],
           subject: ["Science fiction"],
           number_of_pages_median: 412,
+          ratings_average: 3.9574468,
+          ratings_count: 47,
           cover_i: 8188413,
           id_project_gutenberg: ["1965"],
         },
@@ -96,6 +98,7 @@ describe("resolveOpenLibraryDoc", () => {
       languages: ["en"],
       subjects: ["Science fiction"],
       numberOfPages: 412,
+      aggregateRating: { value: 3.9574468, count: 47 },
       cover: {
         uri: "https://covers.openlibrary.org/b/id/8188413-L.jpg",
         mediaType: "image/jpeg",

--- a/packages/metadata-fetcher/src/providers/openLibrary/resolve.ts
+++ b/packages/metadata-fetcher/src/providers/openLibrary/resolve.ts
@@ -3,6 +3,7 @@ import type {
   MetadataIdentifier,
   ResolvedMetadata,
 } from "@prose-reader/archive-reader"
+import { resolvedAggregateRating } from "../../utils/aggregateRating.ts"
 import { omitUndefined } from "../../utils/omitUndefined.ts"
 import { marcLanguageToBcp47 } from "./marcLanguage.ts"
 import type { OpenLibraryDoc } from "./parse.ts"
@@ -55,6 +56,8 @@ export const resolveOpenLibraryDoc = (
     first_publish_year,
     subject,
     number_of_pages_median,
+    ratings_average,
+    ratings_count,
     cover_i,
     id_project_gutenberg,
     ...unhandled
@@ -122,6 +125,7 @@ export const resolveOpenLibraryDoc = (
       })),
     ),
     numberOfPages: number_of_pages_median,
+    aggregateRating: resolvedAggregateRating(ratings_average, ratings_count),
     identifiers: emptyToUndefined(identifiers),
   })
 }

--- a/packages/metadata-fetcher/src/utils/aggregateRating.test.ts
+++ b/packages/metadata-fetcher/src/utils/aggregateRating.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+import { resolvedAggregateRating } from "./aggregateRating.ts"
+
+describe("resolvedAggregateRating", () => {
+  it("keeps a catalog's 0–5 mean and its count", () => {
+    expect(resolvedAggregateRating(3.9574468, 47)).toEqual({
+      value: 3.9574468,
+      count: 47,
+    })
+    expect(resolvedAggregateRating(0, 3)).toEqual({ value: 0, count: 3 })
+    expect(resolvedAggregateRating(5, 1)).toEqual({ value: 5, count: 1 })
+  })
+
+  it("states the mean alone when the source states no count", () => {
+    expect(resolvedAggregateRating(4.5, undefined)).toEqual({ value: 4.5 })
+  })
+
+  it("states nothing from a count alone", () => {
+    expect(resolvedAggregateRating(undefined, 47)).toBeUndefined()
+  })
+
+  it("drops a mean the 0–5 scale cannot hold", () => {
+    expect(resolvedAggregateRating(8, 47)).toBeUndefined()
+    expect(resolvedAggregateRating(-1, 47)).toBeUndefined()
+  })
+
+  it("drops a mean announced over zero ratings", () => {
+    expect(resolvedAggregateRating(4.5, 0)).toBeUndefined()
+  })
+
+  it("drops a count that is not a whole number of ratings, keeping the mean", () => {
+    expect(resolvedAggregateRating(4.5, 12.5)).toEqual({ value: 4.5 })
+    expect(resolvedAggregateRating(4.5, -3)).toEqual({ value: 4.5 })
+  })
+})

--- a/packages/metadata-fetcher/src/utils/aggregateRating.ts
+++ b/packages/metadata-fetcher/src/utils/aggregateRating.ts
@@ -1,0 +1,30 @@
+import type { ResolvedAggregateRating } from "@prose-reader/archive-reader"
+import { omitUndefined } from "./omitUndefined.ts"
+
+const MAX_VALUE = 5
+
+/**
+ * Builds the cross-format aggregate rating from a catalog's mean and count.
+ * Both Google Books and Open Library state the mean on a 1–5 star scale, which
+ * is the scale {@link ResolvedAggregateRating} promises, so neither needs
+ * rescaling — a source on another scale divides before calling this.
+ *
+ * A mean outside 0–5, a count that isn't a non-negative integer, and a mean
+ * announced over zero ratings are all dropped: a catalog contradicting itself
+ * would otherwise render as a real star count.
+ */
+export const resolvedAggregateRating = (
+  mean: number | undefined,
+  count: number | undefined,
+): ResolvedAggregateRating | undefined => {
+  if (mean === undefined || mean < 0 || mean > MAX_VALUE) return undefined
+
+  const ratings =
+    count !== undefined && Number.isInteger(count) && count >= 0
+      ? count
+      : undefined
+
+  if (ratings === 0) return undefined
+
+  return omitUndefined({ value: mean, count: ratings })
+}


### PR DESCRIPTION
## Why

EPUB defines no rating property — not in DCMES, not in the package metadata vocabulary — so nothing was missing on the spec side. But two of the three catalogs behind `metadata-fetcher` state a rating and neither reached a consumer:

- **Google Books** returns `volumeInfo.averageRating` / `ratingsCount`. Nobody parsed them; they only survived on `match.raw`, and only with `includeRaw`.
- **Open Library** exposes `ratings_average` / `ratings_count`, and the provider never asked for them (`fields=` omitted them entirely).

## The shape

```ts
aggregateRating?: { value: number; count?: number }   // value 0–5
```

schema.org's `aggregateRating`, trimmed to what our sources actually state. `bestRating`/`worstRating` are left out on purpose: every source that states a rating is on a 5-star scale, so `best` would be the constant `5` and would force a defensive `value / (best ?? 5)` on every consumer against a divisor that never varies. A source on another scale rescales in its own resolver — same as MARC languages and W3C-DTF dates — and provenance is already structural (`sources.*` on an archive, `providerId` on a match), so the original scale is never needed to interpret the value.

| Source | → | Notes |
| --- | --- | --- |
| Google Books `averageRating`, `ratingsCount` | `aggregateRating` | mean already on the shared scale (Google rounds to a half star) |
| Open Library `ratings_average`, `ratings_count` | `aggregateRating` | added to the requested `fields`; `ratings_sortable` deliberately not mapped — it is an internal ranking key, not a stated rating |
| ComicInfo `CommunityRating` | `aggregateRating` | promoted out of the `comicInfo` corner, no count |
| calibre `calibre:rating`, `schema:*` metas | `properties` | unchanged |

Guards live in one place (`resolvedAggregateRating`, mirrored for ComicInfo's own range check): a mean outside 0–5, a count that is not a whole number of ratings, and a mean announced over zero ratings are all dropped rather than passed on as a renderable star count.

Two deliberate non-changes:

- **A rating is never match evidence.** No new `MetadataMatchField`, no weight — how much a crowd liked a book says nothing about whether it is *this* book, and a popular edition must not outrank the right one.
- **A personal score is not an aggregate.** calibre's `calibre:rating` is one owner's own rating on its own 0–10 scale, so it stays in the open-world `properties` channel instead of being folded in.

## Breaking change

`ResolvedComicInfoMetadata.communityRating` is **removed** — read `metadata.aggregateRating.value` instead (same 0–5 number; no `count`, since the sidecar states none). The format-scoped corners are documented as the home for concepts with *no* cross-format twin, and `CommunityRating` now has one. Needs a semver major.

`FetchedMetadata.version` stays `5`: the field is purely additive there, which that field's own rule allows.

## Verification

- `npm run tsc` clean across all 8 projects; biome clean.
- Unit suites of every affected package pass: archive-reader 250, metadata-fetcher 155 + 12 new (`aggregateRating` guards, both provider resolvers), streamer 71, metadata-fetcher-api 35.
- Against the **live** Open Library API with the provider's exact new field list: `/works/OL893516W` returns `ratings_average: 3.9574468, ratings_count: 47` and resolves to `{ value: 3.9574468, count: 47 }`.
- End-to-end through the API app and its playground, which now shows the rating in each match's detail line (`4.0/5 (47)`), attributed per provider.

Not run to completion: the repo-wide Playwright reader e2e suite (stopped at 127/195, no failures). It exercises layout and navigation in browsers, and the streamer `Manifest` surface it depends on is untouched — the manifest only ever carried rendering fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
