### PR TITLE
fix(archive-reader): read OPF attributes under any prefix bound to its namespace

### DIFF
--- a/gitbook/archive-reader/identifiers.md
+++ b/gitbook/archive-reader/identifiers.md
@@ -128,14 +128,18 @@ The scheme attribute is read under every prefix the document binds to the OPF na
   <dc:identifier pkg:scheme="GoogleBooks">zyTCAlFPjgYC</dc:identifier>
 ```
 
-`opfNamespacePrefixes` reads those bindings off the package element, and `opfIdentifierSchemeAttribute` takes them as its second argument — defaulting to `opf` alone when omitted:
+Bindings are scoped to the element that declares them and inherited by its descendants, so they are accumulated while descending — a package may declare the prefix on `<package>`, on `<metadata>`, or on the identifier itself, and a descendant may rebind one its ancestor bound. `xmlNamespaceScope` layers one element's declarations over the scope it was reached under, and `opfNamespacePrefixes` answers which prefixes name the OPF namespace there:
 
 ```typescript
-const prefixes = opfNamespacePrefixes(packageAttributes) // ["opf", "pkg"]
-opfIdentifierSchemeAttribute(elementAttributes, prefixes) // "GoogleBooks"
+const packageScope = xmlNamespaceScope(packageAttributes)
+const scope = xmlNamespaceScope(elementAttributes, packageScope)
+
+opfIdentifierSchemeAttribute(elementAttributes, opfNamespacePrefixes(scope))
 ```
 
-`opf` is accepted whether or not the package declares it, since using it undeclared is invalid but common. A prefix bound to some other namespace is not read. The unprefixed `scheme` is a deliberate fallback for EPUB 2 documents rather than an equivalent name — an unprefixed attribute is in no namespace at all.
+`opfIdentifierSchemeAttribute` takes the prefixes as its second argument, defaulting to `opf` alone when omitted.
+
+`opf` is accepted whether or not a package declares it, since using it undeclared is invalid but common — but a document that explicitly binds `opf` to another namespace is honoured, and it is then not read. A prefix bound to some other namespace is never read. The unprefixed `scheme` is a deliberate fallback for EPUB 2 documents rather than an equivalent name — an unprefixed attribute is in no namespace at all.
 
 `OPF_IDENTIFIER_SCHEME_LOCAL_NAMES` is the ordered list of local names — `scheme`, then the `Scheme` capitalization some producers emit — for a consumer resolving namespaces itself, as anything holding a DOM can with `getAttributeNS(OPF_NAMESPACE, …)`. `OPF_IDENTIFIER_SCHEME_ATTRIBUTES` remains the literal `opf`-prefixed spellings, which do not cover an aliased prefix.
 

--- a/gitbook/archive-reader/identifiers.md
+++ b/gitbook/archive-reader/identifiers.md
@@ -119,7 +119,27 @@ opfIdentifierTypeScheme({ value: "15", scheme: "onix:codelist5" }) // "ISBN"
 opfIdentifierTypeScheme({ value: "ExampleCatalog" }) // "ExampleCatalog"
 ```
 
-`OPF_IDENTIFIER_SCHEME_ATTRIBUTES` is the ordered list of spellings — `opf:scheme`, `opf:Scheme`, `scheme` — and the first one an element states wins, so a document using only the legacy form keeps it. `opfIdentifierTypeScheme` translates a code stated against `onix:codelist5` and passes anything else through verbatim, including a code that list does not define.
+`opfIdentifierTypeScheme` translates a code stated against `onix:codelist5` and passes anything else through verbatim, including a code that list does not define.
+
+The scheme attribute is read under every prefix the document binds to the OPF namespace, because the prefix is arbitrary — `opf` by convention, but a package is free to bind the namespace to another one and it names the same attribute:
+
+```xml
+<package xmlns:pkg="http://www.idpf.org/2007/opf" ...>
+  <dc:identifier pkg:scheme="GoogleBooks">zyTCAlFPjgYC</dc:identifier>
+```
+
+`opfNamespacePrefixes` reads those bindings off the package element, and `opfIdentifierSchemeAttribute` takes them as its second argument — defaulting to `opf` alone when omitted:
+
+```typescript
+const prefixes = opfNamespacePrefixes(packageAttributes) // ["opf", "pkg"]
+opfIdentifierSchemeAttribute(elementAttributes, prefixes) // "GoogleBooks"
+```
+
+`opf` is accepted whether or not the package declares it, since using it undeclared is invalid but common. A prefix bound to some other namespace is not read. The unprefixed `scheme` is a deliberate fallback for EPUB 2 documents rather than an equivalent name — an unprefixed attribute is in no namespace at all.
+
+`OPF_IDENTIFIER_SCHEME_LOCAL_NAMES` is the ordered list of local names — `scheme`, then the `Scheme` capitalization some producers emit — for a consumer resolving namespaces itself, as anything holding a DOM can with `getAttributeNS(OPF_NAMESPACE, …)`. `OPF_IDENTIFIER_SCHEME_ATTRIBUTES` remains the literal `opf`-prefixed spellings, which do not cover an aliased prefix.
+
+`opf:role` and `opf:file-as` are read the same way.
 
 These are what the parser and resolver use, so a consumer reading through them cannot drift from what `identifiers` reports.
 

