### PR TITLE
feat(archive-reader): expose how an OPF states an identifier's scheme

### DIFF
--- a/gitbook/archive-reader/identifiers.md
+++ b/gitbook/archive-reader/identifiers.md
@@ -100,6 +100,29 @@ This resolves to:
 
 The identifier referenced by the OPF package's `unique-identifier` attribute also receives `unique: true` in resolved archive metadata.
 
+### Reading a scheme out of an OPF yourself
+
+Resolved metadata already answers *what scheme is this identifier on*, so most consumers need nothing else. A consumer holding the package document itself — one editing it in place, and needing to agree with archive-reader about which element is which — can read the two vocabularies directly instead of restating them:
+
+```typescript
+import {
+  OPF_IDENTIFIER_SCHEME_ATTRIBUTES,
+  opfIdentifierSchemeAttribute,
+  opfIdentifierTypeScheme,
+} from "@prose-reader/archive-reader"
+
+// the scheme attribute an element carries, whichever spelling it used
+opfIdentifierSchemeAttribute({ "opf:Scheme": "ISBN" }) // "ISBN"
+
+// the scheme an `identifier-type` refinement names
+opfIdentifierTypeScheme({ value: "15", scheme: "onix:codelist5" }) // "ISBN"
+opfIdentifierTypeScheme({ value: "ExampleCatalog" }) // "ExampleCatalog"
+```
+
+`OPF_IDENTIFIER_SCHEME_ATTRIBUTES` is the ordered list of spellings — `opf:scheme`, `opf:Scheme`, `scheme` — and the first one an element states wins, so a document using only the legacy form keeps it. `opfIdentifierTypeScheme` translates a code stated against `onix:codelist5` and passes anything else through verbatim, including a code that list does not define.
+
+These are what the parser and resolver use, so a consumer reading through them cannot drift from what `identifiers` reports.
+
 For EPUBs that include Apple or Kobo display-option files, the OPF package document remains the identifier source. Those sidecars describe presentation and do not define bibliographic identifier fields.
 
 ## ComicInfo

--- a/packages/archive-reader/src/index.ts
+++ b/packages/archive-reader/src/index.ts
@@ -77,6 +77,12 @@ export {
 export { readArchiveKobo } from "./metadata/kobo/readArchiveKobo.ts"
 export { getArchiveOpfInfo } from "./metadata/opf/getArchiveOpfInfo.ts"
 export { getSpineItemFilesFromArchive } from "./metadata/opf/getSpineItemFilesFromArchive.ts"
+export type { OpfIdentifierTypeMeta } from "./metadata/opf/identifierScheme.ts"
+export {
+  OPF_IDENTIFIER_SCHEME_ATTRIBUTES,
+  opfIdentifierSchemeAttribute,
+  opfIdentifierTypeScheme,
+} from "./metadata/opf/identifierScheme.ts"
 export { isArchiveEpub } from "./metadata/opf/isArchiveEpub.ts"
 export type {
   OpfContributor,

--- a/packages/archive-reader/src/metadata/opf/identifierScheme.test.ts
+++ b/packages/archive-reader/src/metadata/opf/identifierScheme.test.ts
@@ -67,3 +67,13 @@ describe("opfIdentifierSchemeAttribute", () => {
     }
   })
 })
+
+describe("OPF_IDENTIFIER_SCHEME_ATTRIBUTES", () => {
+  it("cannot be mutated by a consumer", () => {
+    expect(Object.isFrozen(OPF_IDENTIFIER_SCHEME_ATTRIBUTES)).toBe(true)
+    expect(() =>
+      (OPF_IDENTIFIER_SCHEME_ATTRIBUTES as string[]).reverse(),
+    ).toThrow()
+    expect(opfIdentifierSchemeAttribute({ "opf:scheme": "ISBN" })).toBe("ISBN")
+  })
+})

