### PR TITLE
feat(archive-reader): build a catalog's reference URL, next to the parser that reads it

### DIFF
--- a/gitbook/archive-reader/identifiers.md
+++ b/gitbook/archive-reader/identifiers.md
@@ -61,7 +61,18 @@ catalogIdentifierFromUrl("https://www.gutenberg.org/ebooks/78139")
 // { value: "78139", scheme: "ProjectGutenberg" }
 ```
 
-Both derive without rewriting anything: `identifiers` still reports the authored URL as a `URL` identifier, because whether that link *is* the publication's catalog identifier is the application's call, not archive-reader's.
+`catalogUrlFromIdentifier` is its inverse, for writing a reference into a container whose only identifier slot is a list of links:
+
+```typescript
+catalogUrlFromIdentifier({ value: "OL7353617M", scheme: "OpenLibrary" })
+// "https://openlibrary.org/books/OL7353617M"
+```
+
+It canonicalizes the value on the way out and returns a URL only once reading it back yields what it was built from, so a value the catalog cannot address — a non-numeric Gutenberg id — declines rather than producing a link nothing recovers. The two directions are defined together and tested against each other, so they cannot drift apart.
+
+`METADATA_CATALOG_SCHEMES` lists the schemes that have a link form, and `isMetadataCatalogScheme` tests one, for code deciding whether a container can carry a given scheme at all.
+
+None of this rewrites anything: `identifiers` still reports the authored URL as a `URL` identifier, because whether that link *is* the publication's catalog identifier is the application's call, not archive-reader's.
 
 The authored `value` needs normalizing before use: it is preserved as the publication wrote it, so it arrives hyphenated (`978-0-441-01359-3`), prefixed (`urn:isbn:9780441013593`), or padded with free text. It returns the canonical form — 10 or 13 characters for an ISBN, digits only for a GTIN.
 

--- a/packages/archive-reader/src/index.ts
+++ b/packages/archive-reader/src/index.ts
@@ -130,7 +130,12 @@ export type {
   ResolvedTitleType,
 } from "./types/resolvedMetadata.ts"
 export type { MetadataCatalogScheme } from "./utils/catalogIdentifiers.ts"
-export { catalogIdentifierFromUrl } from "./utils/catalogIdentifiers.ts"
+export {
+  catalogIdentifierFromUrl,
+  catalogUrlFromIdentifier,
+  isMetadataCatalogScheme,
+  METADATA_CATALOG_SCHEMES,
+} from "./utils/catalogIdentifiers.ts"
 export type { DerivableIdentifierScheme } from "./utils/identifierValues.ts"
 export {
   identifierValue,

--- a/packages/archive-reader/src/utils/catalogIdentifiers.test.ts
+++ b/packages/archive-reader/src/utils/catalogIdentifiers.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { catalogIdentifierFromUrl } from "./catalogIdentifiers.ts"
+import {
+  catalogIdentifierFromUrl,
+  catalogUrlFromIdentifier,
+  isMetadataCatalogScheme,
+  METADATA_CATALOG_SCHEMES,
+} from "./catalogIdentifiers.ts"
 
 describe("catalogIdentifierFromUrl", () => {
   it("reads a Google Books volume from its site and API URLs", () => {
@@ -77,5 +82,106 @@ describe("catalogIdentifierFromUrl", () => {
     expect(
       catalogIdentifierFromUrl("ftp://books.google.com/books?id=k028AAAACAAJ"),
     ).toBeUndefined()
+  })
+})
+
+describe("catalogUrlFromIdentifier", () => {
+  it.each([
+    [
+      "GoogleBooks",
+      "k028AAAACAAJ",
+      "https://books.google.com/books?id=k028AAAACAAJ",
+    ],
+    ["ProjectGutenberg", "2701", "https://www.gutenberg.org/ebooks/2701"],
+    [
+      "OpenLibrary",
+      "/works/OL45883W",
+      "https://openlibrary.org/works/OL45883W",
+    ],
+    ["DOI", "10.1000/182", "https://doi.org/10.1000/182"],
+  ])("builds the %s reference URL", (scheme, value, expected) => {
+    expect(catalogUrlFromIdentifier({ scheme, value })).toBe(expected)
+  })
+
+  it("canonicalizes the value on the way out", () => {
+    expect(
+      catalogUrlFromIdentifier({
+        scheme: "ProjectGutenberg",
+        value: " 0002701 ",
+      }),
+    ).toBe("https://www.gutenberg.org/ebooks/2701")
+    expect(
+      catalogUrlFromIdentifier({ scheme: "OpenLibrary", value: "OL7353617M" }),
+    ).toBe("https://openlibrary.org/books/OL7353617M")
+    expect(
+      catalogUrlFromIdentifier({ scheme: "DOI", value: "doi:10.1000/182" }),
+    ).toBe("https://doi.org/10.1000/182")
+  })
+
+  it("matches the scheme case-insensitively", () => {
+    expect(
+      catalogUrlFromIdentifier({
+        scheme: "googlebooks",
+        value: "k028AAAACAAJ",
+      }),
+    ).toBe("https://books.google.com/books?id=k028AAAACAAJ")
+  })
+
+  it("declines a value its catalog cannot address", () => {
+    expect(
+      catalogUrlFromIdentifier({
+        scheme: "ProjectGutenberg",
+        value: "not-a-number",
+      }),
+    ).toBeUndefined()
+    expect(
+      catalogUrlFromIdentifier({ scheme: "OpenLibrary", value: "not-a-key" }),
+    ).toBeUndefined()
+    expect(
+      catalogUrlFromIdentifier({ scheme: "DOI", value: "just text" }),
+    ).toBeUndefined()
+    expect(
+      catalogUrlFromIdentifier({ scheme: "GoogleBooks", value: "has spaces" }),
+    ).toBeUndefined()
+  })
+
+  it("declines a scheme with no catalog behind it", () => {
+    expect(
+      catalogUrlFromIdentifier({ scheme: "ISBN", value: "9780441013593" }),
+    ).toBeUndefined()
+    expect(
+      catalogUrlFromIdentifier({ scheme: "AcmeCatalog", value: "acme-42" }),
+    ).toBeUndefined()
+  })
+})
+
+describe("the two directions agree", () => {
+  it.each([
+    ["GoogleBooks", "k028AAAACAAJ"],
+    ["ProjectGutenberg", "2701"],
+    ["OpenLibrary", "/works/OL45883W"],
+    ["OpenLibrary", "/books/OL7353617M"],
+    ["DOI", "10.1000/182"],
+  ])("round-trips a %s identifier through its URL", (scheme, value) => {
+    const url = catalogUrlFromIdentifier({ scheme, value })
+
+    expect(url).toBeDefined()
+    expect(url && catalogIdentifierFromUrl(url)).toEqual({ scheme, value })
+  })
+
+  it("covers every catalog scheme in both directions", () => {
+    expect([...METADATA_CATALOG_SCHEMES]).toEqual([
+      "GoogleBooks",
+      "ProjectGutenberg",
+      "OpenLibrary",
+      "DOI",
+    ])
+
+    for (const scheme of METADATA_CATALOG_SCHEMES) {
+      expect(isMetadataCatalogScheme(scheme)).toBe(true)
+    }
+
+    expect(isMetadataCatalogScheme("ISBN")).toBe(false)
+    expect(isMetadataCatalogScheme("AcmeCatalog")).toBe(false)
   })
 })

--- a/packages/archive-reader/src/utils/catalogIdentifiers.test.ts
+++ b/packages/archive-reader/src/utils/catalogIdentifiers.test.ts
@@ -127,6 +127,24 @@ describe("catalogUrlFromIdentifier", () => {
     ).toBe("https://books.google.com/books?id=k028AAAACAAJ")
   })
 
+  it("encodes a DOI suffix that reserves URL characters", () => {
+    expect(
+      catalogUrlFromIdentifier({ scheme: "DOI", value: "10.1000/foo?bar" }),
+    ).toBe("https://doi.org/10.1000/foo%3Fbar")
+    expect(
+      catalogUrlFromIdentifier({ scheme: "DOI", value: "10.1000/foo%bar" }),
+    ).toBe("https://doi.org/10.1000/foo%25bar")
+    expect(
+      catalogUrlFromIdentifier({ scheme: "DOI", value: "10.1000/a#b" }),
+    ).toBe("https://doi.org/10.1000/a%23b")
+  })
+
+  it("leaves the prefix separator literal, doi.org addressing by path", () => {
+    expect(
+      catalogUrlFromIdentifier({ scheme: "DOI", value: "10.1000/182" }),
+    ).toBe("https://doi.org/10.1000/182")
+  })
+
   it("declines a value its catalog cannot address", () => {
     expect(
       catalogUrlFromIdentifier({
@@ -162,6 +180,8 @@ describe("the two directions agree", () => {
     ["OpenLibrary", "/works/OL45883W"],
     ["OpenLibrary", "/books/OL7353617M"],
     ["DOI", "10.1000/182"],
+    ["DOI", "10.1000/foo?bar"],
+    ["DOI", "10.1038/nphys1170"],
   ])("round-trips a %s identifier through its URL", (scheme, value) => {
     const url = catalogUrlFromIdentifier({ scheme, value })
 

--- a/packages/archive-reader/src/utils/catalogIdentifiers.ts
+++ b/packages/archive-reader/src/utils/catalogIdentifiers.ts
@@ -189,6 +189,8 @@ type Catalog = {
   readonly scheme: MetadataCatalogScheme
   readonly normalizeValue: (value: string) => string | undefined
   readonly valueFromUrl: (value: string) => string | undefined
+  /** Builds the catalog's own URL for an already-normalized value. */
+  readonly toUrl: (value: string) => string
 }
 
 const CATALOGS: ReadonlyArray<Catalog> = [
@@ -196,19 +198,50 @@ const CATALOGS: ReadonlyArray<Catalog> = [
     scheme: "GoogleBooks",
     normalizeValue: googleBooksId,
     valueFromUrl: googleBooksIdFromUrl,
+    toUrl: (value) =>
+      `https://books.google.com/books?id=${encodeURIComponent(value)}`,
   },
   {
     scheme: "ProjectGutenberg",
     normalizeValue: projectGutenbergId,
     valueFromUrl: projectGutenbergIdFromUrl,
+    toUrl: (value) => `https://www.gutenberg.org/ebooks/${value}`,
   },
   {
     scheme: "OpenLibrary",
     normalizeValue: openLibraryKey,
     valueFromUrl: openLibraryKeyFromUrl,
+    toUrl: (value) => `https://openlibrary.org${value}`,
   },