--- a/packages/archive-reader/src/index.ts
+++ b/packages/archive-reader/src/index.ts
@@ -80,10 +80,16 @@ export { getSpineItemFilesFromArchive } from "./metadata/opf/getSpineItemFilesFr
 export type { OpfIdentifierTypeMeta } from "./metadata/opf/identifierScheme.ts"
 export {
   OPF_IDENTIFIER_SCHEME_ATTRIBUTES,
+  OPF_IDENTIFIER_SCHEME_LOCAL_NAMES,
   opfIdentifierSchemeAttribute,
   opfIdentifierTypeScheme,
 } from "./metadata/opf/identifierScheme.ts"
 export { isArchiveEpub } from "./metadata/opf/isArchiveEpub.ts"
+export {
+  OPF_NAMESPACE,
+  opfNamespacedAttribute,
+  opfNamespacePrefixes,
+} from "./metadata/opf/opfNamespace.ts"
 export type {
   OpfContributor,
   OpfGuideReference,

--- a/packages/archive-reader/src/index.ts
+++ b/packages/archive-reader/src/index.ts
@@ -85,10 +85,12 @@ export {
   opfIdentifierTypeScheme,
 } from "./metadata/opf/identifierScheme.ts"
 export { isArchiveEpub } from "./metadata/opf/isArchiveEpub.ts"
+export type { XmlNamespaceScope } from "./metadata/opf/opfNamespace.ts"
 export {
   OPF_NAMESPACE,
   opfNamespacedAttribute,
   opfNamespacePrefixes,
+  xmlNamespaceScope,
 } from "./metadata/opf/opfNamespace.ts"
 export type {
   OpfContributor,

--- a/packages/archive-reader/src/metadata/opf/identifierScheme.ts
+++ b/packages/archive-reader/src/metadata/opf/identifierScheme.ts
@@ -1,3 +1,5 @@
+import { opfNamespacedAttribute } from "./opfNamespace.ts"
+
 /**
  * How an OPF states a `dc:identifier`'s scheme. Both halves are facts about
  * what a package document can say, so the parser and the resolver read them
@@ -5,10 +7,22 @@
  */
 
 /**
- * Attribute names an identifier's scheme can be stated on, in the order a read
- * prefers them: EPUB 3's namespaced form, the capitalization some producers
- * emit, and the bare EPUB 2 form. The first one present wins, so a document
- * that uses only the legacy spelling keeps it.
+ * Local names an identifier's scheme can be stated under, in the order a read
+ * prefers them. `Scheme` is not a second name the spec defines — it is the
+ * capitalization some producers emit, read because the value it carries is
+ * unambiguous.
+ */
+export const OPF_IDENTIFIER_SCHEME_LOCAL_NAMES: ReadonlyArray<string> =
+  Object.freeze(["scheme", "Scheme"])
+
+/**
+ * Attribute names an identifier's scheme can be stated on under the
+ * conventional `opf` prefix, in the order a read prefers them, ending with the
+ * bare EPUB 2 form.
+ *
+ * Prefer {@link opfIdentifierSchemeAttribute} with the document's own prefixes:
+ * a package may bind the OPF namespace to another prefix, which these literal
+ * names do not cover.
  */
 export const OPF_IDENTIFIER_SCHEME_ATTRIBUTES: ReadonlyArray<string> =
   Object.freeze(["opf:scheme", "opf:Scheme", "scheme"])
@@ -60,17 +74,16 @@ export const opfIdentifierTypeScheme = (
 }
 
 /**
- * The scheme attribute an element carries, if any — the first spelling of
- * {@link OPF_IDENTIFIER_SCHEME_ATTRIBUTES} it states.
+ * The scheme attribute an element carries, if any. `prefixes` are the ones the
+ * document binds to the OPF namespace — `opfNamespacePrefixes` reads them off
+ * the package element — and default to the conventional `opf` alone.
  */
 export const opfIdentifierSchemeAttribute = (
   attributes: Readonly<Record<string, string | undefined>>,
-): string | undefined => {
-  for (const name of OPF_IDENTIFIER_SCHEME_ATTRIBUTES) {
-    const value = attributes[name]
-
-    if (value !== undefined) return value
-  }
-
-  return undefined
-}
+  prefixes: ReadonlyArray<string> = ["opf"],
+): string | undefined =>
+  opfNamespacedAttribute(
+    attributes,
+    prefixes,
+    OPF_IDENTIFIER_SCHEME_LOCAL_NAMES,
+  )

--- a/packages/archive-reader/src/metadata/opf/opfNamespace.test.ts
+++ b/packages/archive-reader/src/metadata/opf/opfNamespace.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import {
+  OPF_NAMESPACE,
+  opfNamespacedAttribute,
+  opfNamespacePrefixes,
+} from "./opfNamespace"
+
+describe("opfNamespacePrefixes", () => {
+  it("always accepts the conventional prefix", () => {
+    expect(opfNamespacePrefixes({})).toEqual(["opf"])
+  })
+
+  it("collects every prefix bound to the OPF namespace", () => {
+    expect(
+      opfNamespacePrefixes({
+        "xmlns:pkg": OPF_NAMESPACE,
+        "xmlns:p2": ` ${OPF_NAMESPACE} `,
+      }),
+    ).toEqual(["opf", "pkg", "p2"])
+  })
+
+  it("does not repeat the conventional prefix when it is declared", () => {
+    expect(opfNamespacePrefixes({ "xmlns:opf": OPF_NAMESPACE })).toEqual([
+      "opf",
+    ])
+  })
+
+  it("ignores prefixes bound elsewhere, and the default namespace", () => {
+    expect(
+      opfNamespacePrefixes({
+        "xmlns:dc": "http://purl.org/dc/elements/1.1/",
+        xmlns: OPF_NAMESPACE,
+      }),
+    ).toEqual(["opf"])
+  })
+})
+
+describe("opfNamespacedAttribute", () => {
+  const prefixes = ["opf", "pkg"]
+
+  it("prefers a prefixed spelling over the unprefixed fallback", () => {
+    expect(
+      opfNamespacedAttribute(
+        { "pkg:scheme": "ISBN", scheme: "GTIN" },
+        prefixes,
+        ["scheme"],
+      ),
+    ).toBe("ISBN")
+  })
+
+  it("tries each local name across every prefix before falling back", () => {
+    expect(
+      opfNamespacedAttribute({ "pkg:Scheme": "ISBN" }, prefixes, [
+        "scheme",
+        "Scheme",
+      ]),
+    ).toBe("ISBN")
+    expect(
+      opfNamespacedAttribute({ scheme: "ISBN" }, prefixes, [
+        "scheme",
+        "Scheme",
+      ]),
+    ).toBe("ISBN")
+  })
+
+  it("declines an attribute under no accepted prefix", () => {
+    expect(
+      opfNamespacedAttribute({ "other:scheme": "ISBN" }, prefixes, ["scheme"]),
+    ).toBeUndefined()
+  })
+})

--- a/packages/archive-reader/src/metadata/opf/opfNamespace.test.ts
+++ b/packages/archive-reader/src/metadata/opf/opfNamespace.test.ts
@@ -3,35 +3,75 @@ import {
   OPF_NAMESPACE,
   opfNamespacedAttribute,
   opfNamespacePrefixes,
+  xmlNamespaceScope,
 } from "./opfNamespace"
 
-describe("opfNamespacePrefixes", () => {
-  it("always accepts the conventional prefix", () => {
-    expect(opfNamespacePrefixes({})).toEqual(["opf"])
+const DC_NAMESPACE = "http://purl.org/dc/elements/1.1/"
+
+describe("xmlNamespaceScope", () => {
+  it("reads the declarations on an element", () => {
+    expect(
+      xmlNamespaceScope({
+        "xmlns:pkg": OPF_NAMESPACE,
+        "xmlns:dc": DC_NAMESPACE,
+        id: "ignored",
+      }),
+    ).toEqual({ pkg: OPF_NAMESPACE, dc: DC_NAMESPACE })
   })
 
-  it("collects every prefix bound to the OPF namespace", () => {
+  it("inherits what an element does not redeclare", () => {
     expect(
-      opfNamespacePrefixes({
-        "xmlns:pkg": OPF_NAMESPACE,
-        "xmlns:p2": ` ${OPF_NAMESPACE} `,
-      }),
+      xmlNamespaceScope(
+        { "xmlns:extra": DC_NAMESPACE },
+        { pkg: OPF_NAMESPACE },
+      ),
+    ).toEqual({ pkg: OPF_NAMESPACE, extra: DC_NAMESPACE })
+  })
+
+  it("lets a descendant rebind a prefix its ancestor bound", () => {
+    expect(
+      xmlNamespaceScope({ "xmlns:pkg": DC_NAMESPACE }, { pkg: OPF_NAMESPACE }),
+    ).toEqual({ pkg: DC_NAMESPACE })
+  })
+
+  it("leaves the inherited scope untouched", () => {
+    const inherited = { pkg: OPF_NAMESPACE }
+
+    xmlNamespaceScope({ "xmlns:pkg": DC_NAMESPACE }, inherited)
+
+    expect(inherited).toEqual({ pkg: OPF_NAMESPACE })
+  })
+
+  it("ignores the default namespace, which binds no prefix", () => {
+    expect(xmlNamespaceScope({ xmlns: OPF_NAMESPACE })).toEqual({})
+  })
+})
+
+describe("opfNamespacePrefixes", () => {
+  it("accepts the conventional prefix when nothing binds it", () => {
+    expect(opfNamespacePrefixes({})).toEqual(["opf"])
+    expect(opfNamespacePrefixes({ dc: DC_NAMESPACE })).toEqual(["opf"])
+  })
+
+  it("collects every prefix naming the OPF namespace", () => {
+    expect(
+      opfNamespacePrefixes({ pkg: OPF_NAMESPACE, p2: OPF_NAMESPACE }),
     ).toEqual(["opf", "pkg", "p2"])
   })
 
   it("does not repeat the conventional prefix when it is declared", () => {
-    expect(opfNamespacePrefixes({ "xmlns:opf": OPF_NAMESPACE })).toEqual([
-      "opf",
-    ])
+    expect(opfNamespacePrefixes({ opf: OPF_NAMESPACE })).toEqual(["opf"])
   })
 
-  it("ignores prefixes bound elsewhere, and the default namespace", () => {
+  it("honours a document that rebinds the conventional prefix elsewhere", () => {
+    expect(opfNamespacePrefixes({ opf: DC_NAMESPACE })).toEqual([])
     expect(
-      opfNamespacePrefixes({
-        "xmlns:dc": "http://purl.org/dc/elements/1.1/",
-        xmlns: OPF_NAMESPACE,
-      }),
-    ).toEqual(["opf"])
+      opfNamespacePrefixes({ opf: DC_NAMESPACE, pkg: OPF_NAMESPACE }),
+    ).toEqual(["pkg"])
+  })
+
+  it("ignores prefixes bound elsewhere", () => {
+    expect(opfNamespacePrefixes({ dc: DC_NAMESPACE })).toEqual(["opf"])
   })
 })
 
@@ -66,6 +106,12 @@ describe("opfNamespacedAttribute", () => {
   it("declines an attribute under no accepted prefix", () => {
     expect(
       opfNamespacedAttribute({ "other:scheme": "ISBN" }, prefixes, ["scheme"]),
+    ).toBeUndefined()
+  })
+
+  it("declines everything when no prefix names the namespace", () => {
+    expect(
+      opfNamespacedAttribute({ "opf:scheme": "ISBN" }, [], ["scheme"]),
     ).toBeUndefined()
   })
 })

--- a/packages/archive-reader/src/metadata/opf/opfNamespace.ts
+++ b/packages/archive-reader/src/metadata/opf/opfNamespace.ts
@@ -1,36 +1,66 @@
 /** The OPF namespace every package document's own vocabulary lives in. */
 export const OPF_NAMESPACE = "http://www.idpf.org/2007/opf"
 
+/** The conventional prefix, accepted even when a package never declares it. */
+const CONVENTIONAL_OPF_PREFIX = "opf"
+
 const XMLNS_PREFIX = "xmlns:"
 
 /**
- * The prefixes a document binds to the OPF namespace. `opf` is the convention
- * and is always accepted — a package using it without declaring `xmlns:opf` is
- * invalid but common — while any other prefix bound to the namespace names the
- * same attributes and is read alongside it.
+ * The prefix bindings in force at one element: every `xmlns:*` declaration on
+ * it and on its ancestors, nearest winning. XML scopes bindings per element, so
+ * a descendant can introduce a prefix its ancestors never had and rebind one
+ * they did.
  */
-export const opfNamespacePrefixes = (
-  rootAttributes: Readonly<Record<string, string | undefined>>,
-): ReadonlyArray<string> => {
-  const prefixes = new Set<string>(["opf"])
+export type XmlNamespaceScope = Readonly<Record<string, string>>
 
-  for (const [name, value] of Object.entries(rootAttributes)) {
+/**
+ * The scope at an element, given the one its parent was read under. Call it
+ * while descending so each element is read under its own bindings.
+ */
+export const xmlNamespaceScope = (
+  attributes: Readonly<Record<string, string | undefined>>,
+  inherited: XmlNamespaceScope = {},
+): XmlNamespaceScope => {
+  let scope: Record<string, string> | undefined
+
+  for (const [name, value] of Object.entries(attributes)) {
     if (!name.startsWith(XMLNS_PREFIX)) continue
-    if (value?.trim() !== OPF_NAMESPACE) continue
 
     const prefix = name.slice(XMLNS_PREFIX.length)
+    const namespace = value?.trim()
 
-    if (prefix.length > 0) prefixes.add(prefix)
+    if (prefix.length === 0 || namespace === undefined) continue
+
+    scope ??= { ...inherited }
+    scope[prefix] = namespace
   }
 
-  return [...prefixes]
+  return scope ?? inherited
 }
 
 /**
- * An attribute in the OPF namespace, tried under every prefix the document
- * bound to it before the unprefixed spelling EPUB 2 documents use. An
- * unprefixed attribute is in no namespace at all, so it is a deliberate
- * fallback rather than an equivalent name.
+ * The prefixes naming the OPF namespace in a scope. The conventional `opf` is
+ * included unless the document bound it to something else, since using it
+ * undeclared is invalid but common — a rebinding is explicit and is honoured.
+ */
+export const opfNamespacePrefixes = (
+  scope: XmlNamespaceScope,
+): ReadonlyArray<string> => {
+  const prefixes = Object.keys(scope).filter(function namesOpf(prefix) {
+    return scope[prefix] === OPF_NAMESPACE
+  })
+
+  return scope[CONVENTIONAL_OPF_PREFIX] === undefined
+    ? [CONVENTIONAL_OPF_PREFIX, ...prefixes]
+    : prefixes
+}
+
+/**
+ * An attribute in the OPF namespace, tried under every prefix naming it before
+ * the unprefixed spelling EPUB 2 documents use. An unprefixed attribute is in
+ * no namespace at all, so that is a deliberate fallback rather than an
+ * equivalent name.
  */
 export const opfNamespacedAttribute = (
   attributes: Readonly<Record<string, string | undefined>>,

--- a/packages/archive-reader/src/metadata/opf/opfNamespace.ts
+++ b/packages/archive-reader/src/metadata/opf/opfNamespace.ts
@@ -1,0 +1,55 @@
+/** The OPF namespace every package document's own vocabulary lives in. */
+export const OPF_NAMESPACE = "http://www.idpf.org/2007/opf"
+
+const XMLNS_PREFIX = "xmlns:"
+
+/**
+ * The prefixes a document binds to the OPF namespace. `opf` is the convention
+ * and is always accepted — a package using it without declaring `xmlns:opf` is
+ * invalid but common — while any other prefix bound to the namespace names the
+ * same attributes and is read alongside it.
+ */
+export const opfNamespacePrefixes = (
+  rootAttributes: Readonly<Record<string, string | undefined>>,
+): ReadonlyArray<string> => {
+  const prefixes = new Set<string>(["opf"])
+
+  for (const [name, value] of Object.entries(rootAttributes)) {
+    if (!name.startsWith(XMLNS_PREFIX)) continue
+    if (value?.trim() !== OPF_NAMESPACE) continue
+
+    const prefix = name.slice(XMLNS_PREFIX.length)
+
+    if (prefix.length > 0) prefixes.add(prefix)
+  }
+
+  return [...prefixes]
+}
+
+/**
+ * An attribute in the OPF namespace, tried under every prefix the document
+ * bound to it before the unprefixed spelling EPUB 2 documents use. An
+ * unprefixed attribute is in no namespace at all, so it is a deliberate
+ * fallback rather than an equivalent name.
+ */
+export const opfNamespacedAttribute = (
+  attributes: Readonly<Record<string, string | undefined>>,
+  prefixes: ReadonlyArray<string>,
+  localNames: ReadonlyArray<string>,
+): string | undefined => {
+  for (const localName of localNames) {
+    for (const prefix of prefixes) {
+      const value = attributes[`${prefix}:${localName}`]
+
+      if (value !== undefined) return value
+    }
+  }
+
+  for (const localName of localNames) {
+    const value = attributes[localName]
+
+    if (value !== undefined) return value
+  }
+
+  return undefined
+}

--- a/packages/archive-reader/src/metadata/opf/parse.test.ts
+++ b/packages/archive-reader/src/metadata/opf/parse.test.ts
@@ -767,3 +767,69 @@ describe("OPF namespace prefix aliases", () => {
     })
   })
 })
+
+describe("OPF namespace bindings declared below the package element", () => {
+  const withMetadata = (metadataAttrs: string, metadata: string) =>
+    `<?xml version="1.0"?>` +
+    `<package version="3.0" unique-identifier="bookid"` +
+    ` xmlns="http://www.idpf.org/2007/opf"` +
+    ` xmlns:dc="http://purl.org/dc/elements/1.1/">` +
+    `<metadata ${metadataAttrs}>${metadata}</metadata><manifest/><spine/>` +
+    `</package>`
+
+  it("reads a prefix declared on the metadata element", () => {
+    const xml = withMetadata(
+      'xmlns:pkg="http://www.idpf.org/2007/opf"',
+      '<dc:identifier pkg:scheme="GoogleBooks">zyTCAlFPjgYC</dc:identifier>',
+    )
+
+    expect(parseOpf(xml).identifiers).toEqual([
+      { value: "zyTCAlFPjgYC", scheme: "GoogleBooks" },
+    ])
+  })
+
+  it("reads a prefix declared on the identifier itself", () => {
+    const xml = withMetadata(
+      "",
+      '<dc:identifier xmlns:pkg="http://www.idpf.org/2007/opf" pkg:scheme="GoogleBooks">zyTCAlFPjgYC</dc:identifier>',
+    )
+
+    expect(parseOpf(xml).identifiers).toEqual([
+      { value: "zyTCAlFPjgYC", scheme: "GoogleBooks" },
+    ])
+  })
+
+  it("reads a prefix declared on a creator itself", () => {
+    const xml = withMetadata(
+      "",
+      '<dc:creator xmlns:pkg="http://www.idpf.org/2007/opf" pkg:role="ill">Haruki Murakami</dc:creator>',
+    )
+
+    expect(parseOpf(xml).contributors).toEqual([
+      { name: "Haruki Murakami", source: "creator", roles: ["ill"] },
+    ])
+  })
+
+  it("honours a descendant rebinding the conventional prefix elsewhere", () => {
+    const xml = withMetadata(
+      'xmlns:opf="http://example.com/not-opf"',
+      '<dc:identifier opf:scheme="GoogleBooks">zyTCAlFPjgYC</dc:identifier>',
+    )
+
+    expect(parseOpf(xml).identifiers).toEqual([{ value: "zyTCAlFPjgYC" }])
+  })
+
+  it("honours a descendant rebinding an aliased prefix elsewhere", () => {
+    const xml =
+      `<?xml version="1.0"?>` +
+      `<package version="3.0" unique-identifier="bookid"` +
+      ` xmlns="http://www.idpf.org/2007/opf"` +
+      ` xmlns:dc="http://purl.org/dc/elements/1.1/"` +
+      ` xmlns:pkg="http://www.idpf.org/2007/opf">` +
+      `<metadata xmlns:pkg="http://example.com/not-opf">` +
+      '<dc:identifier pkg:scheme="GoogleBooks">zyTCAlFPjgYC</dc:identifier>' +
+      `</metadata><manifest/><spine/></package>`
+
+    expect(parseOpf(xml).identifiers).toEqual([{ value: "zyTCAlFPjgYC" }])
+  })
+})

--- a/packages/archive-reader/src/metadata/opf/parse.test.ts
+++ b/packages/archive-reader/src/metadata/opf/parse.test.ts
@@ -692,3 +692,78 @@ describe("parseOpf — description", () => {
     expect(parseOpf(xml).description).toBe("A story about tests.")
   })
 })
+
+describe("OPF namespace prefix aliases", () => {
+  const packaged = (packageAttrs: string, metadata: string) =>
+    `<?xml version="1.0"?>` +
+    `<package version="3.0" unique-identifier="bookid"` +
+    ` xmlns="http://www.idpf.org/2007/opf"` +
+    ` xmlns:dc="http://purl.org/dc/elements/1.1/"` +
+    ` ${packageAttrs}>` +
+    `<metadata>${metadata}</metadata><manifest/><spine/>` +
+    `</package>`
+
+  it("reads a scheme stated under another prefix bound to the OPF namespace", () => {
+    const xml = packaged(
+      'xmlns:pkg="http://www.idpf.org/2007/opf"',
+      '<dc:identifier pkg:scheme="GoogleBooks">zyTCAlFPjgYC</dc:identifier>',
+    )
+
+    expect(parseOpf(xml).identifiers).toEqual([
+      { value: "zyTCAlFPjgYC", scheme: "GoogleBooks" },
+    ])
+  })
+
+  it("ignores the same local name under a prefix bound elsewhere", () => {
+    const xml = packaged(
+      'xmlns:other="http://example.com/not-opf"',
+      '<dc:identifier other:scheme="GoogleBooks">zyTCAlFPjgYC</dc:identifier>',
+    )
+
+    expect(parseOpf(xml).identifiers).toEqual([{ value: "zyTCAlFPjgYC" }])
+  })
+
+  it("still reads the conventional prefix a package left undeclared", () => {
+    const xml = packaged(
+      'id="pkg"',
+      '<dc:identifier opf:scheme="ISBN">9783161484100</dc:identifier>',
+    )
+
+    expect(parseOpf(xml).identifiers).toEqual([
+      { value: "9783161484100", scheme: "ISBN" },
+    ])
+  })
+
+  it("reads a role and a sort name under an aliased prefix", () => {
+    const xml = packaged(
+      'xmlns:pkg="http://www.idpf.org/2007/opf"',
+      '<dc:creator pkg:role="ill" pkg:file-as="Murakami, Haruki">Haruki Murakami</dc:creator>',
+    )
+
+    expect(parseOpf(xml).contributors).toEqual([
+      {
+        name: "Haruki Murakami",
+        source: "creator",
+        roles: ["ill"],
+        fileAs: "Murakami, Haruki",
+      },
+    ])
+  })
+
+  it("keeps reading the unprefixed EPUB 2 spellings", () => {
+    const xml = packaged(
+      'id="pkg"',
+      '<dc:identifier scheme="ISBN">9783161484100</dc:identifier>' +
+        '<dc:creator role="aut" file-as="Murakami, Haruki">Haruki Murakami</dc:creator>',
+    )
+    const parsed = parseOpf(xml)
+
+    expect(parsed.identifiers).toEqual([
+      { value: "9783161484100", scheme: "ISBN" },
+    ])
+    expect(parsed.contributors[0]).toMatchObject({
+      roles: ["aut"],
+      fileAs: "Murakami, Haruki",
+    })
+  })
+})

--- a/packages/archive-reader/src/metadata/opf/parse.ts
+++ b/packages/archive-reader/src/metadata/opf/parse.ts
@@ -2,7 +2,12 @@ import type { XmlElement, XmlNodeBase } from "xmldoc"
 import { XmlDocument } from "xmldoc"
 import { tokenizeXmlSpaceSeparatedList } from "../../utils/tokenizeXmlSpaceSeparatedList.ts"
 import { opfIdentifierSchemeAttribute } from "./identifierScheme.ts"
-import { opfNamespacedAttribute, opfNamespacePrefixes } from "./opfNamespace.ts"
+import {
+  opfNamespacedAttribute,
+  opfNamespacePrefixes,
+  type XmlNamespaceScope,
+  xmlNamespaceScope,
+} from "./opfNamespace.ts"
 import { layoutHintsFromItemrefProperties } from "./spineItemrefProperties.ts"
 
 export type OpfSpineManifestItem = {
@@ -125,7 +130,7 @@ const childrenNamedLocal = (
 const identifiersFromMetadata = (
   metadataEl: XmlElement,
   uniqueIdentifierId: string | undefined,
-  opfPrefixes: ReadonlyArray<string>,
+  metadataScope: XmlNamespaceScope,
 ): OpfIdentifier[] => {
   const identifiers: OpfIdentifier[] = []
 
@@ -135,7 +140,10 @@ const identifiersFromMetadata = (
     const value = child.val.trim()
     if (value.length === 0) return
 
-    const scheme = opfIdentifierSchemeAttribute(child.attr, opfPrefixes)
+    const scheme = opfIdentifierSchemeAttribute(
+      child.attr,
+      opfNamespacePrefixes(xmlNamespaceScope(child.attr, metadataScope)),
+    )
     const schemeTrimmed = scheme?.trim()
     const idTrimmed = child.attr.id?.trim()
     const id =
@@ -328,7 +336,7 @@ const refinesTargetsId = (refines: string, id: string): boolean =>
 const contributorsFromMetadata = (
   metadataEl: XmlElement,
   metas: ReadonlyArray<OpfMetaEntry>,
-  opfPrefixes: ReadonlyArray<string>,
+  metadataScope: XmlNamespaceScope,
 ): OpfContributor[] => {
   const contributors: OpfContributor[] = []
 
@@ -352,6 +360,9 @@ const contributorsFromMetadata = (
               : [],
           )
 
+    const opfPrefixes = opfNamespacePrefixes(
+      xmlNamespaceScope(child.attr, metadataScope),
+    )
     const attributeRole = trimmedOpfAttr(child, opfPrefixes, "role")
     const roles = [
       ...(attributeRole !== undefined ? [attributeRole] : []),
@@ -561,7 +572,7 @@ export const parseOpf = (opfXml: string): OpfMetadata => {
   const manifestEl = childNamedLocal(doc, "manifest")
   const spineEl = childNamedLocal(doc, "spine")
   const metadataEl = childNamedLocal(doc, "metadata")
-  const opfPrefixes = opfNamespacePrefixes(doc.attr)
+  const packageScope = xmlNamespaceScope(doc.attr)
   const uniqueIdentifierIdRaw = doc.attr["unique-identifier"]?.trim()
   const uniqueIdentifierId =
     uniqueIdentifierIdRaw !== undefined && uniqueIdentifierIdRaw.length > 0
@@ -609,6 +620,8 @@ export const parseOpf = (opfXml: string): OpfMetadata => {
   const identifiers: OpfIdentifier[] = []
 
   if (metadataEl !== undefined) {
+    const metadataScope = xmlNamespaceScope(metadataEl.attr, packageScope)
+
     titles = titlesFromMetadata(metadataEl)
     publisher = firstTextByLocalName(metadataEl, "publisher")
     description = firstTextByLocalName(metadataEl, "description")
@@ -621,9 +634,9 @@ export const parseOpf = (opfXml: string): OpfMetadata => {
     renditionFlowMeta = metaValByProperty(metadataEl, "rendition:flow")
     renditionSpreadMeta = metaValByProperty(metadataEl, "rendition:spread")
     metas = metasFromMetadata(metadataEl)
-    contributors = contributorsFromMetadata(metadataEl, metas, opfPrefixes)
+    contributors = contributorsFromMetadata(metadataEl, metas, metadataScope)
     identifiers.push(
-      ...identifiersFromMetadata(metadataEl, uniqueIdentifierId, opfPrefixes),
+      ...identifiersFromMetadata(metadataEl, uniqueIdentifierId, metadataScope),
     )
   }
 

--- a/packages/archive-reader/src/metadata/opf/parse.ts
+++ b/packages/archive-reader/src/metadata/opf/parse.ts
@@ -2,6 +2,7 @@ import type { XmlElement, XmlNodeBase } from "xmldoc"
 import { XmlDocument } from "xmldoc"
 import { tokenizeXmlSpaceSeparatedList } from "../../utils/tokenizeXmlSpaceSeparatedList.ts"
 import { opfIdentifierSchemeAttribute } from "./identifierScheme.ts"
+import { opfNamespacedAttribute, opfNamespacePrefixes } from "./opfNamespace.ts"
 import { layoutHintsFromItemrefProperties } from "./spineItemrefProperties.ts"
 
 export type OpfSpineManifestItem = {
@@ -124,6 +125,7 @@ const childrenNamedLocal = (
 const identifiersFromMetadata = (
   metadataEl: XmlElement,
   uniqueIdentifierId: string | undefined,
+  opfPrefixes: ReadonlyArray<string>,
 ): OpfIdentifier[] => {
   const identifiers: OpfIdentifier[] = []
 
@@ -133,7 +135,7 @@ const identifiersFromMetadata = (
     const value = child.val.trim()
     if (value.length === 0) return
 
-    const scheme = opfIdentifierSchemeAttribute(child.attr)
+    const scheme = opfIdentifierSchemeAttribute(child.attr, opfPrefixes)
     const schemeTrimmed = scheme?.trim()
     const idTrimmed = child.attr.id?.trim()
     const id =
@@ -273,6 +275,19 @@ const trimmedAttr = (el: XmlElement, name: string): string | undefined => {
   return trimmed !== undefined && trimmed.length > 0 ? trimmed : undefined
 }
 
+/** {@link trimmedAttr} for an attribute in the OPF namespace. */
+const trimmedOpfAttr = (
+  el: XmlElement,
+  opfPrefixes: ReadonlyArray<string>,
+  localName: string,
+): string | undefined => {
+  const trimmed = opfNamespacedAttribute(el.attr, opfPrefixes, [
+    localName,
+  ])?.trim()
+
+  return trimmed !== undefined && trimmed.length > 0 ? trimmed : undefined
+}
+
 const metasFromMetadata = (metadataEl: XmlElement): OpfMetaEntry[] => {
   const metas: OpfMetaEntry[] = []
 
@@ -313,6 +328,7 @@ const refinesTargetsId = (refines: string, id: string): boolean =>
 const contributorsFromMetadata = (
   metadataEl: XmlElement,
   metas: ReadonlyArray<OpfMetaEntry>,
+  opfPrefixes: ReadonlyArray<string>,
 ): OpfContributor[] => {
   const contributors: OpfContributor[] = []
 
@@ -336,17 +352,14 @@ const contributorsFromMetadata = (
               : [],
           )
 
-    const attributeRole =
-      trimmedAttr(child, "opf:role") ?? trimmedAttr(child, "role")
+    const attributeRole = trimmedOpfAttr(child, opfPrefixes, "role")
     const roles = [
       ...(attributeRole !== undefined ? [attributeRole] : []),
       ...refinesFor("role"),
     ]
 
     const fileAs =
-      trimmedAttr(child, "opf:file-as") ??
-      trimmedAttr(child, "file-as") ??
-      refinesFor("file-as")[0]
+      trimmedOpfAttr(child, opfPrefixes, "file-as") ?? refinesFor("file-as")[0]
 
     contributors.push({
       name,
@@ -548,6 +561,7 @@ export const parseOpf = (opfXml: string): OpfMetadata => {
   const manifestEl = childNamedLocal(doc, "manifest")
   const spineEl = childNamedLocal(doc, "spine")
   const metadataEl = childNamedLocal(doc, "metadata")
+  const opfPrefixes = opfNamespacePrefixes(doc.attr)
   const uniqueIdentifierIdRaw = doc.attr["unique-identifier"]?.trim()
   const uniqueIdentifierId =
     uniqueIdentifierIdRaw !== undefined && uniqueIdentifierIdRaw.length > 0
@@ -607,8 +621,10 @@ export const parseOpf = (opfXml: string): OpfMetadata => {
     renditionFlowMeta = metaValByProperty(metadataEl, "rendition:flow")
     renditionSpreadMeta = metaValByProperty(metadataEl, "rendition:spread")
     metas = metasFromMetadata(metadataEl)
-    contributors = contributorsFromMetadata(metadataEl, metas)
-    identifiers.push(...identifiersFromMetadata(metadataEl, uniqueIdentifierId))
+    contributors = contributorsFromMetadata(metadataEl, metas, opfPrefixes)
+    identifiers.push(
+      ...identifiersFromMetadata(metadataEl, uniqueIdentifierId, opfPrefixes),
+    )
   }
 
   const coverHref = coverHrefFromManifestAndMetadata({


### PR DESCRIPTION
## The bug

An XML prefix is arbitrary — what names an attribute is its *(namespace, local name)* pair. `opf` is the convention, but a package may bind the OPF namespace to any prefix, and it names the same attributes:

```xml
<package xmlns="http://www.idpf.org/2007/opf"
         xmlns:pkg="http://www.idpf.org/2007/opf"
         xmlns:dc="http://purl.org/dc/elements/1.1/" ...>
  <metadata>
    <dc:identifier pkg:scheme="GoogleBooks">zyTCAlFPjgYC</dc:identifier>
```

The parser matched the literal `opf:` spellings, so this identifier was read as having **no scheme** and fell back to whatever its value could be inferred as — `Unknown` here, since a Google Books id has no recognizable syntax. An ISBN-shaped value masked the problem by inferring correctly anyway.

Reported by Codex on #329.

## Bindings are element-scoped

The first commit resolved prefixes from `<package>`. That is wrong in both directions, as Codex pointed out on this PR: XML scopes bindings to the element declaring them, inherited by descendants. So it missed a prefix declared on `<metadata>` or on the `dc:identifier` itself, and it trusted a prefix the root bound to the OPF namespace even where a descendant had rebound it.

Bindings now accumulate while descending. `xmlNamespaceScope` layers one element's declarations over the scope it was reached under, and the prefixes naming the namespace are resolved at the element whose attribute is being read.

## Scope

Three attributes, all defined by the package's own vocabulary: the identifier scheme (`scheme` / `Scheme`), `role`, and `file-as`.

**`rendition:layout` and its siblings are deliberately untouched.** Those are `<meta property="rendition:layout">` *values*, governed by EPUB 3's reserved vocabulary prefixes declared with `<package prefix="…">` — a different mechanism from XML namespaces, and matching the literal string is correct by default. Worth its own change if you want it.

Element names already matched by local name (`localNameEq`), so `<opf:package>` and `<pkg:metadata>` were never affected.

## Two rules kept deliberately

- **`opf` is accepted when nothing binds it.** Using it undeclared is invalid but common in the wild. A document that *explicitly* binds `opf` to another namespace is honoured, and it is then not read.
- **The unprefixed spellings stay a fallback, not an equivalent.** An unprefixed attribute is in no namespace at all in XML — unlike an element, which takes the default namespace — so `scheme` is read *after* every prefixed form, as the EPUB 2 legacy shape it is.

A prefix bound to some *other* namespace is never read.

## New exports

| | |
|---|---|
| `OPF_NAMESPACE` | the namespace URI |
| `XmlNamespaceScope` / `xmlNamespaceScope(attributes, inherited?)` | prefix bindings at an element, layered over its parent's |
| `opfNamespacePrefixes(scope)` | the prefixes naming the OPF namespace there |
| `opfNamespacedAttribute(attributes, prefixes, localNames)` | an attribute under any of them, then the unprefixed fallback |
| `OPF_IDENTIFIER_SCHEME_LOCAL_NAMES` | `scheme`, `Scheme` — for a consumer resolving namespaces itself, as anything with a DOM can via `getAttributeNS` |

`opfIdentifierSchemeAttribute` gains an optional second argument for the prefixes, defaulting to `["opf"]`, so the signature stays backward compatible. `OPF_IDENTIFIER_SCHEME_ATTRIBUTES` is unchanged and now documented as *not* covering an aliased prefix.

## Testing

**348 tests pass, up from 324, with none modified** — no behaviour change for documents using the conventional prefix.

Parser cases, each verified to fail before the corresponding fix:

- aliased prefix for the scheme; aliased prefix for `role` and `file-as`
- prefix declared on `<metadata>`; declared on the identifier itself; declared on a creator itself
- a descendant rebinding the conventional prefix elsewhere; a descendant rebinding an aliased prefix elsewhere
- a prefix bound elsewhere ignored; `opf:` undeclared still read; the unprefixed EPUB 2 spellings still read

Plus 14 unit cases for `xmlNamespaceScope` / `opfNamespacePrefixes` / `opfNamespacedAttribute`, including that layering a scope does not mutate the inherited one.

tsc and biome clean.

## Docs

`gitbook/archive-reader/identifiers.md` gains the aliased-prefix explanation with the XML above, the element-scoping model with an example, and both rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)