--- a/packages/archive-reader/src/metadata/opf/identifierScheme.test.ts
+++ b/packages/archive-reader/src/metadata/opf/identifierScheme.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import {
+  OPF_IDENTIFIER_SCHEME_ATTRIBUTES,
+  opfIdentifierSchemeAttribute,
+  opfIdentifierTypeScheme,
+} from "./identifierScheme"
+
+describe("opfIdentifierTypeScheme", () => {
+  it("translates an ONIX codelist 5 code", () => {
+    expect(
+      opfIdentifierTypeScheme({ value: "15", scheme: "onix:codelist5" }),
+    ).toBe("ISBN")
+    expect(
+      opfIdentifierTypeScheme({ value: "06", scheme: " ONIX:CodeList5 " }),
+    ).toBe("DOI")
+  })
+
+  it("passes a code the list does not define through verbatim", () => {
+    expect(
+      opfIdentifierTypeScheme({ value: "99", scheme: "onix:codelist5" }),
+    ).toBe("99")
+  })
+
+  it("treats a value stated against no scheme as a scheme name", () => {
+    expect(opfIdentifierTypeScheme({ value: " DOI " })).toBe("DOI")
+    expect(opfIdentifierTypeScheme({ value: "15" })).toBe("15")
+    expect(
+      opfIdentifierTypeScheme({ value: "ExampleCatalog", scheme: "other" }),
+    ).toBe("ExampleCatalog")
+  })
+
+  it("declines an absent or blank value", () => {
+    expect(opfIdentifierTypeScheme(undefined)).toBeUndefined()
+    expect(opfIdentifierTypeScheme({})).toBeUndefined()
+    expect(
+      opfIdentifierTypeScheme({ value: "   ", scheme: "onix:codelist5" }),
+    ).toBeUndefined()
+  })
+})
+
+describe("opfIdentifierSchemeAttribute", () => {
+  it("prefers the namespaced spelling", () => {
+    expect(
+      opfIdentifierSchemeAttribute({
+        "opf:scheme": "ISBN",
+        "opf:Scheme": "GTIN",
+        scheme: "DOI",
+      }),
+    ).toBe("ISBN")
+  })
+
+  it("falls through the accepted spellings in order", () => {
+    expect(
+      opfIdentifierSchemeAttribute({ "opf:Scheme": "GTIN", scheme: "DOI" }),
+    ).toBe("GTIN")
+    expect(opfIdentifierSchemeAttribute({ scheme: "DOI" })).toBe("DOI")
+  })
+
+  it("declines an element stating none of them", () => {
+    expect(opfIdentifierSchemeAttribute({})).toBeUndefined()
+    expect(opfIdentifierSchemeAttribute({ id: "pub-id" })).toBeUndefined()
+  })
+
+  it("reads every spelling the vocabulary lists", () => {
+    for (const name of OPF_IDENTIFIER_SCHEME_ATTRIBUTES) {
+      expect(opfIdentifierSchemeAttribute({ [name]: "ISBN" })).toBe("ISBN")
+    }
+  })
+})

