### PR TITLE
feat(archive-reader): export the scheme normalizer, and compare ISBN schemes with it

### DIFF
--- a/gitbook/archive-reader/identifiers.md
+++ b/gitbook/archive-reader/identifiers.md
@@ -39,7 +39,7 @@ const gtin = identifierValue(metadata.identifiers, "GTIN") // "9780441013593" | 
 
 One function answers for every scheme it can derive — `ISBN`, `GTIN`, `GoogleBooks`, `OpenLibrary`, `ProjectGutenberg` and `DOI` — so the options are visible at the call site rather than being separate exports to discover.
 
-Asking for either reads `ISBN` **and** `GTIN` identifiers, because the two are one namespace in practice: an ISBN-13 *is* a GTIN-13 in the Bookland (`978`/`979`) range, and [ComicInfo](#comicinfo) has no ISBN field at all — a comic announces its ISBN through `GTIN`, which stays labelled `GTIN` because that is what the source said. Filtering on `scheme === "ISBN"` therefore silently misses every comic ISBN, and filtering on `GTIN` misses every EPUB one. `isIsbnBearingScheme(scheme)` is exported for code that needs the same scheme test on its own.
+Asking for either reads `ISBN` **and** `GTIN` identifiers, because the two are one namespace in practice: an ISBN-13 *is* a GTIN-13 in the Bookland (`978`/`979`) range, and [ComicInfo](#comicinfo) has no ISBN field at all — a comic announces its ISBN through `GTIN`, which stays labelled `GTIN` because that is what the source said. Filtering on `scheme === "ISBN"` therefore silently misses every comic ISBN, and filtering on `GTIN` misses every EPUB one. `isIsbnBearingScheme(scheme)` is exported for code that needs the same scheme test on its own, and `normalizeIdentifierScheme(scheme)` for code comparing a scheme it was handed: publications author these by hand, so `opf:scheme="isbn"` and an `identifier-type` of `ISBN` name the one namespace. A scheme outside the vocabulary keeps the spelling the publication chose.
 
 ### Catalog identifiers
 

--- a/packages/archive-reader/src/index.ts
+++ b/packages/archive-reader/src/index.ts
@@ -143,6 +143,7 @@ export {
 } from "./utils/identifierValues.ts"
 export { mainTitle } from "./utils/mainTitle.ts"
 export { normalizeGtin } from "./utils/normalizeGtin.ts"
+export { normalizeIdentifierScheme } from "./utils/normalizeIdentifierScheme.ts"
 export { normalizeIsbn } from "./utils/normalizeIsbn.ts"
 export { parseW3cDtfDate } from "./utils/parseW3cDtfDate.ts"
 export { tokenizeXmlSpaceSeparatedList } from "./utils/tokenizeXmlSpaceSeparatedList.ts"

--- a/packages/archive-reader/src/metadata/opf/resolve.ts
+++ b/packages/archive-reader/src/metadata/opf/resolve.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../types/resolvedMetadata.ts"
 import { booklandIsbn } from "../../utils/booklandIsbn.ts"
 import { normalizeGtin } from "../../utils/normalizeGtin.ts"
+import { normalizeIdentifierScheme } from "../../utils/normalizeIdentifierScheme.ts"
 import { omitUndefined } from "../../utils/omitUndefined.ts"
 import { parseW3cDtfDate } from "../../utils/parseW3cDtfDate.ts"
 import type {
@@ -40,29 +41,6 @@ const inferredIdentifierScheme = (value: string): string => {
   if (normalizeGtin(trimmed) !== undefined) return "GTIN"
 
   return "Unknown"
-}
-
-const normalizedIdentifierScheme = (scheme: string): string => {
-  switch (scheme.trim().toLowerCase()) {
-    case "isbn":
-      return "ISBN"
-    case "gtin":
-      return "GTIN"
-    case "doi":
-      return "DOI"
-    case "googlebooks":
-      return "GoogleBooks"
-    case "openlibrary":
-      return "OpenLibrary"
-    case "projectgutenberg":
-      return "ProjectGutenberg"
-    case "url":
-      return "URL"
-    case "unknown":
-      return "Unknown"
-    default:
-      return scheme.trim()
-  }
 }
 
 /**
@@ -250,7 +228,7 @@ const collectionIdentifiers = (
     return [
       {
         value,
-        scheme: normalizedIdentifierScheme(
+        scheme: normalizeIdentifierScheme(
           declaredType ?? inferredIdentifierScheme(value),
         ),
       },
@@ -422,7 +400,7 @@ export const resolveOpf = (input: OpfMetadata): ResolvedMetadata => {
         ? parsedIdentifiers.map((identifier) =>
             omitUndefined({
               value: identifier.value,
-              scheme: normalizedIdentifierScheme(
+              scheme: normalizeIdentifierScheme(
                 identifier.scheme ??
                   refinedIdentifierType(identifier, metas) ??
                   inferredIdentifierScheme(identifier.value),

--- a/packages/archive-reader/src/utils/identifierValues.test.ts
+++ b/packages/archive-reader/src/utils/identifierValues.test.ts
@@ -73,6 +73,8 @@ describe("identifierValue for ISBN and GTIN", () => {
   it("treats ISBN and GTIN as the one ISBN-bearing namespace", () => {
     expect(isIsbnBearingScheme("ISBN")).toBe(true)
     expect(isIsbnBearingScheme("GTIN")).toBe(true)
+    expect(isIsbnBearingScheme("isbn")).toBe(true)
+    expect(isIsbnBearingScheme(" gtin ")).toBe(true)
     expect(isIsbnBearingScheme("DOI")).toBe(false)
     expect(isIsbnBearingScheme("Unknown")).toBe(false)
     expect(isIsbnBearingScheme("ObokuCatalog")).toBe(false)

--- a/packages/archive-reader/src/utils/identifierValues.ts
+++ b/packages/archive-reader/src/utils/identifierValues.ts
@@ -9,6 +9,7 @@ import {
   type MetadataCatalogScheme,
 } from "./catalogIdentifiers.ts"
 import { normalizeGtin } from "./normalizeGtin.ts"
+import { normalizeIdentifierScheme } from "./normalizeIdentifierScheme.ts"
 
 /**
  * Whether a scheme can carry an ISBN or a GTIN. The two are one namespace in
@@ -18,12 +19,16 @@ import { normalizeGtin } from "./normalizeGtin.ts"
  * therefore misses every comic ISBN, and filtering on `GTIN` alone misses
  * every EPUB one.
  *
- * Schemes are canonicalized while metadata is resolved, so only the canonical
- * spellings are compared.
+ * Resolving metadata canonicalizes spellings, but this also answers for a
+ * scheme a caller assembled by hand.
  */
 export const isIsbnBearingScheme = (
   scheme: MetadataIdentifierScheme,
-): boolean => scheme === "ISBN" || scheme === "GTIN"
+): boolean => {
+  const normalized = normalizeIdentifierScheme(scheme)
+
+  return normalized === "ISBN" || normalized === "GTIN"
+}
 
 /**
  * Schemes a publication's value can be derived for. Narrower than
@@ -51,8 +56,7 @@ const isbnBearingRule = (
 const catalogDerivationRule = (
   scheme: MetadataCatalogScheme,
 ): DerivationRule => ({
-  carries: (candidate) =>
-    candidate.trim().toLowerCase() === scheme.toLowerCase(),
+  carries: (candidate) => normalizeIdentifierScheme(candidate) === scheme,
   ...catalogRule(scheme),
 })
 

--- a/packages/archive-reader/src/utils/normalizeIdentifierScheme.test.ts
+++ b/packages/archive-reader/src/utils/normalizeIdentifierScheme.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+import { normalizeIdentifierScheme } from "./normalizeIdentifierScheme.ts"
+
+describe("normalizeIdentifierScheme", () => {
+  it.each([
+    ["isbn", "ISBN"],
+    ["ISBN", "ISBN"],
+    ["gtin", "GTIN"],
+    ["doi", "DOI"],
+    ["googlebooks", "GoogleBooks"],
+    ["GOOGLEBOOKS", "GoogleBooks"],
+    ["openlibrary", "OpenLibrary"],
+    ["projectgutenberg", "ProjectGutenberg"],
+    ["url", "URL"],
+    ["unknown", "Unknown"],
+  ])("spells %s the way the vocabulary does", (scheme, expected) => {
+    expect(normalizeIdentifierScheme(scheme)).toBe(expected)
+  })
+
+  it("ignores surrounding whitespace, as authored metadata carries it", () => {
+    expect(normalizeIdentifierScheme("  ISBN\n")).toBe("ISBN")
+    expect(normalizeIdentifierScheme(" ExampleCatalog ")).toBe("ExampleCatalog")
+  })
+
+  it("leaves a custom scheme's spelling to the publication", () => {
+    expect(normalizeIdentifierScheme("ExampleCatalog")).toBe("ExampleCatalog")
+    expect(normalizeIdentifierScheme("examplecatalog")).toBe("examplecatalog")
+    expect(normalizeIdentifierScheme("")).toBe("")
+  })
+})

--- a/packages/archive-reader/src/utils/normalizeIdentifierScheme.ts
+++ b/packages/archive-reader/src/utils/normalizeIdentifierScheme.ts
@@ -1,0 +1,43 @@
+import type {
+  KnownMetadataIdentifierScheme,
+  MetadataIdentifierScheme,
+} from "../types/resolvedMetadata.ts"
+
+/**
+ * Keyed by the scheme union so a scheme added to the vocabulary fails to
+ * compile until it is spelled here too.
+ */
+const CANONICAL_SPELLINGS: Record<
+  Lowercase<KnownMetadataIdentifierScheme>,
+  KnownMetadataIdentifierScheme
+> = {
+  isbn: "ISBN",
+  gtin: "GTIN",
+  doi: "DOI",
+  googlebooks: "GoogleBooks",
+  openlibrary: "OpenLibrary",
+  projectgutenberg: "ProjectGutenberg",
+  url: "URL",
+  unknown: "Unknown",
+}
+
+const SPELLINGS_BY_LOWERCASE = new Map<string, KnownMetadataIdentifierScheme>(
+  Object.entries(CANONICAL_SPELLINGS),
+)
+
+/**
+ * A scheme in the spelling the vocabulary uses, so `opf:scheme="isbn"` and an
+ * `identifier-type` of `ISBN` describe the one namespace. Publications author
+ * these by hand and their case is not significant.
+ *
+ * A scheme outside the vocabulary is returned trimmed but otherwise untouched:
+ * a custom namespace is a supported case, and its spelling is the
+ * publication's to choose.
+ */
+export const normalizeIdentifierScheme = (
+  scheme: MetadataIdentifierScheme,
+): MetadataIdentifierScheme => {
+  const trimmed = scheme.trim()
+
+  return SPELLINGS_BY_LOWERCASE.get(trimmed.toLowerCase()) ?? trimmed
+}


### PR DESCRIPTION
## Why

Publications author scheme names by hand, so `opf:scheme="isbn"` and an `identifier-type` of `ISBN` name the same namespace. Resolution already folds them together — but privately, in a `switch` inside `resolveOpf`. Any consumer comparing a scheme it was *handed* had to reimplement the vocabulary; oboku did exactly that, carrying a `Record<KnownMetadataIdentifierScheme, …>` of all eight spellings whose only job was staying in step with the one here.

There was also an inconsistency worth closing. Of the three scheme comparisons this package exposes:

| helper | matched |
| --- | --- |
| `identifierValue(…, scheme)` | loosely |
| `isMetadataCatalogScheme(scheme)` | loosely |
| `isIsbnBearingScheme(scheme)` | **exactly** |

So whether `"isbn"` answered depended on which helper you reached for — a distinction no caller is in a position to care about.

## What

- `normalizeIdentifierScheme(scheme)` moves out of `resolveOpf` into `utils/`, beside `normalizeIsbn` and `normalizeGtin`, and is exported. A scheme in the vocabulary comes back in the vocabulary's spelling; one outside it comes back trimmed and otherwise untouched, since a custom namespace's spelling is the publication's to choose.
- `isIsbnBearingScheme` compares through it, joining its neighbours.
- The catalog derivation rule uses it too, replacing an ad-hoc `toLowerCase()` comparison.

The vocabulary table is keyed `Record<Lowercase<KnownMetadataIdentifierScheme>, KnownMetadataIdentifierScheme>`, so adding a scheme to the union fails to compile until it is spelled here.

## Behaviour

`isIsbnBearingScheme(" isbn ")` now returns `true` where it returned `false`. Everything reaching it through resolved metadata is unaffected — those schemes are already canonical — so this only widens what a hand-built scheme string matches.

## Docs

`identifiers.md` gains the normalizer next to `isIsbnBearingScheme`, with the reason a consumer needs it.

## Semver

One new export plus a widened predicate. Additive in practice; minor.

## Verification

- `npm test` — 16 projects, exit 0 (archive-reader 315 tests, 28 files)
- `npm run tsc` — clean across 8 projects
- biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)