-  { scheme: "DOI", normalizeValue: doiName, valueFromUrl: doiNameFromUrl },
+  {
+    scheme: "DOI",
+    normalizeValue: doiName,
+    valueFromUrl: doiNameFromUrl,
+    toUrl: (value) => `https://doi.org/${value}`,
+  },
 ]
+
+/**
+ * Every scheme whose catalog addresses a record by URL, so a publication can
+ * state the identifier either explicitly or as a reference link.
+ */
+export const METADATA_CATALOG_SCHEMES: ReadonlyArray<MetadataCatalogScheme> =
+  CATALOGS.map(function toScheme(catalog) {
+    return catalog.scheme
+  })
+
+const catalogFor = (scheme: MetadataIdentifierScheme): Catalog | undefined => {
+  const schemeKey = scheme.trim().toLowerCase()
+
+  return CATALOGS.find(function matchesScheme(catalog) {
+    return catalog.scheme.toLowerCase() === schemeKey
+  })
+}
+
+/** Whether a scheme's catalog addresses its records by URL. */
+export const isMetadataCatalogScheme = (
+  scheme: MetadataIdentifierScheme,
+): boolean => catalogFor(scheme) !== undefined
 
 /**
  * The catalog identifier a reference URL stands for, or `undefined` when no
@@ -229,6 +262,30 @@ export const catalogIdentifierFromUrl = (
   }
 
   return undefined
+}
+
+/**
+ * The catalog's own URL for an identifier — the inverse of
+ * {@link catalogIdentifierFromUrl}, for writing a reference into a container
+ * whose only identifier slot is a list of links.
+ *
+ * `undefined` when the scheme has no catalog, or when the value is not one
+ * that catalog can address. The pair is checked rather than assumed: a URL is
+ * only returned once reading it back yields the value it was built from, so
+ * the two directions cannot drift apart unnoticed.
+ */
+export const catalogUrlFromIdentifier = ({
+  scheme,
+  value,
+}: MetadataIdentifier): string | undefined => {
+  const catalog = catalogFor(scheme)
+  const normalized = catalog?.normalizeValue(value)
+
+  if (catalog === undefined || normalized === undefined) return undefined
+
+  const url = catalog.toUrl(normalized)
+
+  return catalog.valueFromUrl(url) === normalized ? url : undefined
 }
 
 /**

--- a/packages/archive-reader/src/utils/catalogIdentifiers.ts
+++ b/packages/archive-reader/src/utils/catalogIdentifiers.ts
@@ -175,6 +175,15 @@ const doiName = (value: string): string | undefined => {
   return DOI_NAME.test(trimmed) ? trimmed : undefined
 }
 
+/**
+ * DOI suffixes are opaque and may contain characters a URL reserves — a `?`
+ * would otherwise start a query string and drop the rest of the name. Each
+ * path segment is encoded while the separators stay literal, since doi.org
+ * addresses a name by path rather than as one encoded blob.
+ */
+const doiUrlPath = (name: string): string =>
+  name.split("/").map(encodeURIComponent).join("/")
+
 const doiNameFromUrl = (value: string): string | undefined => {
   const url = urlOnHost(value, (hostname) => DOI_HOSTS.has(hostname))
   const decoded =
@@ -217,7 +226,7 @@ const CATALOGS: ReadonlyArray<Catalog> = [
     scheme: "DOI",
     normalizeValue: doiName,
     valueFromUrl: doiNameFromUrl,
-    toUrl: (value) => `https://doi.org/${value}`,
+    toUrl: (value) => `https://doi.org/${doiUrlPath(value)}`,
   },
 ]
 