--- a/packages/archive-reader/src/metadata/opf/identifierScheme.ts
+++ b/packages/archive-reader/src/metadata/opf/identifierScheme.ts
@@ -1,0 +1,79 @@
+/**
+ * How an OPF states a `dc:identifier`'s scheme. Both halves are facts about
+ * what a package document can say, so the parser and the resolver read them
+ * from here rather than each spelling them out.
+ */
+
+/**
+ * Attribute names an identifier's scheme can be stated on, in the order a read
+ * prefers them: EPUB 3's namespaced form, the capitalization some producers
+ * emit, and the bare EPUB 2 form. The first one present wins, so a document
+ * that uses only the legacy spelling keeps it.
+ */
+export const OPF_IDENTIFIER_SCHEME_ATTRIBUTES = [
+  "opf:scheme",
+  "opf:Scheme",
+  "scheme",
+] as const
+
+/**
+ * ONIX codelist 5 codes, which is the list an `identifier-type` refinement
+ * states its value against when it names `onix:codelist5` as its scheme.
+ */
+const ONIX_CODE_LIST_5_IDENTIFIER_TYPES: Readonly<Record<string, string>> = {
+  "02": "ISBN",
+  "03": "GTIN",
+  "04": "UPC",
+  "05": "ISMN",
+  "06": "DOI",
+  "13": "LCCN",
+  "14": "GTIN",
+  "15": "ISBN",
+  "22": "URN",
+  "23": "OCLC",
+  "24": "ISBN",
+  "25": "ISMN",
+  "26": "DOI",
+  "34": "GTIN",
+  "35": "ARK",
+}
+
+/** The `<meta>` fields an identifier's type is read from. */
+export type OpfIdentifierTypeMeta = {
+  readonly value?: string
+  readonly scheme?: string
+}
+
+/**
+ * The scheme an EPUB 3 `identifier-type` refinement names. A value stated
+ * against `onix:codelist5` is a code from that list — `15` is an ISBN — and is
+ * translated; a code the list does not define, and any value stated against
+ * another scheme or none, is already a scheme name and passes through
+ * verbatim.
+ */
+export const opfIdentifierTypeScheme = (
+  meta: OpfIdentifierTypeMeta | undefined,
+): string | undefined => {
+  const value = meta?.value?.trim()
+
+  if (value === undefined || value.length === 0) return undefined
+  if (meta?.scheme?.trim().toLowerCase() !== "onix:codelist5") return value
+
+  return ONIX_CODE_LIST_5_IDENTIFIER_TYPES[value] ?? value
+}
+
+/**
+ * The scheme attribute an element carries, if any — the first spelling of
+ * {@link OPF_IDENTIFIER_SCHEME_ATTRIBUTES} it states.
+ */
+export const opfIdentifierSchemeAttribute = (
+  attributes: Readonly<Record<string, string | undefined>>,
+): string | undefined => {
+  for (const name of OPF_IDENTIFIER_SCHEME_ATTRIBUTES) {
+    const value = attributes[name]
+
+    if (value !== undefined) return value
+  }
+
+  return undefined
+}

--- a/packages/archive-reader/src/metadata/opf/identifierScheme.ts
+++ b/packages/archive-reader/src/metadata/opf/identifierScheme.ts
@@ -10,11 +10,8 @@
  * emit, and the bare EPUB 2 form. The first one present wins, so a document
  * that uses only the legacy spelling keeps it.
  */
