### PR TITLE
build(deps): bump tar from 7.5.11 to 7.5.22 via root override (critical security fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19154,7 +19154,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "apps/*",
     "packages/*"
   ],
+  "overrides": {
+    "tar": "^7.5.22"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.0.6",
     "@rolldown/plugin-babel": "^0.2.3",


### PR DESCRIPTION
## The update

**tar 7.5.11 → 7.5.22** (patch-level, security-motivated).

`npm audit` reports the tree's only **critical** advisory against `tar@7.5.11`:

- **GHSA-vmf3-w455-68vh** (critical) — PAX size override applied to intermediary GNU long-name/long-link headers causes a tar parser interpretation differential (file smuggling)
- Plus five high/moderate DoS advisories fixed in the same line: GHSA-w8wr-v893-vjvp, GHSA-23hp-3jrh-7fpw, GHSA-8x88-c5mf-7j5w, GHSA-gvwx-54wh-qm9j, GHSA-r292-9mhp-454m

All are fixed in `tar@7.5.21+`.

**Why an override instead of a plain lockfile bump:** `tar` is transitive — `lerna@9.0.7` (already the latest release) pins it to the **exact** version `7.5.11`, so no in-range update can move it; `npm audit fix` only offers a nonsensical `--force` downgrade to `lerna@6`. This PR intentionally overrides that exact pin (a root `overrides: { "tar": "^7.5.22" }`) because it is a security fix. The override can be dropped once lerna ships a release with a patched pin.

After this change: `npm ls tar` resolves `7.5.22` everywhere (lerna, pacote, node-gyp, arborist) and the audit drops from 30 vulnerabilities (1 critical) to 29 (0 critical).

### Gates

Baseline was recorded on a clean `master` checkout, then re-run with the update applied — no new failures:

- `npm run format` / `npm run lint` (biome): clean, before and after
- `npm run build` (18 projects): green, before and after
- `npm run tsc` (8 projects): green, before and after
- `npm test` unit suites (vitest): all 14 suites pass, before and after
- Playwright e2e: identical result before and after (fails in the sandbox used for this run because the pinned Playwright browser builds aren't installable there; CI installs its own browsers)

## Pending queue (other updates found this run)

**Remaining security advisories** — all transitive, 29 total (20 high, 9 moderate), most fixable via in-range lockfile refreshes in future runs:
- high: `axios` (via `nx`), `brace-expansion` (many paths), `fast-uri`, `undici`, `image-size` (via `metro`), `postcss`
- moderate: `uuid` (via the `xcode`/`@expo/config-plugins` chain)

**Patch:**
- `@chakra-ui/react` 3.36.0 → 3.36.1
- `@tanstack/react-query` 5.101.2 → 5.101.4
- `@types/react` 19.2.17 → 19.2.18
- `@types/react-dom` 19.2.3 → 19.2.4
- `@vitejs/plugin-react` 6.0.3 → 6.0.5
- `@zip.js/zip.js` 2.8.34 → 2.8.36
- `react` / `react-dom` 19.2.7 → 19.2.8

**Minor:**
- `@playwright/test` 1.61.1 → 1.62.1
- `happy-dom` 20.10.6 → 20.11.2
- `reactjrx` 1.141.2 → 1.142.0 (Dependabot PR #302 already open)
- `vite` 8.1.5 → 8.2.1 (Dependabot PR #300 already open)
- `expo-file-system` 56.0.8 → 56.0.9

**Major (still coming — flagged for review):**
- `typescript` 6.0.3 → 7.0.2
- `@babel/core` 7.29.7 → 8.0.1
- `pdfjs-dist` 5.7.284 → 6.2.108
- `react-dropzone` 15.0.0 → 20.1.0 (Dependabot PR #291 already open)
- `xmldoc` 2.0.3 → 3.0.0
- `expo-file-system` 56.x → 57.0.2

## Needs manual attention

Nothing this run — the chosen update passed all gates. Note the remaining `image-size`/`uuid` advisories sit behind the `expo`/`metro` dependency chains and may need coordinated expo upgrades rather than single-package bumps.

---
_Generated by [Claude Code](https://claude.ai/code/session_01213s5boGTvKKmY9xzAKyjf)_