### PR DESCRIPTION
Follow-up to #326, which added `catalogIdentifierFromUrl` but shipped it without an inverse.

## Why

A container whose only identifier slot is a list of links — ComicInfo's `Web`, which is all a comic has — needs the *write* direction too. Without it, oboku re-encoded the same four hosts and path shapes to build the URLs archive-reader already knew how to parse:

| oboku was building | archive-reader parses |
| --- | --- |
| `books.google.com/books?id=` | `GOOGLE_BOOKS_SITE_HOST` + `searchParams.get("id")` |
| `www.gutenberg.org/ebooks/N` | `GUTENBERG_HOSTS` + `/^\/ebooks\/(\d+)/` |
| `openlibrary.org/<key>` | `OPEN_LIBRARY_HOSTS` + `OPEN_LIBRARY_KEY` |
| `doi.org/<name>` | `DOI_HOSTS` + `DOI_NAME` |

One fact stored twice, with nothing to catch them drifting apart — a change to a parser would quietly stop matching URLs the writer still produced.

## What

```typescript
catalogUrlFromIdentifier({ value: "OL7353617M", scheme: "OpenLibrary" })
// "https://openlibrary.org/books/OL7353617M"

catalogUrlFromIdentifier({ value: "not-a-number", scheme: "ProjectGutenberg" })
// undefined
```

Each catalog's `toUrl` sits beside its parser in the same table. The value is canonicalized on the way out — a padded Gutenberg number, a bare Open Library id, a `doi:` prefix — and a URL is returned only once `valueFromUrl` reads it back as the value it was built from. That check doubles as the invariant: a `describe("the two directions agree")` block round-trips every catalog, so the pair cannot drift silently.

Also exported, for code deciding whether a container can carry a scheme before it has a value to write:

- `METADATA_CATALOG_SCHEMES` — the schemes with a link form
- `isMetadataCatalogScheme(scheme)` — the same test as a predicate

## Unchanged

Resolution. An authored URL is still reported as `{ value: url, scheme: "URL" }` — this only derives and builds.

## Docs

`identifiers.md` gains the inverse alongside `catalogIdentifierFromUrl`, including why the round-trip check is there.

## Semver

Additive: three new exports, no existing behaviour touched. Minor.

## Verification

- `npm test` — 16 projects, exit 0 (20 tests on the module now, up from 13)
- `npm run tsc` — clean across 8 projects
- biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)