-export const OPF_IDENTIFIER_SCHEME_ATTRIBUTES = [
-  "opf:scheme",
-  "opf:Scheme",
-  "scheme",
-] as const
+export const OPF_IDENTIFIER_SCHEME_ATTRIBUTES: ReadonlyArray<string> =
+  Object.freeze(["opf:scheme", "opf:Scheme", "scheme"])
 
 /**
  * ONIX codelist 5 codes, which is the list an `identifier-type` refinement

--- a/packages/archive-reader/src/metadata/opf/parse.ts
+++ b/packages/archive-reader/src/metadata/opf/parse.ts
@@ -1,6 +1,7 @@
 import type { XmlElement, XmlNodeBase } from "xmldoc"
 import { XmlDocument } from "xmldoc"
 import { tokenizeXmlSpaceSeparatedList } from "../../utils/tokenizeXmlSpaceSeparatedList.ts"
+import { opfIdentifierSchemeAttribute } from "./identifierScheme.ts"
 import { layoutHintsFromItemrefProperties } from "./spineItemrefProperties.ts"
 
 export type OpfSpineManifestItem = {
@@ -132,8 +133,7 @@ const identifiersFromMetadata = (
     const value = child.val.trim()
     if (value.length === 0) return
 
-    const scheme =
-      child.attr["opf:scheme"] ?? child.attr["opf:Scheme"] ?? child.attr.scheme
+    const scheme = opfIdentifierSchemeAttribute(child.attr)
     const schemeTrimmed = scheme?.trim()
     const idTrimmed = child.attr.id?.trim()
     const id =

--- a/packages/archive-reader/src/metadata/opf/resolve.ts
+++ b/packages/archive-reader/src/metadata/opf/resolve.ts
@@ -11,6 +11,7 @@ import { normalizeGtin } from "../../utils/normalizeGtin.ts"
 import { normalizeIdentifierScheme } from "../../utils/normalizeIdentifierScheme.ts"
 import { omitUndefined } from "../../utils/omitUndefined.ts"
 import { parseW3cDtfDate } from "../../utils/parseW3cDtfDate.ts"
+import { opfIdentifierTypeScheme } from "./identifierScheme.ts"
 import type {
   OpfContributor,
   OpfIdentifier,
@@ -91,35 +92,6 @@ const contributorsFromOpf = (
 const metaRefinesId = (meta: OpfMetaEntry, id: string): boolean =>
   meta.refines !== undefined && meta.refines.replace(/^#/, "") === id
 
-const ONIX_CODE_LIST_5_IDENTIFIER_TYPES: Readonly<Record<string, string>> = {
-  "02": "ISBN",
-  "03": "GTIN",
-  "04": "UPC",
-  "05": "ISMN",
-  "06": "DOI",
-  "13": "LCCN",
-  "14": "GTIN",
-  "15": "ISBN",
-  "22": "URN",
-  "23": "OCLC",
-  "24": "ISBN",
-  "25": "ISMN",
-  "26": "DOI",
-  "34": "GTIN",
-  "35": "ARK",
-}
-
-const normalizedIdentifierType = (
-  meta: OpfMetaEntry | undefined,
-): string | undefined => {
-  const value = meta?.value?.trim()
-
-  if (value === undefined || value.length === 0) return undefined
-  if (meta?.scheme?.trim().toLowerCase() !== "onix:codelist5") return value
-
-  return ONIX_CODE_LIST_5_IDENTIFIER_TYPES[value] ?? value
-}
-
 const refinedIdentifierType = (
   identifier: OpfIdentifier,
   metas: ReadonlyArray<OpfMetaEntry>,
@@ -128,7 +100,7 @@ const refinedIdentifierType = (
 
   if (id === undefined) return undefined
 
-  return normalizedIdentifierType(
+  return opfIdentifierTypeScheme(
     metas.find(
       (meta) =>
         meta.property === "identifier-type" &&
@@ -216,7 +188,7 @@ const collectionIdentifiers = (
 
     if (value === undefined) return []
 
-    const declaredType = normalizedIdentifierType(
+    const declaredType = opfIdentifierTypeScheme(
       metas.find(
         (candidate) =>
           meta.id !== undefined &&


### PR DESCRIPTION
## Why

Two pieces of OPF vocabulary lived wherever they were first needed:

- **the scheme attribute names** — `opf:scheme`, `opf:Scheme`, `scheme` — spelled out inline in `parse.ts`
- **the ONIX codelist 5 table** that `identifier-type` refinements state their values against, held privately in `resolve.ts`

Neither describes how those functions work. Both describe what a package document can *say*, so they move into one module the parser and resolver read from.

## Why export them

oboku's archive writer edits an OPF in place, which means it has to agree with archive-reader about which element carries which scheme — otherwise it edits an element the reader does not report, or appends a second one beside it. Both failures have happened.

Its only alternative was restating both vocabularies, and it did: a byte-for-byte copy of the ONIX table plus the three attribute spellings. The table tracks an external list, so a copy drifts silently — a code added here would make that writer read a typed identifier as untagged.

Nothing write-oriented is exported. Which spelling a *new* element should use, how to bind its namespace, and whether to reuse or create are the writer's decisions; the reader has no opinion on them.

## What changed

New `metadata/opf/identifierScheme.ts` exporting:

| | |
|---|---|
| `OPF_IDENTIFIER_SCHEME_ATTRIBUTES` | the ordered spellings; first one present wins, so a document using only the legacy form keeps it |
| `opfIdentifierSchemeAttribute(attributes)` | the scheme attribute an element carries, whichever spelling |
| `opfIdentifierTypeScheme(meta)` | the scheme an `identifier-type` refinement names — translating an `onix:codelist5` code, passing anything else through verbatim |

`parse.ts` and `resolve.ts` now call these instead of holding their own copies. `resolve.ts` loses 29 lines; `normalizedIdentifierType` and its private table are gone, with both its call sites (identifiers and collection identifiers) going through the export.

Pure refactor on the reader's side — no behaviour change.

## Testing

- 8 new cases covering ONIX translation, undefined codes, verbatim pass-through, blank values, and each attribute spelling including precedence
- **323 tests pass** across archive-reader, up from 315, with none modified — the existing identifier and resolver suites cover the refactor
- tsc and biome clean

## Docs

`gitbook/archive-reader/identifiers.md` gains a section under **EPUB and OPF** covering the three exports with examples, and says plainly that resolved metadata already answers the common question — these are for a consumer holding the package document itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)