### PR TITLE
fix(enhancer-search): escape regex metacharacters in search queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21466,6 +21466,9 @@
       "dependencies": {
         "@prose-reader/core": "^1.350.0"
       },
+      "devDependencies": {
+        "jsdom": "^29.0.0"
+      },
       "peerDependencies": {
         "rxjs": "*"
       }

--- a/packages/enhancer-search/package.json
+++ b/packages/enhancer-search/package.json
@@ -22,6 +22,9 @@
   "dependencies": {
     "@prose-reader/core": "^1.350.0"
   },
+  "devDependencies": {
+    "jsdom": "^29.0.0"
+  },
   "peerDependencies": {
     "rxjs": "*"
   },

--- a/packages/enhancer-search/src/search.test.ts
+++ b/packages/enhancer-search/src/search.test.ts
@@ -59,6 +59,16 @@ describe("searchInDocument", () => {
     expect(results).toEqual([{ cfi: "Whale@0" }, { cfi: "whale@0" }])
   })
 
+  it("matches characters through Unicode simple case folding", async () => {
+    // U+212A KELVIN SIGN case-folds to "k" only under Unicode folding, which
+    // the `u` flag enables.
+    const doc = createDoc(`<p>300K</p>`)
+
+    const results = await search(doc, "k")
+
+    expect(results).toEqual([{ cfi: "K@3" }])
+  })
+
   it("computes offsets against the original text, not its lowercased form", async () => {
     // "İ".toLowerCase() expands to two code units, which used to shift every
     // subsequent match index and push ranges out of bounds.

--- a/packages/enhancer-search/src/search.test.ts
+++ b/packages/enhancer-search/src/search.test.ts
@@ -1,0 +1,71 @@
+import type { Reader, SpineItem } from "@prose-reader/core"
+import { firstValueFrom } from "rxjs"
+import { describe, expect, it } from "vitest"
+import { searchInDocument } from "./search"
+
+// The real Reader/SpineItem are irrelevant here: searchInDocument only calls
+// reader.cfi.generateCfiFromRange with the ranges it found, so we echo the
+// range boundaries back as the "cfi" to assert on them.
+const reader = {
+  cfi: {
+    generateCfiFromRange: (range: Range) =>
+      `${(range.startContainer as Text).data.slice(range.startOffset, range.endOffset)}@${range.startOffset}`,
+  },
+  // biome-ignore lint/suspicious/noExplicitAny: minimal stub for test
+} as any as Reader
+
+// biome-ignore lint/suspicious/noExplicitAny: minimal stub for test
+const item = {} as any as SpineItem
+
+const createDoc = (body: string) =>
+  new DOMParser().parseFromString(
+    `<html><body>${body}</body></html>`,
+    "text/html",
+  )
+
+const search = (doc: Document, text: string) =>
+  firstValueFrom(searchInDocument(reader, item, doc, text))
+
+describe("searchInDocument", () => {
+  it("treats the query as literal text when it contains regex special characters", async () => {
+    const doc = createDoc(`<p>I love c++ and c# equally</p>`)
+
+    const results = await search(doc, "c++")
+
+    expect(results).toEqual([{ cfi: "c++@7" }])
+  })
+
+  it("does not treat regex metacharacters as wildcards", async () => {
+    const doc = createDoc(`<p>cat cut c.t</p>`)
+
+    const results = await search(doc, "c.t")
+
+    expect(results).toEqual([{ cfi: "c.t@8" }])
+  })
+
+  it("anchors the range to the actual match boundaries", async () => {
+    const doc = createDoc(`<p>this is the (end) of it</p>`)
+
+    const results = await search(doc, "the (end)")
+
+    expect(results).toEqual([{ cfi: "the (end)@8" }])
+  })
+
+  it("matches case-insensitively across nested elements", async () => {
+    const doc = createDoc(`<p>Whale ahead!</p><p>a <b>whale</b> of a time</p>`)
+
+    const results = await search(doc, "whale")
+
+    expect(results).toEqual([{ cfi: "Whale@0" }, { cfi: "whale@0" }])
+  })
+
+  it("computes offsets against the original text, not its lowercased form", async () => {
+    // "İ".toLowerCase() expands to two code units, which used to shift every
+    // subsequent match index and push ranges out of bounds.
+    const doc = createDoc(`<p>İstanbul is big</p>`)
+
+    const results = await search(doc, "big")
+
+    expect(results).toEqual([{ cfi: "big@12" }])
+  })
+})

--- a/packages/enhancer-search/src/search.ts
+++ b/packages/enhancer-search/src/search.ts
@@ -19,7 +19,6 @@ export type SearchResult = ResultItem[]
 const collectMatchingRanges = (
   node: Node,
   regexp: RegExp,
-  matchLength: number,
   rangeList: Range[],
 ) => {
   if (node.nodeName === `head`) return
@@ -34,11 +33,14 @@ const collectMatchingRanges = (
     }
 
     if (subNode.hasChildNodes()) {
-      collectMatchingRanges(subNode, regexp, matchLength, rangeList)
+      collectMatchingRanges(subNode, regexp, rangeList)
     }
 
     if (subNode.nodeType === 3) {
-      const content = (subNode as Text).data.toLowerCase()
+      // Match against the node data as-is: lowercasing here would shift match
+      // indices for characters whose lowercase form has a different length
+      // (e.g. İ), while the regexp already carries the `i` flag.
+      const content = (subNode as Text).data
       if (content) {
         let match: RegExpExecArray | null = null
         regexp.lastIndex = 0
@@ -48,7 +50,7 @@ const collectMatchingRanges = (
           if (match.index >= 0 && subNode.ownerDocument) {
             const range = subNode.ownerDocument.createRange()
             range.setStart(subNode, match.index)
-            range.setEnd(subNode, match.index + matchLength)
+            range.setEnd(subNode, match.index + match[0].length)
 
             rangeList.push(range)
           }
@@ -58,10 +60,16 @@ const collectMatchingRanges = (
   }
 }
 
+// The user query is literal text, not a pattern: metacharacters left
+// unescaped either throw at RegExp construction (`c++`) or match the wrong
+// content (`c.t`).
+const escapeRegExp = (text: string) =>
+  text.replace(/[.*+?^${}()|[\]\\]/g, `\\$&`)
+
 const searchNodeContainingText = (node: Node, text: string) => {
   const rangeList: Range[] = []
 
-  collectMatchingRanges(node, RegExp(`(${text})`, `gi`), text.length, rangeList)
+  collectMatchingRanges(node, RegExp(escapeRegExp(text), `gi`), rangeList)
 
   return rangeList
 }

--- a/packages/enhancer-search/src/search.ts
+++ b/packages/enhancer-search/src/search.ts
@@ -39,7 +39,8 @@ const collectMatchingRanges = (
     if (subNode.nodeType === 3) {
       // Match against the node data as-is: lowercasing here would shift match
       // indices for characters whose lowercase form has a different length
-      // (e.g. İ), while the regexp already carries the `i` flag.
+      // (e.g. İ), while the regexp already matches case-insensitively with
+      // Unicode simple case folding (`iu` flags).
       const content = (subNode as Text).data
       if (content) {
         let match: RegExpExecArray | null = null
@@ -69,7 +70,11 @@ const escapeRegExp = (text: string) =>
 const searchNodeContainingText = (node: Node, text: string) => {
   const rangeList: Range[] = []
 
-  collectMatchingRanges(node, RegExp(escapeRegExp(text), `gi`), rangeList)
+  // `u` widens the `i` flag to Unicode simple case folding (K/K, Deseret…).
+  // Characters only reachable through full case folding (İ → i̇) stay
+  // unmatched on purpose: mapping their ranges back to the original text
+  // would require a fold-index map on this hot path.
+  collectMatchingRanges(node, RegExp(escapeRegExp(text), `giu`), rangeList)
 
   return rangeList
 }

--- a/packages/enhancer-search/vite.config.ts
+++ b/packages/enhancer-search/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig((env) =>
   mergeConfig(libConfig(env), {
     plugins: [dts({ entryRoot: "src", include: ["src/**/*"] })],
     test: {
+      environment: "jsdom",
       coverage: {
         reportsDirectory: `./.test/coverage`,
       },


### PR DESCRIPTION
# The bug

`searchNodeContainingText` interpolated the user's query verbatim into a `RegExp`:

```ts
collectMatchingRanges(node, RegExp(`(${text})`, `gi`), text.length, rangeList)
```

Three observable failures:

1. **Queries with regex metacharacters silently return zero results for the whole book.** `search("c++")` throws `SyntaxError: Invalid regular expression` at construction. The throw is swallowed by the `catchError` in `index.ts` (and `report.error` is a no-op outside debug mode), so the user just sees no matches. Any query containing `+ ? ( ) [ ] * . $ ^ | \` is affected — `"what?"`, `"(a)"`, `"1+1"`…
2. **Metacharacters that survive construction match the wrong content.** `search("c.t")` matches `cat` and `cut`; `search("the (end)")` matches `"the end"` and therefore never finds the literal text `the (end)`.
3. **Ranges could be anchored at the wrong offsets.** The range end used `text.length` instead of the actual match length, and matching ran against a `toLowerCase()` copy of the node data — for characters whose lowercase form has a different length (e.g. `İ` → `i̇`), every subsequent match index shifts, producing ranges over the wrong characters or an `IndexSizeError` that again drops the whole spine item's results.

# The fix

- Escape the query before building the `RegExp` — the query is literal text, not a pattern.
- Match against the node data as-is; the regexp already carries the `i` flag, so lowercasing was redundant and offset-shifting.
- Anchor the range end to `match[0].length` instead of the query length.

No public surface changes. The `gitbook/enhancers/search.md` page is an empty stub, so no doc update applies.

# Verification

Added `packages/enhancer-search/src/search.test.ts` (jsdom environment, same setup as the `cfi` package). Before the fix, 4 of the 5 new tests fail exactly along the lines above (SyntaxError for `c++`, false positives for `c.t`, no match for `the (end)`, `IndexSizeError` for the `İ` document). After the fix all pass.

Gates run locally on the pinned Node 25: biome format ✓, biome lint ✓, build ✓, tsc ✓, unit tests for all 15 packages ✓. (The Playwright e2e suite could not run in this container — no webkit — but this change touches only the search enhancer's text matching, which that suite does not cover.)

# Other findings (not addressed in this PR)

Confirmed during this hunt, left for future runs:

- **`@prose-reader/cfi` generates non-spec text-node steps.** `generate.ts` computes text steps as `childNodes index + 1` instead of the spec's `2 × (preceding element siblings) + 1`, so a text node directly following an element gets an *even* step and resolves back to the wrong node (or fails). Executed trace: `<p><b>Bold</b>tail</p>` → `epubcfi(/4/2[p1]/2:3)` resolves to the `<b>` element instead of the text node.
- **`@prose-reader/cfi` `serialize()` corrupts offset-only range CFIs.** `parse()` clones the whole parent path into `start`/`end` for `,:5,:10` forms and `serialize()` writes the clone back verbatim: `serialize(parse("epubcfi(/6/4!/4/2/1,:5,:10)"))` → `epubcfi(/6/4!/4/2/1,/4/2/1:5,/4/2/1:10)`, which no longer resolves. `updateEpubCfiSpineItemref` (used by the cbz enhancer) round-trips through this and corrupts every such range.
- **Deleted annotations never leave the page.** In `SpineItemHighlights.ts` the stale-highlight predicate compares `itemIndex` (always equal, since the incoming stream is pre-filtered by item index in `ReaderHighlights.ts`), so deleted highlights are never destroyed; the removal line `this.highlights = this.highlights.splice(index, 1)` would also replace the array with the removed element if it ever ran.
- **EPUB3 nav TOC ignores `epub:type="toc"`.** `toc/nav.ts` takes the first `<nav>` via `descendantWithPath("body.nav.ol")`, so a book authored with `landmarks` or `page-list` before the toc nav gets the wrong TOC (executed against the repo's xmldoc). Relatedly, an unrecognized nav shape returns `[]`, which the truthy check in `resolveArchiveToc.ts` accepts, shadowing a valid NCX fallback.
- **Streamer returns HTTP 500 for non-well-formed `.xhtml`.** `calibreFixHook` parses every `.xhtml` with `XmlDocument` before checking it's a calibre cover; a parse throw (e.g. unescaped `&` in an href, unclosed `<img>`) propagates and the raw-blob fallback is never reached, so the chapter never renders.
- **`sortByTitleComparator` returns `1` for equal or prefix strings** (`cmp("chapter","chapter") === 1`), so sorts containing equal/prefix titles produce unstable, wrong orderings (executed). Public export of `@prose-reader/shared`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYuB19e7ifbJmDnBoF4Aqz)_